### PR TITLE
Move Viewport Top to Cursor on page navigate.

### DIFF
--- a/web/editor.tsx
+++ b/web/editor.tsx
@@ -448,7 +448,7 @@ export class Editor {
         }
         this.editorView.dispatch({
           selection: { anchor: pos },
-          scrollIntoView: true,
+          effects: EditorView.scrollIntoView(pos, { y: "start" }),
         });
       } else if (!stateRestored) {
         // Somewhat ad-hoc way to determine if the document contains frontmatter and if so, putting the cursor _after it_.


### PR DESCRIPTION
By default, codemirror would only scroll enough to get the cursor on screen when navigating to a new page position.

This can be disorienting, especially when navigating to anchors like on the [directives](https://silverbullet.md/%F0%9F%94%8C%20Directive) page.