### PR TITLE
add in new refactor file and extract to page command; #210

### DIFF
--- a/plugs/core/core.plug.yaml
+++ b/plugs/core/core.plug.yaml
@@ -336,7 +336,6 @@ functions:
     path: ./refactor.ts:extractToPage
     command:
       name: "Extract text to new page"
-      page: ""
 
   # Plug manager
   updatePlugsCommand:

--- a/plugs/core/core.plug.yaml
+++ b/plugs/core/core.plug.yaml
@@ -21,7 +21,7 @@ functions:
   setEditorMode:
     path: "./editor.ts:setEditorMode"
     events:
-    - editor:init
+      - editor:init
   toggleVimMode:
     path: "./editor.ts:toggleVimMode"
     command:
@@ -330,6 +330,13 @@ functions:
       name: "Text: Marker"
       key: "Alt-m"
       wrapper: "=="
+
+  # Refactoring Commands
+  extractToPageCommand:
+    path: ./refactor.ts:extractToPage
+    command:
+      name: "Extract text to new page"
+      page: ""
 
   # Plug manager
   updatePlugsCommand:

--- a/plugs/core/refactor.ts
+++ b/plugs/core/refactor.ts
@@ -37,5 +37,5 @@ export async function extractToPage(cmdDef: any) {
   console.log("Writing new page to space");
   const newPageMeta = await space.writePage(newName, text);
   console.log("Navigating to new page");
-  await editor.navigate(newName, cursor, true);
+  await editor.navigate(newName);
 }

--- a/plugs/core/refactor.ts
+++ b/plugs/core/refactor.ts
@@ -1,0 +1,41 @@
+import {
+  editor,
+  space,
+} from "$sb/silverbullet-syscall/mod.ts";
+
+export async function extractToPage(cmdDef: any) {
+  console.log("Got a target name", cmdDef.page);
+  const cursor = await editor.getCursor();
+
+  const newName = cmdDef.page ||
+    await editor.prompt(`New page title:`, 'new page');
+  if (!newName) {
+    return;
+  }
+
+  console.log("New name", newName);
+
+  try {
+    // This throws an error if the page does not exist, which we expect to be the case
+    await space.getPageMeta(newName);
+    // So when we get to this point, we error out
+    throw new Error(
+      `Page ${newName} already exists, cannot rename to existing page.`,
+    );
+  } catch (e: any) {
+    if (e.message.includes("not found")) {
+      // Expected not found error, so we can continue
+    } else {
+      await editor.flashNotification(e.message, "error");
+      throw e;
+    }
+  }
+  let text = await editor.getText();
+  const selection = await editor.getSelection();
+  text = text.slice(selection.from, selection.to);
+  await editor.replaceRange(selection.from, selection.to, "");
+  console.log("Writing new page to space");
+  const newPageMeta = await space.writePage(newName, text);
+  console.log("Navigating to new page");
+  await editor.navigate(newName, cursor, true);
+}

--- a/plugs/core/refactor.ts
+++ b/plugs/core/refactor.ts
@@ -3,12 +3,8 @@ import {
   space,
 } from "$sb/silverbullet-syscall/mod.ts";
 
-export async function extractToPage(cmdDef: any) {
-  console.log("Got a target name", cmdDef.page);
-  const cursor = await editor.getCursor();
-
-  const newName = cmdDef.page ||
-    await editor.prompt(`New page title:`, 'new page');
+export async function extractToPage() {
+  const newName = await editor.prompt(`New page title:`, 'new page');
   if (!newName) {
     return;
   }
@@ -33,9 +29,9 @@ export async function extractToPage(cmdDef: any) {
   let text = await editor.getText();
   const selection = await editor.getSelection();
   text = text.slice(selection.from, selection.to);
-  await editor.replaceRange(selection.from, selection.to, "");
+  await editor.replaceRange(selection.from, selection.to, `[[${newName}]]`);
   console.log("Writing new page to space");
-  const newPageMeta = await space.writePage(newName, text);
+  await space.writePage(newName, text);
   console.log("Navigating to new page");
   await editor.navigate(newName);
 }


### PR DESCRIPTION
- `Refactor: Extract to new page` seems cumbersome, so I omitted the refactor. I'm not sure if the "category" is necessary for core plugins, but seems like a good idea for 3rd party. 
- mostly this is based on the existing plugs for renaming  (including the file overwrite protection) and text editing
- Happy to write some tests, but didn't see any infrastructure for it
- I don't know what `cmdDef.page` is doing, it seems like you can declare a argument in the yaml file, but I'm not sure how you would invoke it for page rename for example. Is that for use by other functions?