### PR TITLE
Plug: Emoji aliases (#246)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,17 @@
   "deno.importMap": "import_map.json",
   "deno.config": "deno.jsonc",
   "deno.unstable": true,
+  "[json]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
   "[markdown]": {
     "editor.formatOnSave": false
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
   },
   "deno.documentPreloadLimit": 0
 }

--- a/plugs/emoji/emoji.ts
+++ b/plugs/emoji/emoji.ts
@@ -1,9 +1,18 @@
 import emojiBlob from "./emoji.json" assert { type: "json" };
 import type { CompleteEvent } from "$sb/app_event.ts";
+import { readSetting } from "$sb/lib/settings_page.ts";
+import { editor } from "$sb/silverbullet-syscall/mod.ts";
+
+export type EmojiConfig = {
+  aliases: string[][];
+};
+let emojiConfig: EmojiConfig = { aliases: [] };
 
 const emojis = emojiBlob.split("|").map((line) => line.split(" "));
 
 export function emojiCompleter({ linePrefix, pos }: CompleteEvent) {
+  updateConfig(); // no need to await, will be ready for completion by next keystrokes
+
   const match = /:([\w]+)$/.exec(linePrefix);
   if (!match) {
     return null;
@@ -11,8 +20,8 @@ export function emojiCompleter({ linePrefix, pos }: CompleteEvent) {
 
   const [fullMatch, emojiName] = match;
 
-  const filteredEmoji = emojis.filter(([shortcode]) =>
-    shortcode.includes(emojiName)
+  const filteredEmoji = [...emojiConfig.aliases, ...emojis].filter(
+    ([shortcode]) => shortcode.includes(emojiName)
   );
 
   return {
@@ -23,5 +32,54 @@ export function emojiCompleter({ linePrefix, pos }: CompleteEvent) {
       label: emoji,
       type: "emoji",
     })),
+  };
+}
+
+let lastConfigUpdate = 0;
+async function updateConfig() {
+  // Update at most every 5 seconds
+  if (Date.now() < lastConfigUpdate + 5000) return;
+  lastConfigUpdate = Date.now();
+  const config = await readSetting("emoji");
+
+  // This is simpler to write in SETTINGS and prevents duplicates,
+  // which could be supported but probably aren't user's intent
+  const errorMsg =
+    "Emoji aliases in SETTINGS should be a map with entries 'name: 😀'";
+
+  let aliasMap: Record<string, any> = {};
+  if (config.aliases && typeof config.aliases !== "object") {
+    await editor.flashNotification(errorMsg, "error");
+  } else {
+    aliasMap = config.aliases;
+  }
+
+  const aliases = [];
+  const badAliases = [];
+  for (const alias in aliasMap) {
+    if (typeof aliasMap[alias] !== "string") {
+      badAliases.push(alias);
+      continue;
+    }
+    const emoji: string = aliasMap[alias].trim();
+    // For detecting misconfiguration like 'smile: grinning_face' which wouldn't work.
+    // Side effect: can't use for phrases like 'br: Best regards', but Slash Commands are meant for that
+    if ([...emoji].find((c) => c.charCodeAt(0) <= 127)) {
+      // ASCII characters somewhere in text
+      badAliases.push(alias);
+      continue;
+    }
+
+    aliases.push([alias, emoji]);
+  }
+  if (badAliases.length > 0) {
+    await editor.flashNotification(
+      errorMsg + `, need to fix: ${badAliases.join(",")}`,
+      "error"
+    );
+  }
+
+  emojiConfig = {
+    aliases: aliases,
   };
 }

--- a/plugs/emoji/emoji.ts
+++ b/plugs/emoji/emoji.ts
@@ -2,10 +2,8 @@ import emojiBlob from "./emoji.json" assert { type: "json" };
 import type { CompleteEvent } from "$sb/app_event.ts";
 import { readSetting } from "$sb/lib/settings_page.ts";
 import { editor } from "$sb/silverbullet-syscall/mod.ts";
+import type { EmojiConfig } from "../../web/types.ts";
 
-export type EmojiConfig = {
-  aliases: string[][];
-};
 let emojiConfig: EmojiConfig = { aliases: [] };
 
 const emojis = emojiBlob.split("|").map((line) => line.split(" "));
@@ -21,7 +19,7 @@ export function emojiCompleter({ linePrefix, pos }: CompleteEvent) {
   const [fullMatch, emojiName] = match;
 
   const filteredEmoji = [...emojiConfig.aliases, ...emojis].filter(
-    ([shortcode]) => shortcode.includes(emojiName)
+    ([shortcode]) => shortcode.includes(emojiName),
   );
 
   return {
@@ -75,7 +73,7 @@ async function updateConfig() {
   if (badAliases.length > 0) {
     await editor.flashNotification(
       errorMsg + `, need to fix: ${badAliases.join(",")}`,
-      "error"
+      "error",
     );
   }
 

--- a/web/types.ts
+++ b/web/types.ts
@@ -2,7 +2,6 @@ import { Manifest } from "../common/manifest.ts";
 import { PageMeta } from "$sb/types.ts";
 import { AppCommand } from "./hooks/command.ts";
 import { defaultSettings } from "../common/util.ts";
-import { EmojiConfig } from "../plugs/emoji/emoji.ts";
 
 // Used by FilterBox
 export type FilterOption = {
@@ -33,6 +32,10 @@ export type ActionButton = {
   description?: string;
   command: string;
   args?: any[];
+};
+
+export type EmojiConfig = {
+  aliases: string[][];
 };
 
 export type BuiltinSettings = {

--- a/web/types.ts
+++ b/web/types.ts
@@ -2,6 +2,7 @@ import { Manifest } from "../common/manifest.ts";
 import { PageMeta } from "$sb/types.ts";
 import { AppCommand } from "./hooks/command.ts";
 import { defaultSettings } from "../common/util.ts";
+import { EmojiConfig } from "../plugs/emoji/emoji.ts";
 
 // Used by FilterBox
 export type FilterOption = {
@@ -43,6 +44,7 @@ export type BuiltinSettings = {
   actionButtons: ActionButton[];
   // Format: compatible with docker ignore
   spaceIgnore?: string;
+  emoji?: EmojiConfig;
 };
 
 export type PanelConfig = {

--- a/website/Plugs/Emoji.md
+++ b/website/Plugs/Emoji.md
@@ -2,3 +2,5 @@
 tags: plug
 ---
 The Emoji plug provides support for auto-completion of the `:emoji:` style syntax. It currently has support for the [15.1 emoji unicode standard](https://emojipedia.org/emoji-15.1). 🎉
+
+You can add your own aliases for emojis in [[SETTINGS]].

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -11,7 +11,7 @@ customStyles: "[[STYLES]]"
 hideSyncButton: false
 
 # Configure the shown action buttons (top right bar)
-actionButtons: 
+actionButtons:
 - icon: home # Use any icon from https://feathericons.com
   command: "{[Navigate: Home]}"
   description: "Go to the index page"
@@ -33,7 +33,7 @@ shortcuts:
 - command: "{[Stats: Show]}" # Using the command link syntax here
   mac: "Cmd-s" # Mac-specific keyboard shortcut
   key: "Ctrl-s" # Windows/Linux specific keyboard shortcut
-- command: "Navigate: Center Cursor" # But a command name is also supported 
+- command: "Navigate: Center Cursor" # But a command name is also supported
   key: "Alt-x"
 - command: "{[Upload: File]}"
   priority: 1 # Make sure this appears at the top of the list in the command palette
@@ -46,4 +46,9 @@ spaceIgnore: |
    largefolder
    *.mp4
 
+# Add alternative names to emoji picker
+emoji:
+  aliases:
+    smile: 😀
+    sweat_smile: 😅
 ```


### PR DESCRIPTION
Allows users to define emoji aliases in SETTINGS which are then used in hints after `:`. Some details we might want to discuss:

The settings are `emoji: aliases:`, instead of `emojiAliases:`, it feels a bit weird to require double indent, but it's putting everything under the plug's name (as hinted here https://github.com/silverbulletmd/silverbullet/issues/226#issuecomment-1362014066). And getting an existing emoji list would have its own key for URL 🤔 

If I understood correctly, the complete handler would be run on each keystroke, so the config is updated in the background, with an interval [like federation config](https://github.com/silverbulletmd/silverbullet/blob/04abc283b065fd5666bbe33b67206ef816303bfc/plugs/federation/config.ts#L12-L14)