### PR TITLE
update listify command to work with selection and add keyboard shortcut

### DIFF
--- a/plugs/core/core.plug.yaml
+++ b/plugs/core/core.plug.yaml
@@ -293,6 +293,8 @@ functions:
     path: ./text.ts:listifySelection
     command:
       name: "Text: Listify Selection"
+      key: "Ctrl-Shift-8"
+      mac: "Cmd-Shift-8"
   numberListifySelection:
     path: ./text.ts:numberListifySelection
     command:

--- a/plugs/core/text.ts
+++ b/plugs/core/text.ts
@@ -22,7 +22,18 @@ export async function quoteSelection() {
 export async function listifySelection() {
   let text = await editor.getText();
   const selection = await editor.getSelection();
+
+  //if very first of doc, just add a bullet and end
+  if (selection.to == 0 && selection.from == 0) {
+    await editor.insertAtCursor("* ")
+    return
+  }
+
   let from = selection.from;
+  if (text[from] == "\n") {
+    //end of line, need to find previous line break
+    from--
+  }
   while (from >= 0 && text[from] !== "\n") {
     from--;
   }
@@ -42,12 +53,11 @@ export async function numberListifySelection() {
   from++;
   text = text.slice(from, selection.to);
   let counter = 1;
-  text = `1. ${
-    text.replaceAll(/\n(?!\n)/g, () => {
-      counter++;
-      return `\n${counter}. `;
-    })
-  }`;
+  text = `1. ${text.replaceAll(/\n(?!\n)/g, () => {
+    counter++;
+    return `\n${counter}. `;
+  })
+    }`;
   await editor.replaceRange(from, selection.to, text);
 }
 


### PR DESCRIPTION
I originally wanted to add in just the keyboard shortcut (cmd+shift+8 I think is by far the most common, google/slack etc.) but also fixed a bug /expanded scope that allows you to listify the current line that the cursor is in, not having to select text first. 

I think ideally listifying would be more like a toggle (subsequent invocations would de-listify) instead of the current behavior where you just add bullets with each invocation. 

As always, open to whatever feedback and discussion! 