### PR TITLE
allow top bar action buttons to be links and make home one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ website_build
 deno.lock
 fly.toml
 env.sh
+test_space

--- a/web/components/top_bar.tsx
+++ b/web/components/top_bar.tsx
@@ -13,6 +13,7 @@ export type ActionButton = {
   icon: FunctionalComponent<FeatherProps>;
   description: string;
   callback: () => void;
+  href?: string;
 };
 
 export function TopBar({
@@ -118,17 +119,21 @@ export function TopBar({
               </div>
             )}
             <div className="sb-actions">
-              {actionButtons.map((actionButton) => (
-                <button
-                  onClick={(e) => {
-                    actionButton.callback();
-                    e.stopPropagation();
-                  }}
-                  title={actionButton.description}
-                >
-                  <actionButton.icon size={18} />
-                </button>
-              ))}
+              {actionButtons.map((actionButton) => {
+                const button =
+                    <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          actionButton.callback();
+                          e.stopPropagation();
+                        }}
+                        title={actionButton.description}
+                    >
+                      <actionButton.icon size={18} />
+                    </button>
+
+                return actionButton.href !== undefined ? (<a href={actionButton.href}>{button}</a>) : button;
+              })}
             </div>
           </div>
         </div>

--- a/web/editor.tsx
+++ b/web/editor.tsx
@@ -1405,6 +1405,7 @@ export class Editor {
               callback: () => {
                 editor.navigate("");
               },
+              href: "",
             },
             {
               icon: BookIcon,


### PR DESCRIPTION
I often want to be able to middle click to open the space's home page in a separate tab. The current code for top bar action buttons doesn't allow for this browser built in functionality. The changes in this PR are to allow action buttons to optionally be contained in an anchor tag with an href. This PR also applies that functionality to the home button.