### PR TITLE
Add note about https requirements

### DIFF
--- a/website/Client Modes.md
+++ b/website/Client Modes.md
@@ -23,7 +23,7 @@ Disadvantages:
 
 # Synced mode
 $sync
-In this mode, all content is synchronized to the client, and all processing happens there. The server effectively acts as a “dumb data store.” All SilverBullet functionality is available even when there is no network connection available.
+In this mode, all content is synchronized to the client, and all processing happens there. The server effectively acts as a “dumb data store.” All SilverBullet functionality is available even when there is no network connection available. This requires SilverBullet to be served with HTTPS, otherwise the service worker responsible for sync won't launch.
 
 Advantages:
 * **100% offline capable**: disconnect your client from the network, shutdown the server, and everything still works. Changes synchronize automatically once a network connection is re-established.

--- a/website/Install/Docker.md
+++ b/website/Install/Docker.md
@@ -35,6 +35,8 @@ $ docker run -d --restart unless-stopped --name silverbullet -p 3000:3000 -v ./s
 
 There you go!
 
+Note that to get offline mode to work you need to serve SilverBullet with HTTPS, via for example a reverse proxy.
+
 # Versions
 The `zefhemel/silverbullet` image will give you the latest released version. This is equivalent to `zefhemel/silverbullet:latest`. If you prefer, you can also pin to a specific release, e.g. `zefhemel/silverbullet:0.6.0`. If you prefer to live on the bleeding edge, you can use the `zefhemel/silverbullet:edge` image, which is updated on every commit to the `main` brain. This is the YOLO option.
 


### PR DESCRIPTION
I just spent time trying out SilverBullet by just running the Docker container without any reverse proxy or anything in front of it. I couldn't understand why the offline mode didn't work. Finally I found the output in the dev console explaining that the web worker didn't launch because I didn't use https. To avoid other people wasting time, I added a note about this in the docs for Synced mode and the Docker.md page.