### PR TITLE
Check if symlink is a file or directory

### DIFF
--- a/common/spaces/disk_space_primitives.ts
+++ b/common/spaces/disk_space_primitives.ts
@@ -163,11 +163,22 @@ async function* walkPreserveSymlinks(
       // Skip hidden files and folders
       continue;
     }
-    if (dirEntry.isFile) {
+
+    let entry: Deno.DirEntry | Deno.FileInfo = dirEntry;
+
+    if (dirEntry.isSymlink) {
+      try {
+        entry = await Deno.stat(fullPath);
+      } catch (e) {
+        console.error("Error reading symlink", fullPath, e.message);
+      }
+    }
+
+    if (entry.isFile) {
       yield { path: fullPath, entry: dirEntry };
     }
 
-    if (dirEntry.isDirectory || dirEntry.isSymlink) {
+    if (entry.isDirectory) {
       // If it's a directory or a symlink, recurse into it
       yield* walkPreserveSymlinks(fullPath);
     }


### PR DESCRIPTION
If you have a symlink to a file (not a directory), an error is thrown:

```
Error: Not a directory (os error 20): readdir '/path/to/the/symlinked/file'
    at async Object.[Symbol.asyncIterator] (ext:deno_fs/30_fs.js:220:19)
    at async walkPreserveSymlinks (file:///Users/joe/projects/silverbullet/common/spaces/disk_space_primitives.ts:160:20)
    at async walkPreserveSymlinks (file:///Users/joe/projects/silverbullet/common/spaces/disk_space_primitives.ts:172:7)
    at async walkPreserveSymlinks (file:///Users/joe/projects/silverbullet/common/spaces/disk_space_primitives.ts:172:7)
    at async DiskSpacePrimitives.fetchFileList (file:///Users/joe/projects/silverbullet/common/spaces/disk_space_primitives.ts:128:22)
    at async AssetBundlePlugSpacePrimitives.fetchFileList (file:///Users/joe/projects/silverbullet/common/spaces/asset_bundle_space_primitives.ts:13:19)
    at async FilteredSpacePrimitives.fetchFileList (file:///Users/joe/projects/silverbullet/common/spaces/filtered_space_primitives.ts:16:13)
    at async PlugSpacePrimitives.fetchFileList (file:///Users/joe/projects/silverbullet/common/spaces/plug_space_primitives.ts:72:19)
    at async EventedSpacePrimitives.fetchFileList (file:///Users/joe/projects/silverbullet/common/spaces/evented_space_primitives.ts:32:25)
    at async ServerSystem.loadPlugs (file:///Users/joe/projects/silverbullet/server/server_system.ts:196:28) {
  code: "ENOTDIR"
}
``` 

Looks like [this recent fix](https://github.com/silverbulletmd/silverbullet/commit/a8d042f9b27184f7894f7aab38df9ad058492059) introduced this bug. This should fix it, I believe. It will also ignore invalid symlinks.