### PR TITLE
Allow passing additional arguments to `renamePageCommand` and `renamePrefixCommand`

### DIFF
--- a/plugs/index/refactor.ts
+++ b/plugs/index/refactor.ts
@@ -183,7 +183,7 @@ export async function renamePrefixCommand(cmdDef: any) {
   );
 
   if (
-    !(cmdDef.disableConfirmation ?? await editor.confirm(
+    cmdDef.disableConfirmation !== true && !(await editor.confirm(
       `This will affect ${allAffectedPages.length} pages. Are you sure?`,
     ))
   ) {


### PR DESCRIPTION
Adds the ability to send additional arguments to `renamePageCommand` and `renamePrefixCommand` of the `index` plug, as well as returning `true` or `false` from each command to indicate whether the action was successful.

The arguments are completely optional, and the existing behavior remains the default when the additional arguments aren't provided, so everything remains fully backward-compatible. 

## Why

I've created a [tree view component/plug](https://github.com/joekrill/silverbullet-treeview) and one of the desired features is to [allow dragging and dropping nodes to rename pages](https://github.com/silverbulletmd/silverbullet/issues/102#issuecomment-1696908355). That renaming functionality already exists via these two methods, but we need to be able to pass in some values that are currently hard-coded in those functions. We also need to know whether the operation succeeded or failed to determine if the tree should be updated, and - in some cases - whether the user should be redirected to the renamed page.

## `renamePageCommand` 

This command already allowed a `page` argument to be provided that specified the name to rename to. If this wasn't provided the user is prompted for a new name. The following additional arguments can now be passed:

- `oldPage` - This is the page to be renamed _from_. Previous behavior always used the current page (`editor.getCurrentPage()`), and this is still the case if `oldPage` is not provided. But in the case of the tree view, the user may be dragging  page other than the current one.
- `navigateThere` - Specifies whether, after the rename, the user should be navigated to the new page. Previously this was always `true`, because it was always the current page being renamed, so it made sense to navigate to the updated page. This still defaults to `true`, but can be override to prevent that behavior. If the user drags a node from the tree view that isn't the current page, we don't want to redirect them to that page. 

## `renamePrefixCommand`

This command is written in a way that always prompts the user for the prefixes to rename from and to, as well as showing a confirmation dialog before performing the rename. It did not have the ability to be given any arguments at all. This update allows the following arguments to be provided programmatically:

- `oldPrefix` - The prefix to rename from
- `newPrefix` - The prefix to rename to. 
- `disableConfirmation` - When true, disables showing the confirmation prompt before renaming. 
