### PR TITLE
Add custom data field to template plug

### DIFF
--- a/plugs/template/page.ts
+++ b/plugs/template/page.ts
@@ -90,6 +90,7 @@ async function instantiatePageTemplate(
   templateName: string,
   intoCurrentPage: string | undefined,
   askName: boolean,
+  customData: any = undefined,
 ) {
   const templateText = await space.readPage(templateName!);
 
@@ -107,6 +108,7 @@ async function instantiatePageTemplate(
     created: "",
     lastModified: "",
     perm: "rw",
+    data: customData,
   };
   // Just used to extract the frontmatter
   const { frontmatter } = await renderTemplate(


### PR DESCRIPTION
This PR adds the possibility to optionally use additional custom data to instantiate templates. 

The additional parameter can be used to inject additional data, so plugs or space-scripts can render data that was collected from external datasources.

