### PR TITLE
Fix "Rename page" command

### DIFF
--- a/plugs/core/core.plug.yaml
+++ b/plugs/core/core.plug.yaml
@@ -68,6 +68,7 @@ functions:
       name: "Page: Rename"
       mac: Cmd-Alt-r
       key: Ctrl-Alt-r
+      page: ""
 
   pageComplete:
     path: "./page.ts:pageComplete"

--- a/plugs/core/page.ts
+++ b/plugs/core/page.ts
@@ -90,12 +90,12 @@ export async function deletePage() {
   await space.deletePage(pageName);
 }
 
-export async function renamePage(targetName?: string) {
-  console.log("Got a target name", targetName);
+export async function renamePage(cmdDef: any) {
+  console.log("Got a target name", cmdDef.page);
   const oldName = await editor.getCurrentPage();
   const cursor = await editor.getCursor();
   console.log("Old name is", oldName);
-  const newName = targetName ||
+  const newName = cmdDef.page ||
     await editor.prompt(`Rename ${oldName} to:`, oldName);
   if (!newName) {
     return;

--- a/web/editor.tsx
+++ b/web/editor.tsx
@@ -844,7 +844,7 @@ export class Editor {
             console.log("Now renaming page to...", newName);
             editor.system.loadedPlugs.get("core")!.invoke(
               "renamePage",
-              [newName],
+              [{ page: newName }],
             ).then(() => {
               editor.focus();
             }).catch(console.error);


### PR DESCRIPTION
Renaming a page works when pressing <kbd>Enter</kbd> after editing the page name, but fails when using the "Rename page" command, either from the command palette for via hotkey (Cmd+Alt+R):

<img width="822" alt="Screen Shot 2022-12-12 at 9 30 19 PM" src="https://user-images.githubusercontent.com/739304/207211710-c4ce256f-9e03-49af-b948-a43fc7ec0b73.png">

The `renamePage` function expects a string but is called with a command definition (`cmdDef`). This probably deserves a refactor, but overloading the command definition with a `page` parameter allows it to be called successfully in both contexts.