### PR TITLE
Correctly skip adding default shortcuts for overriden commands

### DIFF
--- a/web/editor_state.ts
+++ b/web/editor_state.ts
@@ -302,7 +302,7 @@ export function createCommandKeyBindings(client: Client): KeyBinding[] {
   for (const def of client.clientSystem.commandHook.editorCommands.values()) {
     if (def.command.key) {
       // If we've already overridden this command, skip it
-      if (overriddenCommands.has(def.command.key)) {
+      if (overriddenCommands.has(def.command.name)) {
         continue;
       }
       commandKeyBindings.push({


### PR DESCRIPTION
A small bug was causing existing shortcuts to continue to work even when adding overrides to `SETTINGS` (the overrides worked as well).

Fixes #688

(Note this does _not_ fix #689 - looks like that's caused by something different)

@zefhemel I hope you don't mind me putting up these PRs! I thought I could help fix some of these small bugs.