### PR TITLE
feat: make darkmode more readable

### DIFF
--- a/web/styles/theme.scss
+++ b/web/styles/theme.scss
@@ -129,6 +129,17 @@
     background-color: #d7e1f6 !important;
   }
 
+
+  .cm-panels-bottom {
+      background-color: #e1e1e1;
+      border-top: #cacaca 1px solid;
+      .cm-vim-panel {
+        padding: 0 20px;
+        max-width: var(--editor-width);
+        margin: auto;
+      }
+  }
+
   .cm-editor .cm-tooltip-autocomplete {
     .cm-completionDetail {
       font-style: normal;
@@ -410,6 +421,7 @@
   .cm-line.sb-directive-start,
   .cm-line.sb-directive-end {
     color: var(--directive-font-color);
+
     background-color: rgb(233, 233, 233, 50%);
     padding: 3px;
   }
@@ -540,14 +552,19 @@
 
 html[data-theme="dark"] {
   #sb-root {
-    background-color: #000;
+    background-color: #111;
+    --directive-font-color: #adadad;
     color: #fff;
   }
 
   #sb-top {
-    background-color: rgb(96, 96, 96);
+    background-color: rgb(38, 38, 38);
     border-bottom: rgb(62, 62, 62) 1px solid;
     color: #fff;
+  }
+
+  .sb-directive-start {
+    background-color: rgb(38, 38, 38) !important;
   }
 
   .sb-actions button {
@@ -571,7 +588,9 @@ html[data-theme="dark"] {
     color: #c7c7c7;
   }
 
+  .sb-meta {
 
+  }
 
   .sb-modal-box,
   /* duplicating the class name to increase specificity */
@@ -586,6 +605,20 @@ html[data-theme="dark"] {
 
   #sb-editor {
 
+    .cm-selectionBackground {
+      background-color: #d7e1f630 !important;
+    }
+
+    .cm-panels-bottom {
+      border-top: rgb(62, 62, 62) 1px solid;
+      background: rgb(38, 38, 38);
+      color: white !important;
+      .cm-vim-panel {
+        max-width: var(--editor-width);
+        margin: auto;
+      }
+    }
+
     .sb-line-h1,
     .sb-line-h2,
     .sb-line-h3,
@@ -597,7 +630,7 @@ html[data-theme="dark"] {
       background-color: rgb(41, 40, 35, 0.5);
 
       .sb-frontmatter-marker {
-        color: #000;
+        color: #fff;
       }
     }
 


### PR DESCRIPTION
Hi @zefhemel :)

Silverbullet is an awesome app that I thoroughly enjoy. Thanks for creating it! In fact, I even tried to build [something similar](https://github.com/jim-fx/notarium) myself.

Among the many features of Silverbullet, I particularly enjoy using the vim-mode and dark theme. However, I believe there is still some room for improvement to the readable of the dark theme.

Changes:
- switched dark mode background from `#000` to `#111`
- Made the vim status bar the same width as the content window
- made the vim selection a bit transparent so text is readable when selected
- made the top-bar and the vim-status bar the same background color
- increased the contrast of the query header so it is readable
- make the "frontmatter" text readable 

Edit: I just saw that there are some open Issues #10 #58 #127  and a PR ( #179 ) regarding the same topic, but they seam to be stale

![Bildschirmfoto am 2023-05-04 um 14 42 40](https://user-images.githubusercontent.com/29272343/236209756-5d5a065f-a95c-4d3c-8697-d2c9a14621c8.jpg)

![Bildschirmfoto am 2023-05-04 um 14 33 32](https://user-images.githubusercontent.com/29272343/236209775-2c5e3e2b-49c8-4ca3-9b34-81a038d1a59b.jpg)

![Bildschirmfoto am 2023-05-04 um 14 54 32](https://user-images.githubusercontent.com/29272343/236210858-2b0ad63b-f8ec-4095-bd77-2862f7beb686.jpg)
