### PR TITLE
Ensure dates consider timezones

### DIFF
--- a/packages/plugs/core/dates.ts
+++ b/packages/plugs/core/dates.ts
@@ -1,3 +1,11 @@
 export function niceDate(d: Date): string {
-  return d.toISOString().split("T")[0];
+  function pad(n: number) {
+    let s = String(n);
+    if (s.length === 1) {
+      s = '0' + s;
+    }
+    return s;
+  }
+
+  return d.getFullYear() + '-' + pad(d.getMonth() +  1) + '-' + pad(d.getDate())
 }

--- a/packages/plugs/core/template.ts
+++ b/packages/plugs/core/template.ts
@@ -143,8 +143,7 @@ export async function dailyNoteCommand() {
   } catch {
     console.warn(`No daily note template found at ${dailyNoteTemplate}`);
   }
-  let isoDate = new Date().toISOString();
-  let date = isoDate.split("T")[0];
+  let date = niceDate(new Date())
   let pageName = `${dailyNotePrefix}${date}`;
   if (dailyNoteTemplateText) {
     try {


### PR DESCRIPTION
`toISOString()` returns the time in UTC. This leads to e.g. `{[Open Daily Note]} ` ignoring the timezone of the user. `/today` was also affected.

`niceDate()` now renders it's string without the use of `toISOString()`.

Fixes https://github.com/silverbulletmd/silverbullet/issues/83