### PR TITLE
Add GHR protocol to plug manager

### DIFF
--- a/packages/plugs/core/core.plug.yaml
+++ b/packages/plugs/core/core.plug.yaml
@@ -280,7 +280,10 @@ functions:
     path: "./plugmanager.ts:getPlugGithub"
     events:
       - get-plug:github
-
+  getPlugGithubRelease:
+    path: "./plugmanager.ts:getPlugGithubRelease"
+    events:
+      - get-plug:ghr
   # Debug commands
   parseCommand:
     path: ./debug.ts:parsePageCommand

--- a/packages/plugs/core/plugmanager.ts
+++ b/packages/plugs/core/plugmanager.ts
@@ -92,3 +92,18 @@ export async function getPlugGithub(identifier: string): Promise<Manifest> {
     `//raw.githubusercontent.com/${owner}/${repoClean}/${branch}/${path}`
   );
 }
+
+export async function getPlugGithubRelease(identifier: string): Promise<Manifest> {
+  let [owner, repo, version] = identifier.split("/");
+  if (!version || version === "latest") {
+    console.log('fetching the latest version');
+    const req = await fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`);
+    if (req.status !== 200) {
+      throw new Error(`Could not fetch latest relase manifest from ${identifier}}`);
+    }
+    const result = await req.json();
+    version = result.name;
+  } 
+  const finalUrl = `//github.com/${owner}/${repo}/releases/download/${version}/${repo}.plug.json`;
+  return getPlugHTTPS(finalUrl);
+}

--- a/website/🔌 Plugs.md
+++ b/website/🔌 Plugs.md
@@ -52,6 +52,7 @@ Reload your list of plugs via the `Plugs: Update` command (`Cmd-Shift-p` on Mac,
 Once you’re happy with your plug, you can distribute it in various ways:
 
 * You can put it on github by simply committing the resulting `.plug.json` file there and instructing users to point to by adding `- github:yourgithubuser/yourrepo/yourplugname.plug.json` to their `PLUGS` file
+* Add a release in your github repo and instruct users to add the release as `- ghr:yourgithubuser/yourrepo` or if they need a spcecific release `- ghr:yourgithubuser/yourrepo/release-name`
 * You can put it on any other web server, and tell people to load it via https, e.g. `- https://mydomain.com/mypugname.plug.json`.
 
 ### Recommended development workflow


### PR DESCRIPTION
After writing the discussion on https://github.com/silverbulletmd/silverbullet/discussions/47

I figured at least the protocol should be easy to do and here it is. I modified the backlinks release to conform to that one so once this is merged you can install silverbullet-backlinks by adding:
```yaml
- ghr:willyfrog/silverbullet-backlinks
```
or specify a version
```yaml
- ghr:willyfrog/silverbullet-backlinks/v0.2
```

I haven't properly managed what happens on unresolved plugs, as I think it is out of scope. Right now it is throwing an error the same way an unresolved https plug does
This is it in action
![CleanShot 2022-07-23 at 21 04 38](https://user-images.githubusercontent.com/1515906/180619525-2777bb9b-cedc-412f-9b16-590f73fd482b.gif)
.