### PR TITLE
Include `context` when opening the command palette via syscall

### DIFF
--- a/web/syscalls/editor.ts
+++ b/web/syscalls/editor.ts
@@ -265,6 +265,7 @@ export function editorSyscalls(client: Client): SysCallMapping {
     "editor.openCommandPalette": () => {
       client.ui.viewDispatch({
         type: "show-palette",
+        context: client.getContext(),
       });
     },
     // Folding


### PR DESCRIPTION
It looks like dispatching the `show-palette` action via a syscall doesn't include the current context. This means context-specific commands (like "Task: Postpone" and "Link: Unfurl") are not available even in the correct context.

Incidentally, the context _is_ correctly passed when [opening the command palette using three-finger tap](https://github.com/silverbulletmd/silverbullet/blob/cf010b5ef29a1dfde166241ae6e6c6dac21d89bf/web/editor_ui.tsx#L60).

Fixes #684 