### PR TITLE
Adds a `system.getVersion` syscall that returns the current system version

### DIFF
--- a/common/syscalls/system.ts
+++ b/common/syscalls/system.ts
@@ -4,6 +4,7 @@ import type { Client } from "../../web/client.ts";
 import { CommandDef } from "../hooks/command.ts";
 import { proxySyscall } from "../../web/syscalls/util.ts";
 import type { CommonSystem } from "../common_system.ts";
+import { version } from "../../version.ts";
 
 export function systemSyscalls(
   system: System<any>,
@@ -97,6 +98,9 @@ export function systemSyscalls(
     },
     "system.getMode": () => {
       return readOnlyMode ? "ro" : "rw";
+    },
+    "system.getVersion": () => {
+      return version;
     },
   };
   return api;

--- a/plug-api/syscalls/system.ts
+++ b/plug-api/syscalls/system.ts
@@ -35,3 +35,7 @@ export function getEnv(): Promise<string | undefined> {
 export function getMode(): Promise<"ro" | "rw"> {
   return syscall("system.getMode");
 }
+
+export function getVersion(): Promise<string> {
+  return syscall("system.getVersion");
+}


### PR DESCRIPTION
Adds a `syscall` -- `system.getVersion` -- for obtaining the current system version. Useful if plug functionality requires a minimum version to work. 