### PR TITLE
Add inline manifest documentation

### DIFF
--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -8,7 +8,6 @@ import { CodeWidgetT } from "../web/hooks/code_widget.ts";
 import { MQHookT } from "../plugos/hooks/mq.ts";
 import { EndpointHookT } from "../plugos/hooks/endpoint.ts";
 
-/** @typedef {import("../plug-api/lib/tree.ts")} tree */
 /** @typedef {import("../plugos/types.ts")} plugos */
 
 /** Silverbullet hooks give plugs access to silverbullet core systems. */
@@ -24,7 +23,7 @@ export type SilverBulletHooks =
 
 /** Syntax extension allow plugs to declaratively add new *inline* parse tree nodes to the markdown parser. */
 export type SyntaxExtensions = {
-  /** Key-value pair of node **name** (see {@link tree.ParseTree.type}), to parsing and highlighting instructions.
+  /** Key-value pair of node **name** (see: plug-api/lib/tree.ts#ParseTree.type), to parsing and highlighting instructions.
    */
   syntax?: { [key: string]: NodeDef };
 };
@@ -49,7 +48,7 @@ export type NodeDef = {
   className?: string;
 };
 
-/** A plug manifest configures {@link SilverBulletHooks hooks}, declares {@link SyntaxExtensions syntax} extensions, and describes plug {@link plugos.Manifest metadata}.
+/** A plug manifest configures {@link SilverBulletHooks hooks}, declares {@link SyntaxExtensions syntax} extensions, and describes plug.
  *
  * Typically the manifest file is in a plug's root directory, named `${plugName}.plug.yaml`.
  */

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -8,6 +8,8 @@ import { CodeWidgetT } from "../web/hooks/code_widget.ts";
 import { MQHookT } from "../plugos/hooks/mq.ts";
 import { EndpointHookT } from "../plugos/hooks/endpoint.ts";
 
+/** @typedef {import("../plug-api/lib/tree.ts")} tree */
+
 /** Silverbullet hooks give plugs access to silverbullet core systems.
   */
 export type SilverBulletHooks =
@@ -24,7 +26,7 @@ export type SilverBulletHooks =
  * 
  */
 export type SyntaxExtensions = {
-  /** Key-value pair of node **name** (see {@link ../plug-api/lib/tree.ts#ParseTree#type})), to parsing and highlighting instructions.
+  /** Key-value pair of node **name** (see {@link tree.ParseTree.type}), to parsing and highlighting instructions.
    */
   syntax?: { [key: string]: NodeDef };
 };
@@ -52,7 +54,7 @@ export type NodeDef = {
   className?: string;
 };
 
-/** A plug manifest configures {@link SilverBulletHooks | hooks}, declares {@link SyntaxExtension | syntax} extension, and describes plug @{link plugos.Manifest | metadata}.
+/** A plug manifest configures {@link SilverBulletHooks hooks}, declares {@link SyntaxExtension syntax} extension, and describes plug {@link plugos.Manifest metadata}.
  *
  * Typically the manifest file is in a plug's root directory, named `${plugName}.plug.yaml`.
  */

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -27,14 +27,19 @@ export type SilverBulletHooks =
 
 /** Syntax extension allow plugs to declaratively add new *inline* parse tree nodes to the markdown parser. */
 export type SyntaxExtensions = {
-  /** Key-value pair of node **name** (see: plug-api/lib/tree.ts#ParseTree.type), to parsing and highlighting instructions.
+  /** A map of node **name** (also called "type"), to parsing and highlighting instructions. Each entry defines a new node.
+   * 
+   * see: plug-api/lib/tree.ts#ParseTree
    */
   syntax?: { [key: string]: NodeDef };
 };
 
 /** Parsing and highlighting instructions for SyntaxExtension */
 export type NodeDef = {
-  /** Characters to begin matching on. */
+  /** An array of possible first characters to begin matching on.
+   * 
+   * **Example**: If this node has the regex '[abc][123]', NodeDef.firstCharacters should be ["a", "b", "c"].
+  */
   firstCharacters: string[];
 
   /** A regular expression that matches the *entire* syntax, including the first character. */

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -18,14 +18,35 @@ export type SilverBulletHooks =
   & EndpointHookT
   & PlugNamespaceHookT;
 
+/** Syntax extension allow plugs to declaratively add new *inline* parse tree nodes to the markdown parser.
+ * 
+ */
 export type SyntaxExtensions = {
+  /** Key-value pair of node **name** (see {@link ../plug-api/lib/tree.ts#ParseTree#type])), to parsing and highlighting instructions.
+   */
   syntax?: { [key: string]: NodeDef };
 };
 
+/** Parsing and highlighting instructions for SyntaxExtension */
 export type NodeDef = {
+  /** Characters to begin matching on.
+   */
   firstCharacters: string[];
+
+  /** A regular expression that matches the *entire* syntax, including the first character.
+   */
   regex: string;
+
+  /** CSS styles to apply to the matched text.
+   * 
+   * Key-value pair of CSS key to value:
+   * 
+   * **Example**: `backgroundColor: "rgba(22,22,22,0.07)"`
+   */
   styles: { [key: string]: string };
+
+  /** CSS class name to apply to the matched text
+   */
   className?: string;
 };
 

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -9,7 +9,7 @@ import { MQHookT } from "../plugos/hooks/mq.ts";
 import { EndpointHookT } from "../plugos/hooks/endpoint.ts";
 
 /** @typedef {import("../plug-api/lib/tree.ts")} tree */
-/** @typedef {import("../plugos/types.ts")} plugos */
+/** @typedef {import("../plugos/types.ts").Manifest} plugosManifest */
 
 /** Silverbullet hooks give plugs access to silverbullet core systems.
   */
@@ -55,7 +55,7 @@ export type NodeDef = {
   className?: string;
 };
 
-/** A plug manifest configures {@link SilverBulletHooks hooks}, declares {@link SyntaxExtensions syntax} extension, and describes plug {@link plugos.Manifest metadata}.
+/** A plug manifest configures {@link SilverBulletHooks hooks}, declares {@link SyntaxExtensions syntax} extensions, and describes plug {@link plugosManifest Manifest}.
  *
  * Typically the manifest file is in a plug's root directory, named `${plugName}.plug.yaml`.
  */

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -52,7 +52,7 @@ export type NodeDef = {
   className?: string;
 };
 
-/** A plug manifest configures {@link SilverBulletHooks hooks}, declares {@link SyntaxExtensions syntax} extensions, and describes plug.
+/** A plug manifest configures hooks, declares syntax extensions, and describes plug metadata.
  *
  * Typically the manifest file is in a plug's root directory, named `${plugName}.plug.yaml`.
  */

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -22,7 +22,7 @@ export type SilverBulletHooks =
  * 
  */
 export type SyntaxExtensions = {
-  /** Key-value pair of node **name** (see {@link ../plug-api/lib/tree.ts#ParseTree#type])), to parsing and highlighting instructions.
+  /** Key-value pair of node **name** (see {@link ../plug-api/lib/tree.ts#ParseTree#type})), to parsing and highlighting instructions.
    */
   syntax?: { [key: string]: NodeDef };
 };

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -11,8 +11,7 @@ import { EndpointHookT } from "../plugos/hooks/endpoint.ts";
 /** @typedef {import("../plug-api/lib/tree.ts")} tree */
 /** @typedef {import("../plugos/types.ts")} plugos */
 
-/** Silverbullet hooks give plugs access to silverbullet core systems.
-  */
+/** Silverbullet hooks give plugs access to silverbullet core systems. */
 export type SilverBulletHooks =
   & CommandHookT
   & SlashCommandHookT
@@ -23,9 +22,7 @@ export type SilverBulletHooks =
   & EndpointHookT
   & PlugNamespaceHookT;
 
-/** Syntax extension allow plugs to declaratively add new *inline* parse tree nodes to the markdown parser.
- * 
- */
+/** Syntax extension allow plugs to declaratively add new *inline* parse tree nodes to the markdown parser. */
 export type SyntaxExtensions = {
   /** Key-value pair of node **name** (see {@link tree.ParseTree.type}), to parsing and highlighting instructions.
    */
@@ -34,12 +31,10 @@ export type SyntaxExtensions = {
 
 /** Parsing and highlighting instructions for SyntaxExtension */
 export type NodeDef = {
-  /** Characters to begin matching on.
-   */
+  /** Characters to begin matching on. */
   firstCharacters: string[];
 
-  /** A regular expression that matches the *entire* syntax, including the first character.
-   */
+  /** A regular expression that matches the *entire* syntax, including the first character. */
   regex: string;
 
   /** CSS styles to apply to the matched text.
@@ -50,8 +45,7 @@ export type NodeDef = {
    */
   styles: { [key: string]: string };
 
-  /** CSS class name to apply to the matched text
-   */
+  /** CSS class name to apply to the matched text */
   className?: string;
 };
 

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -52,4 +52,8 @@ export type NodeDef = {
   className?: string;
 };
 
+/** A plug manifest configures {@link SilverBulletHooks | hooks}, declares {@link SyntaxExtension | syntax} extension, and describes plug @{link plugos.Manifest | metadata}.
+ *
+ * Typically the manifest file is in a plug's root directory, named `${plugName}.plug.yaml`.
+ */
 export type Manifest = plugos.Manifest<SilverBulletHooks> & SyntaxExtensions;

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -8,6 +8,8 @@ import { CodeWidgetT } from "../web/hooks/code_widget.ts";
 import { MQHookT } from "../plugos/hooks/mq.ts";
 import { EndpointHookT } from "../plugos/hooks/endpoint.ts";
 
+/** Silverbullet hooks give plugs access to silverbullet core systems.
+  */
 export type SilverBulletHooks =
   & CommandHookT
   & SlashCommandHookT

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -8,7 +8,13 @@ import { CodeWidgetT } from "../web/hooks/code_widget.ts";
 import { MQHookT } from "../plugos/hooks/mq.ts";
 import { EndpointHookT } from "../plugos/hooks/endpoint.ts";
 
-/** Silverbullet hooks give plugs access to silverbullet core systems. */
+/** Silverbullet hooks give plugs access to silverbullet core systems. 
+ * 
+ * Hooks are associated with typescript functions through a manifest file.
+ * On various triggers (user enters a slash command, an HTTP endpoint is hit, user clicks, etc) the typescript function is called.
+ * 
+ * related: plugos/type.ts#FunctionDef
+*/
 export type SilverBulletHooks =
   & CommandHookT
   & SlashCommandHookT

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -9,6 +9,7 @@ import { MQHookT } from "../plugos/hooks/mq.ts";
 import { EndpointHookT } from "../plugos/hooks/endpoint.ts";
 
 /** @typedef {import("../plug-api/lib/tree.ts")} tree */
+/** @typedef {import("../plugos/types.ts")} plugos */
 
 /** Silverbullet hooks give plugs access to silverbullet core systems.
   */
@@ -54,7 +55,7 @@ export type NodeDef = {
   className?: string;
 };
 
-/** A plug manifest configures {@link SilverBulletHooks hooks}, declares {@link SyntaxExtension syntax} extension, and describes plug {@link plugos.Manifest metadata}.
+/** A plug manifest configures {@link SilverBulletHooks hooks}, declares {@link SyntaxExtensions syntax} extension, and describes plug {@link plugos.Manifest metadata}.
  *
  * Typically the manifest file is in a plug's root directory, named `${plugName}.plug.yaml`.
  */

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -27,7 +27,7 @@ export type SilverBulletHooks =
 
 /** Syntax extension allow plugs to declaratively add new *inline* parse tree nodes to the markdown parser. */
 export type SyntaxExtensions = {
-  /** A map of node **name** (also called "type"), to parsing and highlighting instructions. Each entry defines a new node.
+  /** A map of node **name** (also called "type"), to parsing and highlighting instructions. Each entry defines a new node. By convention node names (types) are UpperCamelCase (PascalCase).
    * 
    * see: plug-api/lib/tree.ts#ParseTree
    */

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -8,8 +8,6 @@ import { CodeWidgetT } from "../web/hooks/code_widget.ts";
 import { MQHookT } from "../plugos/hooks/mq.ts";
 import { EndpointHookT } from "../plugos/hooks/endpoint.ts";
 
-/** @typedef {import("../plugos/types.ts")} plugos */
-
 /** Silverbullet hooks give plugs access to silverbullet core systems. */
 export type SilverBulletHooks =
   & CommandHookT

--- a/common/manifest.ts
+++ b/common/manifest.ts
@@ -9,7 +9,7 @@ import { MQHookT } from "../plugos/hooks/mq.ts";
 import { EndpointHookT } from "../plugos/hooks/endpoint.ts";
 
 /** @typedef {import("../plug-api/lib/tree.ts")} tree */
-/** @typedef {import("../plugos/types.ts").Manifest} plugosManifest */
+/** @typedef {import("../plugos/types.ts")} plugos */
 
 /** Silverbullet hooks give plugs access to silverbullet core systems.
   */
@@ -55,7 +55,7 @@ export type NodeDef = {
   className?: string;
 };
 
-/** A plug manifest configures {@link SilverBulletHooks hooks}, declares {@link SyntaxExtensions syntax} extensions, and describes plug {@link plugosManifest Manifest}.
+/** A plug manifest configures {@link SilverBulletHooks hooks}, declares {@link SyntaxExtensions syntax} extensions, and describes plug {@link plugos.Manifest metadata}.
  *
  * Typically the manifest file is in a plug's root directory, named `${plugName}.plug.yaml`.
  */

--- a/plugos/types.ts
+++ b/plugos/types.ts
@@ -5,7 +5,7 @@ import { AssetJson } from "./asset_bundle/bundle.ts";
  * Defines plug metadata and functions.
  */
 export interface Manifest<HookT> {
-  /** The plug's name. Typically this matches ${plugName} in the manifest file name. */
+  /** The plug's name. Typically this is the name of the manifest file, without the file extension. */
   name: string;
 
   /** A list of syscall permissions required for this plug to function.
@@ -26,16 +26,16 @@ export interface Manifest<HookT> {
 
   /** A map of function names to definitions. Declared functions are public, and may be associated with various hooks
    * 
-   * see: ../common/manifest.ts#SilverBulletHooks
+   * see: common/manifest.ts#SilverBulletHooks
    */
   functions: {
     [key: string]: FunctionDef<HookT>;
   };
 }
 
-/** Associates hooks with a function */
+/** Associates hooks with a function. This is the generic base structure, that identifies the function. Hooks are defined by the type parameter. */
 export type FunctionDef<HookT> = {
-  /** A function path, in the form `${relativeFilename}:${functionName}`, that attached to the given hooks.
+  /** A function path, in the form `${relativeFilename}:${functionName}`.
    * 
    * During compilation (see `../build_plugs.ts`) the function is read from the file and inlined into the plug bundle.
    * 

--- a/plugos/types.ts
+++ b/plugos/types.ts
@@ -1,6 +1,10 @@
 import { System } from "./system.ts";
 import { AssetJson } from "./asset_bundle/bundle.ts";
 
+/** @typedef {import("../plug-api/plugos-syscall/shell.ts")} shell */
+/** @typedef {import("../plug-api/plugos-syscall/asset.ts")} asset */
+/** @typedef {import("../manifest.ts")} manifest */
+
 /** The generic top level of a plug manifest file.
  * Defines plug metadata and functions.
  */
@@ -12,17 +16,17 @@ export interface Manifest<HookT> {
    * 
    * Possible values:
    * - `fetch`: enables `fetch` function.
-   * - `shell`: enables {@link ../plug-api/plugos-syscall/shell.ts#run}.
+   * - `shell`: enables {@link shell.run}.
    */
   requiredPermissions?: string[];
 
   /** A list of files or glob patterns that should be bundled with the plug.
    * 
-   * These files will be accessible through the {@link ../plug-api/plugos-syscall/asset.ts#readAsset} function.
+   * These files will be accessible through the {@link asset.readAsset} function.
    */
   assets?: string[] | AssetJson;
 
-  /** A map of function names to definitions. Declared functions are public, and may be associated with {@link ../manifest.ts#SilverBulletHooks} */
+  /** A map of function names to definitions. Declared functions are public, and may be associated with {@link manifest.SilverBulletHooks} */
   functions: {
     [key: string]: FunctionDef<HookT>;
   };
@@ -32,7 +36,7 @@ export interface Manifest<HookT> {
 export type FunctionDef<HookT> = {
   /** A function path, in the form `${relativeFilename}:${functionName}`, that attached to the given hooks.
    * 
-   * During compilation (see {@link ../build_plugs.ts}) the function is read from the file and inlined into the plug bundle.
+   * During compilation (see `../build_plugs.ts`) the function is read from the file and inlined into the plug bundle.
    * 
    * This field and {@link FunctionDef.redirect} are mutually exclusive/
    */

--- a/plugos/types.ts
+++ b/plugos/types.ts
@@ -10,13 +10,20 @@ export interface Manifest<HookT> {
   };
 }
 
+/** Associates hooks with a function */
 export type FunctionDef<HookT> = {
-  // Read the function from this path and inline it
-  // Format: filename:functionName
+  /** A function path, in the form `${relativeFilename}:${functionName}`, that attached to the given hooks.
+   * 
+   * During compilation (see @{link ../build_plugs.ts}) the function is read from the file and inlined into the plug bundle.
+   * 
+   * This field and @{link FunctionDef.redirect} are mutually exclusive/
+   */
   path?: string;
-  // Reuse an
-  // Format: plugName.functionName
+
+  /** A function from another plug, in the form `${plugName}.${functionName}` that will be attached to the given hooks. */
   redirect?: string;
+
+  /** Environments where this plug is allowed to run, current may be one of "cli", "server", or "client". */
   env?: string;
 } & HookT;
 

--- a/plugos/types.ts
+++ b/plugos/types.ts
@@ -1,10 +1,28 @@
 import { System } from "./system.ts";
 import { AssetJson } from "./asset_bundle/bundle.ts";
 
+/** The generic top level of a plug manifest file.
+ * Defines plug metadata and functions.
+ */
 export interface Manifest<HookT> {
+  /** The plug's name. Typically this matches ${plugName} in the manifest file name. */
   name: string;
+
+  /** A list of syscall permissions required for this plug to function.
+   * 
+   * Possible values:
+   * - `fetch`: enables `fetch` function.
+   * - `shell`: enables {@link ../plug-api/plugos-syscall/shell.ts#run}.
+   */
   requiredPermissions?: string[];
+
+  /** A list of files or glob patterns that should be bundled with the plug.
+   * 
+   * These files will be accessible through the {@link ../plug-api/plugos-syscall/asset.ts#readAsset} function.
+   */
   assets?: string[] | AssetJson;
+
+  /** A map of function names to definitions. Declared functions are public, and may be associated with {@link ../manifest.ts#SilverBulletHooks} */
   functions: {
     [key: string]: FunctionDef<HookT>;
   };

--- a/plugos/types.ts
+++ b/plugos/types.ts
@@ -32,9 +32,9 @@ export interface Manifest<HookT> {
 export type FunctionDef<HookT> = {
   /** A function path, in the form `${relativeFilename}:${functionName}`, that attached to the given hooks.
    * 
-   * During compilation (see @{link ../build_plugs.ts}) the function is read from the file and inlined into the plug bundle.
+   * During compilation (see {@link ../build_plugs.ts}) the function is read from the file and inlined into the plug bundle.
    * 
-   * This field and @{link FunctionDef.redirect} are mutually exclusive/
+   * This field and {@link FunctionDef.redirect} are mutually exclusive/
    */
   path?: string;
 

--- a/plugos/types.ts
+++ b/plugos/types.ts
@@ -1,10 +1,6 @@
 import { System } from "./system.ts";
 import { AssetJson } from "./asset_bundle/bundle.ts";
 
-/** @typedef {import("../plug-api/plugos-syscall/shell.ts")} shell */
-/** @typedef {import("../plug-api/plugos-syscall/asset.ts")} asset */
-/** @typedef {import("../manifest.ts")} manifest */
-
 /** The generic top level of a plug manifest file.
  * Defines plug metadata and functions.
  */
@@ -15,18 +11,23 @@ export interface Manifest<HookT> {
   /** A list of syscall permissions required for this plug to function.
    * 
    * Possible values:
-   * - `fetch`: enables `fetch` function.
-   * - `shell`: enables {@link shell.run}.
+   * - `fetch`: enables `fetch` function. (see: plug-api/plugos-syscall/fetch.ts, and plug-api/lib/fetch.ts)
+   * - `shell`: enables the `shell.run` syscall. (see: plug-api/plugos-syscall/shell.ts)
    */
   requiredPermissions?: string[];
 
   /** A list of files or glob patterns that should be bundled with the plug.
    * 
-   * These files will be accessible through the {@link asset.readAsset} function.
+   * These files will be accessible through the `asset.readAsset` function.
+   * 
+   * see: plug-api/plugos-syscall/asset.ts#readAsset
    */
   assets?: string[] | AssetJson;
 
-  /** A map of function names to definitions. Declared functions are public, and may be associated with {@link manifest.SilverBulletHooks} */
+  /** A map of function names to definitions. Declared functions are public, and may be associated with various hooks
+   * 
+   * see: ../common/manifest.ts#SilverBulletHooks
+   */
   functions: {
     [key: string]: FunctionDef<HookT>;
   };
@@ -38,7 +39,7 @@ export type FunctionDef<HookT> = {
    * 
    * During compilation (see `../build_plugs.ts`) the function is read from the file and inlined into the plug bundle.
    * 
-   * This field and {@link FunctionDef.redirect} are mutually exclusive/
+   * This field and `FunctionDef.redirect` are mutually exclusive.
    */
   path?: string;
 


### PR DESCRIPTION
Just a little documentation for manifest type definition. Hoping to add this to copy most of this info to the website at some point. But I thought putting it in code would be a good place to start.