### PR TITLE
Add `fetch` to editor plug's `requiredPermissions`

### DIFF
--- a/plugs/editor/editor.plug.yaml
+++ b/plugs/editor/editor.plug.yaml
@@ -1,4 +1,6 @@
 name: editor
+requiredPermissions:
+  - fetch
 functions:
   setEditorMode:
     path: "./editor.ts:setEditorMode"


### PR DESCRIPTION
The "Link: Unfurl" command always fails because it uses fetch to get the title of the patch, but the plug does not have `fetch` permission.