### PR TITLE
deno task build fixes for windows

### DIFF
--- a/build_plugs.ts
+++ b/build_plugs.ts
@@ -1,0 +1,38 @@
+import { path, expandGlobSync, flags } from "./plugos/deps.ts";
+import { bundleRun } from "./plugos/bin/plugos-bundle.ts"
+import {
+  esbuild,
+} from "./plugos/compile.ts";
+
+if (import.meta.main) {
+  const args = flags.parse(Deno.args, {
+    boolean: ["debug", "watch", "reload", "info"],
+    string: ["dist", "importmap"],
+    alias: { w: "watch" },
+  });
+
+  if (!args.dist) {
+    args.dist = path.resolve(path.join("dist_bundle", "_plug"));
+  }
+
+  const manifests : string[] = [];
+  const pattern : string = path.join("plugs", "*", "*.plug.yaml");
+  for (const file of expandGlobSync(pattern)) {
+      manifests.push(file.path);
+  }
+
+  await bundleRun(
+    manifests,
+    args.dist,
+    args.watch,
+    {
+      debug: args.debug,
+      reload: args.reload,
+      info: args.info,
+      importMap: args.importmap
+        ? new URL(args.importmap, `file://${Deno.cwd()}/`)
+        : undefined,
+    },
+  );
+  esbuild.stop();
+}

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,11 +3,11 @@
     "clean": "rm -rf dist dist_bundle",
     "install": "deno install -f -A --unstable silverbullet.ts",
     "test": "deno test -A --unstable",
-    "build": "./build_plugs.sh && deno run -A --unstable --check build.ts",
+    "build": "deno run -A --unstable --check build_plugs.ts && deno run -A --unstable --check build.ts",
     "watch-web": "deno run -A --unstable --check build.ts --watch",
     "watch-server": "deno run -A --unstable --check --watch silverbullet.ts",
     // The only reason to run a shell script is that deno task doesn't support globs yet (e.g. *.plug.yaml)
-    "watch-plugs": "./build_plugs.sh -w",
+    "watch-plugs": "deno run -A --unstable --check build_plugs.ts -w",
     "bundle": "deno bundle silverbullet.ts dist/silverbullet.js",
     // Regenerates some bundle files (checked into the repo)
     // Install lezer-generator with "npm install -g @lezer/generator"

--- a/plugos/deps.ts
+++ b/plugos/deps.ts
@@ -1,6 +1,7 @@
 export { globToRegExp } from "https://deno.land/std@0.165.0/path/glob.ts";
 export { walk } from "https://deno.land/std@0.165.0/fs/mod.ts";
 export * as path from "https://deno.land/std@0.165.0/path/mod.ts";
+export { expandGlobSync } from "https://deno.land/std@0.165.0/fs/mod.ts";
 export { mime } from "https://deno.land/x/mimetypes@v1.0.0/mod.ts";
 export { default as cacheDir } from "https://deno.land/x/cache_dir@0.2.0/mod.ts";
 export * as flags from "https://deno.land/std@0.165.0/flags/mod.ts";


### PR DESCRIPTION
Fix `deno task build` for Windows.

Windows doesn't support `.sh` files so replaced with direct usage in `deno.jsonc`.

Since we're no longer going via shell, the glob patterns are not expanded so modified `plugos-bundle.ts` to assume that if no files are given, we want to build everything and we glob ourselves.

Alternative: still pass glob pattern on cmd-line and glob internally (will be no-op if already globbed).

`build_plugs.sh` is no longer used but I left it in case you're using it from cmd-line.

Makes progress on #107