### PR TITLE
Store extracted customStyles in uiOptions

### DIFF
--- a/type/web.ts
+++ b/type/web.ts
@@ -81,6 +81,7 @@ export type AppViewState = {
     vimMode: boolean;
     darkMode: boolean;
     forcedROMode: boolean;
+    customStyles?: string;
   };
 
   // Page navigator mode

--- a/web/client.ts
+++ b/web/client.ts
@@ -1087,9 +1087,13 @@ export class Client {
           console.error("Failed to load custom styles", e);
         }
       }
-      document.getElementById("custom-styles")!.innerHTML = accumulatedCSS.join(
-        "\n\n",
-      );
+      const customStylesContent = accumulatedCSS.join("\n\n");
+      this.ui.viewDispatch({
+        type: "set-ui-option",
+        key: "customStyles",
+        value: customStylesContent,
+      });
+      document.getElementById("custom-styles")!.innerHTML = customStylesContent;
     }
   }
 


### PR DESCRIPTION
Stores the results of loading/parsing `settings.customStyles` in`uiOptions`.

### Motivation

For the [treeview plug](https://github.com/joekrill/silverbullet-treeview) I'd like to match the main application styles as closely as possible to be consistent. For the best results, we really need to:

1. Use the CSS variables and styles defined by the current theme. 
2. Know the current theme (dark mode).
3. Apply any user-defined custom styles.

The first two are fairly simple to handle in a plug (see [here](https://github.com/joekrill/silverbullet-treeview/blob/327d663ed52eb6aceb89dbf472d55c21b1f1ac46/treeview.ts#L104) and [here](https://github.com/joekrill/silverbullet-treeview/blob/327d663ed52eb6aceb89dbf472d55c21b1f1ac46/treeview.ts#L128)). In order to get the custom styles, though, I would have to duplicate the logic of the [`loadCustomStyles` function](https://github.com/silverbulletmd/silverbullet/blob/dfbec4f7859b468bd100180f0c997da19b0ca10b/web/client.ts#L1068). While _relatively_ straight-forward, it seemed like this might be less error prone, more maintainable, more performant, and allow other plugs can take advantage of the functionality without having to re-implement it. Now a plug can just call `await editor.getUiOption("customStyles")` to get the custom styles. 

Thoughts? Does this seem like a useful and reasonable change? And is `uiOptions` the right place for this?

We could also consider making this functionality the default for all panels created using `showPanel`. I had originally planned on [putting up a PR for that](https://github.com/joekrill/silverbullet/tree/inject-styles-in-panel-iframes), before realizing that it was pretty straight-forward to leave it up to the plug. That also has a lot more implications and would affect any existing plugs (though it _did_ give the Markdown Preview dark mode support!). I guess the real question is: should it be a simple opt-in, simple opt-out, or up to the plug to handle the details?