### PR TITLE
fix: `Esc` prevent default (browser) action

### DIFF
--- a/packages/web/components/filter.tsx
+++ b/packages/web/components/filter.tsx
@@ -173,6 +173,7 @@ export function FilterList({
                 case "Escape":
                   exiting = true;
                   onSelect(undefined);
+                  e.preventDefault();
                   break;
                 case " ":
                   if (completePrefix && !text) {


### PR DESCRIPTION
Since I typically have my browsers full-screened in macOS if the default action of `Escape` is _not_ `e.preventDefault()`-ed then I get the behavior of the browser window itself exiting full screen. This fixes that. 