### PR TITLE
GH-683: Fix template dark mode

### DIFF
--- a/web/styles/theme.scss
+++ b/web/styles/theme.scss
@@ -224,4 +224,9 @@ html[data-theme="dark"] {
   --editor-frontmatter-marker-color: #fff;
   --editor-widget-background-color: rgba(72, 72, 72, 0.5);
   --editor-task-marker-color: var(--subtle-color);
+  --editor-task-state-color: var(--subtle-color);
+
+  --editor-directive-mark-color: #ba0303;
+  --editor-directive-color: #898989;
+  --editor-directive-background-color: #4c4c4c7d;
 }


### PR DESCRIPTION
#### Summary
Change directive color in dark mode

#### Ticket Link
Fixes https://github.com/silverbulletmd/silverbullet/issues/683

Screenshots:

|  before  |  after  |
|----|----|
|<img width="865" alt="Screenshot 2024-02-12 at 8 42 48 PM" src="https://github.com/silverbulletmd/silverbullet/assets/16203333/5b384ead-a6c3-4a25-8a74-149991fd3234"> | <img width="955" alt="Screenshot 2024-02-12 at 8 42 27 PM" src="https://github.com/silverbulletmd/silverbullet/assets/16203333/eb410b76-be4f-4bbd-9d0d-3957b9704276"> |