### PR TITLE
Pre-fill new page name with heading

### DIFF
--- a/plugs/index/refactor.ts
+++ b/plugs/index/refactor.ts
@@ -230,7 +230,19 @@ export async function renamePrefixCommand(cmdDef: any) {
 }
 
 export async function extractToPageCommand() {
-  const newName = await editor.prompt(`New page title:`, "new page");
+  const selection = await editor.getSelection();
+  let text = await editor.getText();
+  text = text.slice(selection.from, selection.to);
+
+  const match = text.match("#{1,6}\\s+([^\n]*)");
+
+  let newName;
+  if (match) {
+    newName = match[1];
+  } else {
+    newName = "new page";
+  }
+  newName = await editor.prompt(`New page title:`, newName);
   if (!newName) {
     return;
   }
@@ -252,9 +264,6 @@ export async function extractToPageCommand() {
       throw e;
     }
   }
-  let text = await editor.getText();
-  const selection = await editor.getSelection();
-  text = text.slice(selection.from, selection.to);
   await editor.replaceRange(selection.from, selection.to, `[[${newName}]]`);
   console.log("Writing new page to space");
   await space.writePage(newName, text);


### PR DESCRIPTION
Hi! 

Just started using silverbullet and find it to be fantastic. 

One small thing I've noticed: I often start with one page where I write stuff, using headings. When this page gets too long, I extract part of it, usually starting with a heading. And in most cases I want to name the page the exact same thing as the heading. So with this change, when extracting a page, it will check if the first line is a markdown heading. If it is, it will be used as a default name in the prompt asking for a page name.

This uses a regular expression to check for a heading. It seemed a bit overkill to do a full markdown parsing for this specific check.

JavaScript is far from my primary programming language, so please let me know if I'm doing something bad and I'll be happy to fix it!