### PR TITLE
Add a {time} template helper, reuse timestamp code from Quick Note as a niceTime

### DIFF
--- a/common/syscalls/handlebar_helpers.ts
+++ b/common/syscalls/handlebar_helpers.ts
@@ -1,4 +1,4 @@
-import { niceDate } from "$sb/lib/dates.ts";
+import { niceDate, niceTime } from "$sb/lib/dates.ts";
 
 export function handlebarHelpers() {
   return {

--- a/common/syscalls/handlebar_helpers.ts
+++ b/common/syscalls/handlebar_helpers.ts
@@ -15,6 +15,8 @@ export function handlebarHelpers() {
     substring: (s: string, from: number, to: number, elipsis = "") =>
       s.length > to - from ? s.substring(from, to) + elipsis : s,
 
+    time: () => niceTime(new Date());
+
     today: () => niceDate(new Date()),
     tomorrow: () => {
       const tomorrow = new Date();

--- a/common/syscalls/handlebar_helpers.ts
+++ b/common/syscalls/handlebar_helpers.ts
@@ -15,8 +15,7 @@ export function handlebarHelpers() {
     substring: (s: string, from: number, to: number, elipsis = "") =>
       s.length > to - from ? s.substring(from, to) + elipsis : s,
 
-    time: () => niceTime(new Date());
-
+    time: () => niceTime(new Date()),
     today: () => niceDate(new Date()),
     tomorrow: () => {
       const tomorrow = new Date();

--- a/plug-api/lib/dates.ts
+++ b/plug-api/lib/dates.ts
@@ -9,3 +9,10 @@ export function niceDate(d: Date): string {
 
   return d.getFullYear() + "-" + pad(d.getMonth() + 1) + "-" + pad(d.getDate());
 }
+
+export function niceTime(d: Date): string {
+  const isoDate = d.toISOString();
+  let [date, time] = isoDate.split("T");
+  // hh:mm:ss
+  return time.split(".")[0];
+}

--- a/plugs/template/template.ts
+++ b/plugs/template/template.ts
@@ -1,7 +1,7 @@
 import { editor, handlebars, markdown, space } from "$sb/syscalls.ts";
 import { extractFrontmatter } from "$sb/lib/frontmatter.ts";
 import { renderToText } from "$sb/lib/tree.ts";
-import { niceDate } from "$sb/lib/dates.ts";
+import { niceDate, niceTime } from "$sb/lib/dates.ts";
 import { readSettings } from "$sb/lib/settings_page.ts";
 import { cleanPageRef } from "$sb/lib/resolve.ts";
 import { PageMeta } from "$sb/types.ts";

--- a/plugs/template/template.ts
+++ b/plugs/template/template.ts
@@ -169,9 +169,8 @@ export async function quickNoteCommand() {
   const { quickNotePrefix } = await readSettings({
     quickNotePrefix: "📥 ",
   });
-  const isoDate = new Date().toISOString();
-  let [date, time] = isoDate.split("T");
-  time = time.split(".")[0];
+  const date = niceDate(new Date());
+  const time = niceTime(new Date());
   const pageName = `${quickNotePrefix}${date} ${time}`;
   await editor.navigate(pageName);
 }


### PR DESCRIPTION
I was looking to create an "interstitial journal" timestamp snippet, and found there was no {time} helper. I centralised the code from the Quick Note alongside niceDate.

This should yield hh:mm:ss (although I'd personally prefer hh:mm), bear in mind this is my first time writing TypeScript :)