### PR TITLE
Fix URLs in 🔌 Git.md

### DIFF
--- a/website/🔌 Git.md
+++ b/website/🔌 Git.md
@@ -1,7 +1,7 @@
 ---
 type: plug
-uri: github:silverbulletmd/silverbullet-github/github.plug.json
-repo: https://github.com/silverbulletmd/silverbullet-github
+uri: github:silverbulletmd/silverbullet-git/git.plug.json
+repo: https://github.com/silverbulletmd/silverbullet-git
 author: Zef Hemel
 ---
 


### PR DESCRIPTION
The plugs are really great! I just discovered them and stumbled over a typo. I think `git` and `github` got messed up here.