### PR TITLE
Add link command

### DIFF
--- a/packages/plugs/core/core.plug.yaml
+++ b/packages/plugs/core/core.plug.yaml
@@ -215,6 +215,12 @@ functions:
     path: ./text.ts:numberListifySelection
     command:
       name: "Text: Number Listify Selection"
+  linkSelection:
+    path: ./text.ts:linkSelection
+    command:
+      name: "Text: Link Selection"
+      key: "Ctrl-Shift-k"
+      mac: "Cmd-Shift-k"
   bold:
     path: ./text.ts:wrapSelection
     command:

--- a/packages/plugs/core/text.ts
+++ b/packages/plugs/core/text.ts
@@ -61,16 +61,18 @@ export async function linkSelection() {
   const selection = await getSelection();
   const textSelection = text.slice(selection.from, selection.to);
   let linkedText = `[]()`;
+  let pos = 1;
   if (textSelection.length > 0) {
     try {
       new URL(textSelection);
       linkedText = `[](${textSelection})`;
     } catch {
       linkedText = `[${textSelection}]()`;
-
+      pos = linkedText.length - 1;
     }
   }
   await replaceRange(selection.from, selection.to, linkedText)
+  await moveCursor(selection.from + pos);
 }
 
 export function wrapSelection(cmdDef: any) {

--- a/packages/plugs/core/text.ts
+++ b/packages/plugs/core/text.ts
@@ -56,6 +56,23 @@ export async function numberListifySelection() {
   await replaceRange(from, selection.to, text);
 }
 
+export async function linkSelection() {
+  const text = await getText();
+  const selection = await getSelection();
+  const textSelection = text.slice(selection.from, selection.to);
+  let linkedText = `[]()`;
+  if (textSelection.length > 0) {
+    try {
+      new URL(textSelection);
+      linkedText = `[](${textSelection})`;
+    } catch {
+      linkedText = `[${textSelection}]()`;
+
+    }
+  }
+  await replaceRange(selection.from, selection.to, linkedText)
+}
+
 export function wrapSelection(cmdDef: any) {
   return insertMarker(cmdDef.wrapper);
 }


### PR DESCRIPTION
Add links with cmd/ctrl+shift+k (feel free to change it afterwards)

It tries to detect if the selected text should be wrapped as url or as display text. If no text is selected, then it adds an empty link.

Future improvements: 
- better/flexible url detection (right now it requires having a protocol)
- maybe use a modal as other tools do that show the display text and the url and allows for editing
- ~~move caret to first empty section.~~ Done