### PR TITLE
Expose instantiate template function

### DIFF
--- a/plugs/template/page.ts
+++ b/plugs/template/page.ts
@@ -86,12 +86,12 @@ function selectPageTemplate(options: TemplateObject[]) {
   );
 }
 
-async function instantiatePageTemplate(
+export async function instantiatePageTemplate(
   templateName: string,
   intoCurrentPage: string | undefined,
   askName: boolean,
   customData: any = undefined,
-) {
+): Promise<string | void> {
   const templateText = await space.readPage(templateName!);
 
   console.log(
@@ -158,7 +158,7 @@ async function instantiatePageTemplate(
       if (newPageConfig.openIfExists) {
         console.log("Page already exists, navigating there");
         await editor.navigate({ page: pageName, pos: 0 });
-        return;
+        return pageName;
       }
 
       // let's warn
@@ -200,6 +200,7 @@ async function instantiatePageTemplate(
       pos: carretPos !== -1 ? carretPos : undefined,
     });
   }
+  return pageName;
 }
 
 export async function loadPageObject(pageName?: string): Promise<PageMeta> {

--- a/plugs/template/template.plug.yaml
+++ b/plugs/template/template.plug.yaml
@@ -8,18 +8,21 @@ functions:
   cleanTemplate:
     path: api.ts:cleanTemplate
 
+  instantiatePageTemplate:
+    path: page.ts:instantiatePageTemplate
+
   # Indexing
   indexTemplate:
     path: index.ts:indexTemplate
     events:
-    # Special event only triggered for template pages
-    - page:indexTemplate
+      # Special event only triggered for template pages
+      - page:indexTemplate
 
   # Completion
   templateSlashCommand:
     path: snippet.ts:snippetSlashComplete
     events:
-    - slash:complete
+      - slash:complete
 
   insertSnippetTemplate:
     path: snippet.ts:insertSnippetTemplate
@@ -57,14 +60,13 @@ functions:
       key: "Alt-Shift-t"
       requireMode: rw
 
-
   # Lint
   lintTemplateFrontmatter:
     path: lint.ts:lintTemplateFrontmatter
     events:
-    - editor:lint
+      - editor:lint
 
   lintTemplateBlocks:
     path: lint.ts:lintTemplateBlocks
     events:
-    - editor:lint
+      - editor:lint


### PR DESCRIPTION
This will expose the `instantiatePageTemplate` function, so it can be used via a syscall to generate pages from space scripts . It is a small extension of #716 to make the function also available in space script.