### PR TITLE
Improvements for mobile view

### DIFF
--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -259,3 +259,14 @@
 div:not(.cm-focused).cm-fat-cursor {
   outline: none !important;
 }
+
+@media only screen and (max-width: 600px) {
+  #sb-main .cm-editor {
+    .sb-table-widget {
+      overflow: auto;
+      th, td {
+        white-space: nowrap;
+      }
+    }
+  }
+}

--- a/web/styles/theme.scss
+++ b/web/styles/theme.scss
@@ -682,3 +682,11 @@ html[data-theme="dark"] {
   }
 
 }
+
+@media only screen and (max-width: 600px) {
+  #sb-editor {
+    .sb-directive-start-outside, .sb-directive-end-outside {
+      height: 22px;
+    }
+  }
+}


### PR DESCRIPTION
As discussed in https://github.com/silverbulletmd/silverbullet/pull/441, I came up with hidding the directive start and end blocks for small devices only (assuming the screen width is smaller than 600px). Also improve the display of tables to show a horizontal scroll bar instead of breaking words.

![Screenshot from 2023-07-05 22-26-06](https://github.com/silverbulletmd/silverbullet/assets/259848/bb27d4f2-9021-4c25-adad-f8f306e9e3f6)

instead of

![Screenshot from 2023-07-05 22-20-48](https://github.com/silverbulletmd/silverbullet/assets/259848/7f37d867-952a-436a-9c7f-8f681c6b61a8)
