### PR TITLE
Improve error on formating plug sections

### DIFF
--- a/packages/plugs/core/plugmanager.ts
+++ b/packages/plugs/core/plugmanager.ts
@@ -38,7 +38,12 @@ export async function updatePlugsCommand() {
 export async function updatePlugs() {
   let plugList: string[] = [];
   try {
-    plugList = await readYamlPage("PLUGS");
+    const plugListRead: any[] = await readYamlPage("PLUGS");
+    console.log(plugList);
+    plugList = plugListRead.filter((plug) => typeof plug === 'string');
+    if (plugList.length !== plugListRead.length) {
+      throw new Error(`Some of the plugs were not in a yaml list format, they were ignored`);
+    }
   } catch (e: any) {
     throw new Error(`Error processing PLUGS: ${e.message}`);
   }

--- a/packages/plugs/core/plugmanager.ts
+++ b/packages/plugs/core/plugmanager.ts
@@ -39,7 +39,6 @@ export async function updatePlugs() {
   let plugList: string[] = [];
   try {
     const plugListRead: any[] = await readYamlPage("PLUGS");
-    console.log(plugList);
     plugList = plugListRead.filter((plug) => typeof plug === 'string');
     if (plugList.length !== plugListRead.length) {
       throw new Error(`Some of the plugs were not in a yaml list format, they were ignored`);


### PR DESCRIPTION
So I inadvertently added a space, which is valid YAML but not the one expected.
<img width="571" alt="CleanShot 2022-07-29 at 18 24 57@2x" src="https://user-images.githubusercontent.com/1515906/181803460-cc0e0e30-541e-4af5-827a-46431572eae7.png">

this should give a more meaningful message, I still think we need a better way to notify users, but for now this works.