### PR TITLE
Relax hashtag pattern matching (Support Emoji)

### DIFF
--- a/common/markdown_parser/parser.ts
+++ b/common/markdown_parser/parser.ts
@@ -19,6 +19,8 @@ import { TaskList } from "./extended_task.ts";
 
 export const pageLinkRegex = /^\[\[([^\]\|]+)(\|([^\]]+))?\]\]/;
 
+export const tagRegex = /#[^\d\s!@#$%^&*(),.?":{}|<>\\][^\s!@#$%^&*(),.?":{}|<>\\]*/;
+
 const WikiLink: MarkdownConfig = {
   defineNodes: [
     { name: "WikiLink", style: ct.WikiLinkTag },
@@ -504,7 +506,7 @@ const NakedURL = regexParser(
 const Hashtag = regexParser(
   {
     firstCharCode: 35, // #
-    regex: /^#[^#\d\s\[\]]+\w+/,
+    regex: new RegExp(`^${tagRegex.source}`),
     nodeType: "Hashtag",
     className: "sb-hashtag",
     tag: ct.HashtagTag,

--- a/web/components/page_navigator.tsx
+++ b/web/components/page_navigator.tsx
@@ -3,8 +3,9 @@ import { FilterOption } from "../../type/web.ts";
 import { CompletionContext, CompletionResult } from "../deps.ts";
 import { PageMeta } from "../../type/types.ts";
 import { isFederationPath } from "$sb/lib/resolve.ts";
+import { tagRegex as mdTagRegex } from "$common/markdown_parser/parser.ts";
 
-export const tagRegex = /#[^#\d\s\[\]]+\w+/g;
+const tagRegex = new RegExp(mdTagRegex.source, "g")
 
 export function PageNavigator({
   allPages,


### PR DESCRIPTION
Adjust the RegExp for matching tags in order to better support compatibility  with other PKM systems. Though not the exact matcher used in Obsidian (since  its source is closed), this matcher is modeled mostly after it and allows most  non-whitespace characters, including Emoji.

I use a task line like `- [ ] Gift Idea #🎁 #Person-Name` to denote gift ideas for friends and family. This patch allows SilverBullet to recognize the emoji.