### PR TITLE
WIP implementation of dead link searching

### DIFF
--- a/plugs/core/core.plug.yaml
+++ b/plugs/core/core.plug.yaml
@@ -56,7 +56,10 @@ functions:
     path: "./page.ts:deletePage"
     command:
       name: "Page: Delete"
-
+  findDeadLinks:
+    path: "./page.ts:findDeadLinks"
+    command:
+      name: "Find Dead Links"
   # Attachments
   attachmentQueryProvider:
     path: ./attachment.ts:attachmentQueryProvider


### PR DESCRIPTION
Open points I'd like some feedback on before finalizing structure, cleaning up, properly attributing the included code, etc. 

- Is this desired to be a core plugin? 
- Is there a better UI that just writing a page? Is it bad to just write over the page?  
  - Is there a way to embed commands (with arguments) in the page? I was thinking it might be nice to have a "rename dead link to suggestion" type button. and embedding `{[rename(a,b)}] might be useful. 
- it might be great to have an idea around testing, I'm sure there are lots of edge cases my test space didn't show. Not sure what the performance would be with thousands+ files. 
- is it worth filtering to page names that have distances under a certain value? showing multiple suggestions?
![Jan-11-2023 12-51-15](https://user-images.githubusercontent.com/867661/211881031-89b48693-c2a0-488a-89b0-87318025512c.gif)
