### PR TITLE
Automatically append Task completed date

### DIFF
--- a/common/markdown_parser/customtags.ts
+++ b/common/markdown_parser/customtags.ts
@@ -23,6 +23,7 @@ export const TaskTag = Tag.define();
 export const TaskMarkTag = Tag.define();
 export const TaskStateTag = Tag.define();
 export const TaskDeadlineTag = Tag.define();
+export const TaskCompletedTag = Tag.define();
 
 export const HashtagTag = Tag.define();
 export const NakedURLTag = Tag.define();

--- a/common/markdown_parser/parser.ts
+++ b/common/markdown_parser/parser.ts
@@ -519,6 +519,14 @@ const TaskDeadline = regexParser({
   tag: ct.TaskDeadlineTag,
 });
 
+const TaskCompletedDate = regexParser({
+  firstCharCode: 9989, // ✅
+  regex: /^✅\s*\d{4}\-\d{2}\-\d{2}/,
+  className: "sb-task-completed",
+  nodeType: "CompletedDate",
+  tag: ct.TaskCompletedTag,
+});
+
 const NamedAnchor = regexParser({
   firstCharCode: 36, // $
   regex: /^\$[a-zA-Z\.\-\/]+[\w\.\-\/]*/,
@@ -608,6 +616,7 @@ export const extendedMarkdownLanguage = markdown({
     NakedURL,
     Hashtag,
     TaskDeadline,
+    TaskCompletedDate,
     NamedAnchor,
     {
       props: [
@@ -640,6 +649,7 @@ export const extendedMarkdownLanguage = markdown({
           Hashtag: ct.HashtagTag,
           NakedURL: ct.NakedURLTag,
           DeadlineDate: ct.TaskDeadlineTag,
+          CompletedDate: ct.TaskCompletedTag,
           NamedAnchor: ct.NamedAnchorTag,
         }),
       ],

--- a/common/markdown_parser/parser.ts
+++ b/common/markdown_parser/parser.ts
@@ -16,8 +16,6 @@ import {
 import * as ct from "./customtags.ts";
 import { NakedURLTag } from "./customtags.ts";
 import { TaskList } from "./extended_task.ts";
-import { readSetting } from "$sb/lib/settings_page.ts";
-
 
 export const pageLinkRegex = /^\[\[([^\]\|]+)(\|([^\]]+))?\]\]/;
 
@@ -356,13 +354,6 @@ export const highlightingExpressionParser = expressionParser.configure({
 });
 
 export const attributeStartRegex = /^\[([\w\$]+)(::?\s*)/;
-// export const attributeMap = readSetting('attributeMap', {});
-// TODO: readSetting doesnt look like it works here
-const attributeMap = {
-  '📅': "deadline",
-  '✅': "completed",
-  '⌛': "scheduled"
-}
 
 export const Attribute: MarkdownConfig = {
   defineNodes: [
@@ -378,29 +369,7 @@ export const Attribute: MarkdownConfig = {
       parse(cx, next, pos) {
         let match: RegExpMatchArray | null;
         const textFromPos = cx.slice(pos, cx.end);
-        if (Object.keys(attributeMap).includes(String.fromCharCode(next))) {
-          const emoji = String.fromCharCode(next);
-          console.log("Detected emoji: ", next, emoji);
-          const attributeName = attributeMap[emoji as keyof typeof attributeMap];
-          if (attributeName) {
-            const attributeValue = textFromPos.split(' ')[1];
-            console.log("Detected emoji attribute: ", emoji, attributeName, attributeValue);
-            return cx.addElement(
-              cx.elt("Attribute", pos, pos + 2 + attributeName.length + attributeValue.length, [
-                cx.elt("AttributeMark", pos, pos + 1), // emoji
-                cx.elt("AttributeName", pos + 1, pos + 1 + attributeName.length),
-                cx.elt(
-                  "AttributeValue",
-                  pos + 1 + attributeName.length,
-                  pos + 1 + attributeName.length + attributeValue.length,
-                ),
-              ]),
-            );
-          } else {
-            console.error("Attribute name not found for emoji: ", emoji, next);
-            return -1;
-          }
-        } else if (
+        if (
           next != 91 /* '[' */ ||
           // and match the whole thing
           !(match = attributeStartRegex.exec(textFromPos))

--- a/common/markdown_parser/parser.ts
+++ b/common/markdown_parser/parser.ts
@@ -16,6 +16,8 @@ import {
 import * as ct from "./customtags.ts";
 import { NakedURLTag } from "./customtags.ts";
 import { TaskList } from "./extended_task.ts";
+import { readSetting } from "$sb/lib/settings_page.ts";
+
 
 export const pageLinkRegex = /^\[\[([^\]\|]+)(\|([^\]]+))?\]\]/;
 
@@ -354,6 +356,13 @@ export const highlightingExpressionParser = expressionParser.configure({
 });
 
 export const attributeStartRegex = /^\[([\w\$]+)(::?\s*)/;
+// export const attributeMap = readSetting('attributeMap', {});
+// TODO: readSetting doesnt look like it works here
+const attributeMap = {
+  '📅': "deadline",
+  '✅': "completed",
+  '⌛': "scheduled"
+}
 
 export const Attribute: MarkdownConfig = {
   defineNodes: [
@@ -369,7 +378,29 @@ export const Attribute: MarkdownConfig = {
       parse(cx, next, pos) {
         let match: RegExpMatchArray | null;
         const textFromPos = cx.slice(pos, cx.end);
-        if (
+        if (Object.keys(attributeMap).includes(String.fromCharCode(next))) {
+          const emoji = String.fromCharCode(next);
+          console.log("Detected emoji: ", next, emoji);
+          const attributeName = attributeMap[emoji as keyof typeof attributeMap];
+          if (attributeName) {
+            const attributeValue = textFromPos.split(' ')[1];
+            console.log("Detected emoji attribute: ", emoji, attributeName, attributeValue);
+            return cx.addElement(
+              cx.elt("Attribute", pos, pos + 2 + attributeName.length + attributeValue.length, [
+                cx.elt("AttributeMark", pos, pos + 1), // emoji
+                cx.elt("AttributeName", pos + 1, pos + 1 + attributeName.length),
+                cx.elt(
+                  "AttributeValue",
+                  pos + 1 + attributeName.length,
+                  pos + 1 + attributeName.length + attributeValue.length,
+                ),
+              ]),
+            );
+          } else {
+            console.error("Attribute name not found for emoji: ", emoji, next);
+            return -1;
+          }
+        } else if (
           next != 91 /* '[' */ ||
           // and match the whole thing
           !(match = attributeStartRegex.exec(textFromPos))

--- a/plugs/index/attributes.ts
+++ b/plugs/index/attributes.ts
@@ -4,6 +4,7 @@ import { queryObjects } from "./api.ts";
 import { ObjectValue, QueryExpression } from "../../type/types.ts";
 import { determineTags } from "$lib/cheap_yaml.ts";
 
+
 export type AttributeObject = ObjectValue<{
   name: string;
   attributeType: string;
@@ -61,6 +62,28 @@ export async function objectAttributeCompleter(
       readOnly: value.readOnly,
     } as AttributeCompletion;
   });
+}
+
+export function parseAttributesFromRegex(line: string): Record<string, any>[] {
+  const attributes: Record<string, any>[] = [];
+  console.log(`Parsing line for regex attributes: ${line}`);
+  Object.entries(regexToAttributeConfig).forEach(([pattern, config]) => {
+    const regex = new RegExp(pattern);
+    let match;
+    match = regex.exec(line);
+    if (match) {
+      console.log(`Match found for pattern: ${pattern}`, match);
+      if (match.length > 1) {
+        attributes.push({ [config.attributeName]: match[1], matchedString: match[0] });
+      }
+    } else {
+      console.log(`No match found for pattern: ${pattern} on line: ${line}`);
+    }
+  });
+  if (attributes.length === 0) {
+    console.log(`No regex attributes found for line: ${line}`);
+  }
+  return attributes;
 }
 
 /**

--- a/plugs/index/builtins.ts
+++ b/plugs/index/builtins.ts
@@ -28,6 +28,7 @@ export const builtins: Record<string, Record<string, string>> = {
     page: "!string",
     state: "!string",
     deadline: "string",
+    completed: "string",
     pos: "!number",
     tags: "string[]",
   },

--- a/plugs/markdown/markdown_render.ts
+++ b/plugs/markdown/markdown_render.ts
@@ -359,6 +359,15 @@ function render(
         body: renderToText(t),
       };
 
+    case "CompletedDate":
+      return {
+        name: "span",
+        attrs: {
+          class: "task-completed",
+        },
+        body: renderToText(t),
+      };
+
     // Tables
     case "Table":
       return {

--- a/plugs/tasks/task.ts
+++ b/plugs/tasks/task.ts
@@ -32,6 +32,7 @@ export type TaskObject = ObjectValue<
     done: boolean;
     state: string;
     deadline?: string;
+    completed?: string;
   } & Record<string, any>
 >;
 
@@ -43,6 +44,10 @@ export type TaskStateObject = ObjectValue<{
 
 function getDeadline(deadlineNode: ParseTree): string {
   return deadlineNode.children![0].text!.replace(/📅\s*/, "");
+}
+
+function getCompletedDate(completedDateNode: ParseTree): string {
+  return completedDateNode.children![0].text!.replace(/✅\s*/, "");
 }
 
 const completeStates = ["x", "X"];
@@ -83,6 +88,11 @@ export async function indexTasks({ name, tree }: IndexTreeEvent) {
       if (tree.type === "DeadlineDate") {
         task.deadline = getDeadline(tree);
         // Remove this node from the tree
+        return null;
+      }
+      if (tree.type === "CompletedDate") {
+        task.completed = getCompletedDate(tree);
+        console.log("completedDate: ", task.completed);
         return null;
       }
       if (tree.type === "Hashtag") {

--- a/web/style.ts
+++ b/web/style.ts
@@ -52,6 +52,7 @@ export default function highlightStyles() {
     { tag: ct.HashtagTag, class: "sb-hashtag" },
     { tag: ct.NakedURLTag, class: "sb-naked-url" },
     { tag: ct.TaskDeadlineTag, class: "sb-task-deadline" },
+    { tag: ct.TaskCompletedTag, class: "sb-task-completed" },
     { tag: ct.NamedAnchorTag, class: "sb-named-anchor" },
 
     { tag: ct.DirectiveMarkTag, class: "sb-directive-mark" },

--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -321,7 +321,8 @@
     font-size: 91%;
   }
 
-  .sb-task-deadline {
+  .sb-task-deadline,
+  .sb-task-completed {
     background-color: rgba(22, 22, 22, 0.07)
   }
 

--- a/website/Plugs/Tasks.md
+++ b/website/Plugs/Tasks.md
@@ -37,6 +37,14 @@ Tasks can specify deadlines:
 
 When the cursor is positioned inside of a due date, the {[Task: Postpone]} command can be used to postpone the task for a certain period.
 
+## Completion Dates
+
+Tasks can automatically have the date appended when the task is completed:
+
+- [x] This is already completed ✅ 2024-02-15
+
+This feature is disabled by default, go to [[SETTINGS]] and set `tasks.appendCompletedDate: true` to turn it on.
+
 ## Querying
 All meta data (`done` status, `state`, `tags`, `deadline` and custom attributes) is extracted and available via the `task` query source to [[Live Queries]]:
 

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -60,4 +60,9 @@ tasks:
   # If true, append the current date to a task when marking it as completed
   appendCompletedDate: true
 
+# Map certain emojis to named attributes, `📅 2024-02-15` effectively becomes `[deadline: 2024-02-15]`
+attributeMap:
+  📅: deadline
+  ✅: completed
+  ⌛: scheduled
 ```

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -55,4 +55,9 @@ emoji:
   aliases:
     smile: 😀
     sweat_smile: 😅
+
+tasks:
+  # If true, append the current date to a task when marking it as completed
+  appendCompletedDate: true
+
 ```

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -60,4 +60,8 @@ tasks:
   # If true, append the current date to a task when marking it as completed
   appendCompletedDate: true
 
+regexAttributes:
+  "\\s⌛\\s+(\\d{4}-\\d{2}-\\d{2})": "scheduled"
+  "\\s📆\\s+(\\d{4}-\\d{2}-\\d{2})": "deadline"
+  "\\s❗\\s+(\\d)": "priority"
 ```

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -60,9 +60,4 @@ tasks:
   # If true, append the current date to a task when marking it as completed
   appendCompletedDate: true
 
-# Map certain emojis to named attributes, `📅 2024-02-15` effectively becomes `[deadline: 2024-02-15]`
-attributeMap:
-  📅: deadline
-  ✅: completed
-  ⌛: scheduled
 ```


### PR DESCRIPTION
This adds an option (off by default) that appends todays date to a task when it is marked as completed, and looks like this: 
<img width="603" alt="image" src="https://github.com/silverbulletmd/silverbullet/assets/215985/eea786df-64be-4a50-a758-3b5b0ff65e99">

It also shows up in queries so you should be able to filter on it, like `task where page = @page.name and completed < "2024-02-16"`

I mentioned this on discord a little, but I briefly considered creating a new plug for this.  However, I also wanted the ability to extract the completed date from a task in queries.  I couldn't figure out how to parse that and add the 'completed' key with a separate plug since some of the related code isn't part of the tasks plug.

