### PR TITLE
Add support for multiple order by

### DIFF
--- a/plugs/directive/query.test.ts
+++ b/plugs/directive/query.test.ts
@@ -26,8 +26,9 @@ Deno.test("Test parser", () => {
     `task where completed = false and dueDate <= "{{today}}" order by dueDate desc limit 5`,
   );
   assertEquals(parsedQuery1.table, "task");
-  assertEquals(parsedQuery1.orderBy, "dueDate");
-  assertEquals(parsedQuery1.orderDesc, true);
+  assertEquals(parsedQuery1.ordering.length, 1);
+  assertEquals(parsedQuery1.ordering[0].orderBy, "dueDate");
+  assertEquals(parsedQuery1.ordering[0].orderDesc, true);
   assertEquals(parsedQuery1.limit, 5);
   assertEquals(parsedQuery1.filter.length, 2);
   assertEquals(parsedQuery1.filter[0], {
@@ -69,6 +70,7 @@ Deno.test("Test parser", () => {
     parseQuery(`gh-events where type in ["PushEvent", "somethingElse"]`),
     {
       table: "gh-events",
+      ordering: [],
       filter: [
         {
           op: "in",
@@ -81,12 +83,14 @@ Deno.test("Test parser", () => {
 
   assertEquals(parseQuery(`something render [[template/table]]`), {
     table: "something",
+    ordering: [],
     filter: [],
     render: "template/table",
   });
 
   assertEquals(parseQuery(`something render "template/table"`), {
     table: "something",
+    ordering: [],
     filter: [],
     render: "template/table",
   });


### PR DESCRIPTION
Fixes #385 

* The grammar already supports multiple `order by` clauses
* Modified `ParsedQuery` to be able to contain multiple `order by` clauses by adding `ordering: QueryOrdering[]`
* Added the logic to do sorting by multiple keys
* Invariant: The behavior on single key sort is kept as before.

An Interesting bug that surfaced: When comparing tags, which are array, in earlier implementation the comparison always resulted in a "===" being false even when tags were equal. This automatically resulted in `a` being greater than `b`. For a single key it didn't matter. But kf we keep that implementation as is (which first compares the a and b by an `===`) then that would mean that it will always return false on comparison which would mean that we will never evaluate the latter keys. 