### PR TITLE
Exclude copy code button from more code widgets

### DIFF
--- a/web/cm_plugins/code_copy.ts
+++ b/web/cm_plugins/code_copy.ts
@@ -13,7 +13,7 @@ import {
 const ICON_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-copy"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
 
-const EXCLUDE_LANGUAGES = ["template", "query", "embed"];
+const EXCLUDE_LANGUAGES = ["template", "include", "query", "toc", "embed"];
 
 class CodeCopyWidget extends WidgetType {
   constructor(readonly value: string, readonly client: Client) {


### PR DESCRIPTION
This is a minor improvement to #735

I believe this to be a complete list now, because I looked at all markdown widgets with buttons in #719