### PR TITLE
Fix prebuilt image

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full:latest
+
+RUN bash -c 'VERSION="18" \
+    && source $HOME/.nvm/nvm.sh && nvm install $VERSION \
+    && nvm use $VERSION && nvm alias default $VERSION'
+
+RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,6 @@
+image:
+  file: .gitpod.Dockerfile
+
 ports:
   - port: 3000
     name: Silverbullet
@@ -12,25 +15,17 @@ github:
 tasks:
   - name: Setup
     init: |
-      nvm install
-      nvm use
       npm install
       npm run clean-build
       gp sync-done setup
-      exit
   - name: Run Silverbullet server
     init: |      
       gp sync-await setup
-      nvm use
       mkdir pages
     command: npm run server -- ./pages
   - name: Run ParcelJS
-    init: |
-      gp sync-await setup
-      nvm use
+    init: gp sync-await setup
     command: npm run watch
   - name: Build plugins
-    init: |
-      gp sync-await setup
-      nvm use
+    init: gp sync-await setup
     command: npm run plugs


### PR DESCRIPTION
When a Gitpod was restarted or started from a prebuilt the `init` command are not run again. This resulted in `nvm use` not being run and a node version mismatch happening.

To avoid this issue a custom Dockerimage is used. This has the unfortunate effect that the node version is not synced with `.nvmrc`.