### PR TITLE
Add type guards in query functions

### DIFF
--- a/common/query_functions.test.ts
+++ b/common/query_functions.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, it } from "$std/testing/bdd.ts";
+import { buildQueryFunctions } from "$common/query_functions.ts";
+import type { System } from "$lib/plugos/system.ts";
+import { assertEquals, assertRejects, assertThrows } from "$lib/test_deps.ts";
+
+let functions: ReturnType<typeof buildQueryFunctions>;
+
+beforeEach(() => {
+  functions = buildQueryFunctions(
+    new Set(["page1"]),
+    {} as System<unknown>,
+  );
+});
+
+describe("pageExists", () => {
+  const invalidValues = [/hello/, 1, null, undefined, true, {}];
+  for (const value of invalidValues) {
+    it(`should throw if name is ${value}`, () => {
+      assertThrows(
+        () => functions.pageExists(value),
+        Error,
+        "pageExists(): name is not a string",
+      );
+    });
+  }
+
+  it("should return true if name starts with ! or {{", () => {
+    assertEquals(functions.pageExists("!invalid name"), true);
+    assertEquals(functions.pageExists("{{invalid name"), true);
+  });
+
+  it("should return true if page exists", () => {
+    assertEquals(functions.pageExists("page1"), true);
+  });
+
+  it("should return false if page doesn't exist", () => {
+    assertEquals(functions.pageExists("page2"), false);
+  });
+});
+
+describe("template", () => {
+  const invalidValues = [/hello/, 1, null, undefined, true, {}];
+  for (const value of invalidValues) {
+    it(`should throw if template is ${value}`, async () => {
+      await assertRejects(
+        () => functions.template(value),
+        Error,
+        "template(): template is not a string",
+      );
+    });
+  }
+});

--- a/common/query_functions.ts
+++ b/common/query_functions.ts
@@ -15,13 +15,21 @@ export function buildQueryFunctions(
   return {
     ...builtinFunctions,
     pageExists(name: string) {
+      if (typeof name !== "string") {
+        throw new Error("pageExists(): name is not a string");
+      }
+
       if (name.startsWith("!") || name.startsWith("{{")) {
         // Let's assume federated pages exist, and ignore template variable ones
         return true;
       }
       return allKnownPages.has(name);
     },
-    async template(template: string, obj: any) {
+    async template(template: unknown, obj: unknown) {
+      if (typeof template !== "string") {
+        throw new Error("template(): template is not a string");
+      }
+
       return (await system.invokeFunction("template.renderTemplate", [
         template,
         obj,

--- a/lib/builtin_query_functions.test.ts
+++ b/lib/builtin_query_functions.test.ts
@@ -1,0 +1,136 @@
+import { describe, it } from "$std/testing/bdd.ts";
+import { builtinFunctions } from "./builtin_query_functions.ts";
+import { assertEquals, assertThrows } from "$lib/test_deps.ts";
+
+describe("replace()", () => {
+  const { replace } = builtinFunctions;
+
+  describe("Exceptions", () => {
+    const invalidValues = [/hello/, 1, null, undefined, true, {}];
+
+    for (const value of invalidValues) {
+      it(`should throw if str is ${value}`, () => {
+        assertThrows(
+          () => replace(value),
+          Error,
+          "replace(): str is not a string",
+        );
+      });
+    }
+
+    for (const value of invalidValues.slice(1)) {
+      it(`should throw if matcher is ${value}`, () => {
+        assertThrows(
+          () => replace("input", value, "replaced"),
+          Error,
+          "replace(): match is not a string or regexp",
+        );
+      });
+    }
+
+    for (const value of invalidValues) {
+      it(`should throw if replace is ${value}`, () => {
+        assertThrows(
+          () => replace("input", /in/, value),
+          Error,
+          "replace(): replace is not a string",
+        );
+      });
+    }
+
+    it("should throw if replacementPairs is odd", () => {
+      assertThrows(
+        () => replace("input", /hello/),
+        Error,
+        "replace(): requires an even number of replacement arguments",
+      );
+    });
+  });
+
+  it("should work with regexp match", () => {
+    const output = replace("input", ["in"], "out");
+    assertEquals(output, "output");
+  });
+
+  it("should work with case-insensitive regexp match", () => {
+    const output1 = replace("Input", ["in"], "out");
+    assertEquals(output1, "Input");
+
+    const output2 = replace("Input", ["in", "i"], "out");
+    assertEquals(output2, "output");
+  });
+
+  it("should work with string match", () => {
+    const output = replace("input", "in", "out");
+    assertEquals(output, "output");
+  });
+
+  it("should not work with case-insensitive string match", () => {
+    const output = replace("Input", "in", "out");
+    assertEquals(output, "Input");
+  });
+
+  it("should work with multiple match and replace", () => {
+    const output = replace("input", "in", "Hello ", ["put"], "WoRlD", [
+      "world",
+      "i",
+    ], "World");
+    assertEquals(output, "Hello World");
+  });
+});
+
+describe("niceDate", () => {
+  const { niceDate } = builtinFunctions;
+
+  const invalidValues = [
+    /hello/,
+    null,
+    undefined,
+    true,
+    {},
+    "invalid",
+  ];
+  for (const value of invalidValues) {
+    it(`should throw if ts is ${value}`, () => {
+      assertThrows(
+        () => niceDate(value),
+        Error,
+        "niceDate(): ts is not a valid date",
+      );
+    });
+
+    const validValues = [
+      1704067200000,
+      "2024-01-01",
+      "01/01/2024",
+      new Date("2024-01-01"),
+    ];
+    for (const value of validValues) {
+      it(`should display a nice date given ${value}`, () => {
+        assertEquals(niceDate(value), "2024-01-01");
+      });
+    }
+  }
+});
+
+describe("escapeRegexp", () => {
+  const { escapeRegexp } = builtinFunctions;
+
+  const invalidValues = [/hello/, 1, null, undefined, true, {}];
+  for (const value of invalidValues) {
+    it(`should throw if ts is ${value}`, () => {
+      assertThrows(
+        () => escapeRegexp(value),
+        Error,
+        "escapeRegexp(): ts is not a string",
+      );
+    });
+  }
+
+  it("should escape regexp characters", () => {
+    assertEquals(
+      escapeRegexp("[-\/\\^$*+?.(Hello)|[\]{}]"),
+      "\\[\\-\\/\\\\\\^\\$\\*\\+\\?\\.\\(Hello\\)\\|\\[\\]\\{\\}\\]",
+    );
+  });
+});

--- a/lib/test_deps.ts
+++ b/lib/test_deps.ts
@@ -4,6 +4,7 @@ export {
   AssertionError,
   assertMatch,
   assertNotEquals,
+  assertRejects,
   assertThrows,
   equal,
   fail,


### PR DESCRIPTION
As the user can type whatever they want as arguments, this PR changes the query functions' parameters' types to `unknown`  and adds type guards to provide better exception handling.

Here's an example, using the following snippet
````
```template
{{replace(45, "4", "5")}}
```
````

**Without type guards**
![uh](https://github.com/silverbulletmd/silverbullet/assets/26678512/9b657c7e-6d7a-47d4-a02a-a336c93dc4cb)

**With type guards**
![nice](https://github.com/silverbulletmd/silverbullet/assets/26678512/f928b6b3-150a-44b6-aeeb-e95734a3e5b9)