### PR TITLE
Add Gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,36 @@
+ports:
+  - port: 3000
+    name: Silverbullet
+    onOpen: open-browser
+    visibility: public
+
+github:
+  prebuilds:
+    master: true
+    pullRequests: true
+
+tasks:
+  - name: Setup
+    init: |
+      nvm install
+      nvm use
+      npm install
+      npm run clean-build
+      gp sync-done setup
+      exit
+  - name: Run Silverbullet server
+    init: |      
+      gp sync-await setup
+      nvm use
+      mkdir pages
+    command: npm run server -- ./pages
+  - name: Run ParcelJS
+    init: |
+      gp sync-await setup
+      nvm use
+    command: npm run watch
+  - name: Build plugins
+    init: |
+      gp sync-await setup
+      nvm use
+    command: npm run plugs

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Once downloaded and booted, SB will print out a URL to open SB in your browser (
 #protip: If you have a PWA enabled browser (like any browser based on Chromium) hit that little button right of the location bar to install SB, and give it its own window frame (sans location bar) and desktop/dock icon. At last the PWA has found its killer app.
 
 ## Developing Silver Bullet
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/https://github.com/silverbulletmd/silverbullet)
+
 Silver Bullet is written in [TypeScript](https://www.typescriptlang.org/) and built on top of the excellent [CodeMirror 6](https://codemirror.net/) editor component. Additional UI is built using React.js. [ParcelJS](https://parceljs.org/) is used to build both the front-end and back-end bundles. The server backend runs as a HTTP server on node.js using express.
 
 This repo is a monorepo using npm's "workspaces" feature. It consists of a number of npm packages under `packages`.


### PR DESCRIPTION
This PR add support for running SB in a Gitpod. It's tarting developers who want to work in a cloud workspace. For a demo netlify is better used.

The dev environment is setup in the same way as as suggested in the [readme](https://github.com/silverbulletmd/silverbullet#developing-silver-bullet). Hence, all changes are automatically picked up. (Expect for changes to pugs).
The `npm` version used in Gitpod is the one defined in  `.nvmrc`.

Please note that in order for [prebuilds](https://www.gitpod.io/docs/prebuilds) to work the [Gitpod GitHub app](https://github.com/apps/gitpod-io) needs to be added to this repository: https://www.gitpod.io/docs/prebuilds#configuring-prebuilds-manually.

Fixes https://github.com/silverbulletmd/silverbullet/issues/77