### PR TITLE
Accept SB_USER environment variable as a secondary source of creds

### DIFF
--- a/server/http_server.ts
+++ b/server/http_server.ts
@@ -34,7 +34,7 @@ export class HttpServer {
     this.hostname = options.hostname;
     this.port = options.port;
     this.app = new Application(); //{ serverConstructor: FlashServer });
-    this.user = options.user;
+    this.user = options.user ?? Deno.env.get("SB_USER");
     this.systemBoot = new SpaceSystem(
       options.assetBundle,
       options.pagesPath,

--- a/website/Server.md
+++ b/website/Server.md
@@ -30,7 +30,7 @@ silverbullet <pages-path>
 
 By default, SilverBullet will bind to port `3000`, to use a different port use the `--port` flag. 
 
-For security reasons, by default SilverBullet only allows connections via `localhost` (or `127.0.0.1`). To also allow connections from the network, pass a `--hostname 0.0.0.0` flag (0.0.0.0 for all connections, or insert a specific address to limit the host), ideally combined with `--user username:password` to add BasicAuth password protection.
+For security reasons, by default SilverBullet only allows connections via `localhost` (or `127.0.0.1`). To also allow connections from the network, pass a `--hostname 0.0.0.0` flag (0.0.0.0 for all connections, or insert a specific address to limit the host), ideally combined with `--user username:password` to add BasicAuth password protection. Credentials can also be specified with the `SB_USER` environment variable, `SB_USER=username:password`. If both are specified, the `--user` flag takes precedence.
 
 Once downloaded and booted, SilverBullet will print out a URL to open SB in your browser.
 

--- a/website/Sync.md
+++ b/website/Sync.md
@@ -21,7 +21,8 @@ Here’s how to use SilverBullet’s sync functionality:
 1. Set up a SilverBullet [[Server]] somewhere where all your other devices have access to it. This can be your local network, a VPN, or if you’re living the wild life — the public Internet (do put some SSL and authentication on it, please).
 2. Connect any other SilverBullet instance (likely the [[Desktop]] or [[Mobile]] app) to it via the {[Sync: Configure]} command. This will ask for:
    * A URL to connect to (the URL of the SB server configured under (1))
-   * A username and password (optional) if you run the server with the `--user myuser:mypass` flag (as you should)
+   * A username and password (optional) if you run the server with the `--user myuser:mypass` flag or the `SB_USER=myuser:mypass` environment variable (as you should)
+
 3. Now you have two options:
     1. Perform a one-time “clean sync” _wiping all local content_ and syncing down content from the sync server. For this, use the {[Sync: Wipe Local Space and Sync]} command. This is likely what you want for e.g. an initial [[Mobile]] setup.
     2. Use {[Sync: Sync]} to perform a regular sync, comparing the local and remote space and generating conflicts where appropriate.


### PR DESCRIPTION
Allow BasicAuth credentials to be specified with the `SB_USER` environment variable. This prevents the password from being revealed when listing processes with the ps command.