### PR TITLE
Add shortcut hint for command switcher

### DIFF
--- a/packages/web/components/top_bar.tsx
+++ b/packages/web/components/top_bar.tsx
@@ -7,6 +7,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useEffect, useState } from "react";
 import { Notification } from "../types";
+import { isMacLike } from "../../common/util";
 
 function prettyName(s: string | undefined): string {
   if (!s) {
@@ -39,6 +40,8 @@ export function TopBar({
   rhs?: React.ReactNode;
 }) {
   const [theme, setTheme] = useState<string>(localStorage.theme ?? "light");
+
+  const isMac = isMacLike();
 
   return (
     <div id="sb-top" onClick={onClick}>
@@ -83,7 +86,7 @@ export function TopBar({
                 onActionClick();
                 e.stopPropagation();
               }}
-              title="Open the command palette"
+              title={"Open the command palette (" + (isMac ? "Cmd" : "Ctrl") + "+/)"}
             >
               <FontAwesomeIcon icon={faRunning} />
             </button>


### PR DESCRIPTION
Add a hint about the keybord shortcut to the command switcher icon. Otherwise there is no way to discover it in the product.

![image](https://user-images.githubusercontent.com/16541325/192110136-69205212-0506-49f7-8ea6-74970730ec22.png)
