### PR TITLE
Index plug: index paragraph nodes

### DIFF
--- a/plugs/index/builtins.ts
+++ b/plugs/index/builtins.ts
@@ -47,6 +47,11 @@ export const builtins: Record<string, Record<string, string>> = {
     inDirective: "boolean",
     asTemplate: "boolean",
   },
+  paragraph: {
+    text: "string",
+    page: "string",
+    pos: "number",
+  },
 };
 
 export async function loadBuiltinsIntoIndex() {

--- a/plugs/index/index.plug.yaml
+++ b/plugs/index/index.plug.yaml
@@ -86,6 +86,11 @@ functions:
     events:
       - page:index
 
+  indexParagraphs:
+    path: "./paragraph.ts:indexParagraphs"
+    events:
+      - page:index
+
   # Backlinks
   indexLinks:
     path: "./page_links.ts:indexLinks"

--- a/plugs/index/paragraph.ts
+++ b/plugs/index/paragraph.ts
@@ -1,0 +1,56 @@
+import type { IndexTreeEvent } from "$sb/app_event.ts";
+import { removeQueries } from "$sb/lib/query.ts";
+import { indexObjects } from "./api.ts";
+import {
+  addParentPointers,
+  renderToText,
+  traverseTree,
+  traverseTreeAsync,
+} from "$sb/lib/tree.ts";
+import { extractAttributes } from "$sb/lib/attribute.ts";
+
+export type ParagraphObject = {
+  ref: string;
+  tags: string[];
+  text: string;
+  // TODO: maybe it would be useful to have a list of the the headings above the paragraph
+  page: string;
+  startPos: number;
+  endPos: number;
+} & Record<string, any>;
+
+export async function indexParagraphs({ name: page, tree }: IndexTreeEvent) {
+  const objects: ParagraphObject[] = [];
+  await traverseTreeAsync(tree, async (p) => {
+    // only search directly under document
+    if (p.type == "Document") return false;
+    if (p.type != "Paragraph") return true;
+
+    const tags = new Set<string>(["paragraph"]);
+    // tag the paragraph with any hashtags inside it
+    traverseTree(p, (e) => {
+      if (e.type == "Hashtag") {
+        tags.add(e.children![0].text!.substring(1));
+        return true;
+      }
+
+      return false;
+    });
+
+    const attrs = await extractAttributes(p, false);
+    objects.push({
+      ref: `${page}:${p.from}:${p.to}`,
+      text: renderToText(p),
+      tags: [...tags.values()],
+      page,
+      startPos: p.from!,
+      endPos: p.to!,
+      ...attrs,
+    });
+
+    // stop on every element except document (see above)
+    return true;
+  });
+
+  await indexObjects<ParagraphObject>(page, objects);
+}

--- a/plugs/index/paragraph.ts
+++ b/plugs/index/paragraph.ts
@@ -1,12 +1,6 @@
 import type { IndexTreeEvent } from "$sb/app_event.ts";
-import { removeQueries } from "$sb/lib/query.ts";
 import { indexObjects } from "./api.ts";
-import {
-  addParentPointers,
-  renderToText,
-  traverseTree,
-  traverseTreeAsync,
-} from "$sb/lib/tree.ts";
+import { renderToText, traverseTree, traverseTreeAsync } from "$sb/lib/tree.ts";
 import { extractAttributes } from "$sb/lib/attribute.ts";
 
 export type ParagraphObject = {
@@ -15,8 +9,7 @@ export type ParagraphObject = {
   text: string;
   // TODO: maybe it would be useful to have a list of the the headings above the paragraph
   page: string;
-  startPos: number;
-  endPos: number;
+  pos: number;
 } & Record<string, any>;
 
 export async function indexParagraphs({ name: page, tree }: IndexTreeEvent) {
@@ -38,13 +31,13 @@ export async function indexParagraphs({ name: page, tree }: IndexTreeEvent) {
     });
 
     const attrs = await extractAttributes(p, false);
+    const pos = p.from!;
     objects.push({
-      ref: `${page}:${p.from}:${p.to}`,
+      ref: `${page}@${pos}`,
       text: renderToText(p),
       tags: [...tags.values()],
       page,
-      startPos: p.from!,
-      endPos: p.to!,
+      pos,
       ...attrs,
     });
 

--- a/plugs/index/paragraph.ts
+++ b/plugs/index/paragraph.ts
@@ -3,20 +3,22 @@ import { indexObjects } from "./api.ts";
 import { renderToText, traverseTree, traverseTreeAsync } from "$sb/lib/tree.ts";
 import { extractAttributes } from "$sb/lib/attribute.ts";
 
+/** ParagraphObject  An index object for the top level text nodes */
 export type ParagraphObject = {
   ref: string;
   tags: string[];
   text: string;
-  // TODO: maybe it would be useful to have a list of the the headings above the paragraph
   page: string;
   pos: number;
 } & Record<string, any>;
 
 export async function indexParagraphs({ name: page, tree }: IndexTreeEvent) {
   const objects: ParagraphObject[] = [];
+
   await traverseTreeAsync(tree, async (p) => {
     // only search directly under document
-    if (p.type == "Document") return false;
+    //  Paragraph nodes also appear under block elements
+    if (p.type == "Document") return false; // continue traversal if p is Document
     if (p.type != "Paragraph") return true;
 
     const tags = new Set<string>(["paragraph"]);
@@ -41,7 +43,7 @@ export async function indexParagraphs({ name: page, tree }: IndexTreeEvent) {
       ...attrs,
     });
 
-    // stop on every element except document (see above)
+    // stop on every element except document, including paragraphs
     return true;
   });
 


### PR DESCRIPTION
 Only considers top level paragraphs (right below Document node).
Includes attributes and tags in the paragraphs.

Just something I threw together real quick after seeing the discussion on discord. Definitely needs more tests.