### PR TITLE
Clean replacement

### DIFF
--- a/web/active_lines.ts
+++ b/web/active_lines.ts
@@ -1,0 +1,60 @@
+import { 
+    Facet,
+    EditorView,
+    Extension,
+    Decoration,
+    RangeSetBuilder,
+    ViewPlugin,
+    DecorationSet,
+    ViewUpdate } from "./deps.ts";
+  
+    const baseTheme = EditorView.baseTheme({
+      "&light .cm-zebraStripe": {backgroundColor: "#d4fafa"},
+      "&dark .cm-zebraStripe": {backgroundColor: "#1a2727"}
+    })
+  
+    const stepSize = Facet.define<number, number>({
+      combine: values => values.length ? Math.min(...values) : 1
+    })
+    
+    export function activeLines(options: {step?: number} = {}): Extension {
+      return [
+        baseTheme,
+        options.step == null ? [] : stepSize.of(options.step),
+        addClass
+      ]
+    }
+  
+    const activeLine = Decoration.line({
+      attributes: {class: "sb-activeLine"}
+    })
+    
+    function activeLineDeco(view: EditorView) {
+      let step = view.state.facet(stepSize)
+      let builder = new RangeSetBuilder<Decoration>()
+
+      for (let {from, to} of view.state.selection.ranges) {
+        for (let pos = from; pos <= to;) {
+          let line = view.state.doc.lineAt(pos)
+          if ((line.number % step) == 0)
+            builder.add(line.from, line.from, activeLine)
+          pos = line.to + 1
+        }
+      }
+      return builder.finish()
+    }
+  
+    const addClass = ViewPlugin.fromClass(class {
+      decorations: DecorationSet
+    
+      constructor(view: EditorView) {
+        this.decorations = activeLineDeco(view)
+      }
+    
+      update(update: ViewUpdate) {
+        if (update.docChanged || update.selectionSet)
+          this.decorations = activeLineDeco(update.view)
+      }
+    }, {
+      decorations: v => v.decorations
+    })

--- a/web/cm_plugins/clean.ts
+++ b/web/cm_plugins/clean.ts
@@ -16,14 +16,14 @@ import { frontmatterPlugin } from "./frontmatter.ts";
 
 export function cleanModePlugins(client: Client) {
   return [
-    linkPlugin(client),
-    blockquotePlugin(),
-    admonitionPlugin(client),
-    hideMarksPlugin(),
-    hideHeaderMarkPlugin(),
-    cleanBlockPlugin(),
-    frontmatterPlugin(),
-    fencedCodePlugin(client),
+    //linkPlugin(client),
+    //blockquotePlugin(),
+    //admonitionPlugin(client),
+    //hideMarksPlugin(),
+    //hideHeaderMarkPlugin(),
+    //cleanBlockPlugin(),
+    //frontmatterPlugin(),
+    //fencedCodePlugin(client),
     taskListPlugin({
       // TODO: Move this logic elsewhere?
       onCheckboxClick: (pos) => {
@@ -40,7 +40,7 @@ export function cleanModePlugins(client: Client) {
     }),
     listBulletPlugin(),
     tablePlugin(client),
-    cleanWikiLinkPlugin(client),
-    cleanCommandLinkPlugin(client),
+    //cleanWikiLinkPlugin(client),
+    //cleanCommandLinkPlugin(client),
   ] as Extension[];
 }

--- a/web/deps.ts
+++ b/web/deps.ts
@@ -68,6 +68,8 @@ export {
   StateField,
   Text,
   Transaction,
+  Facet,
+  RangeSetBuilder,
 } from "@codemirror/state";
 
 export type {

--- a/web/editor_state.ts
+++ b/web/editor_state.ts
@@ -44,6 +44,7 @@ import { extendedMarkdownLanguage } from "$common/markdown_parser/parser.ts";
 import { parseCommand } from "$common/command.ts";
 import { safeRun } from "$lib/async.ts";
 import { codeCopyPlugin } from "./cm_plugins/code_copy.ts";
+import { activeLines } from "./active_lines.ts";
 
 export function createEditorState(
   client: Client,
@@ -107,6 +108,7 @@ export function createEditorState(
       inlineImagesPlugin(client),
       codeCopyPlugin(client),
       highlightSpecialChars(),
+      activeLines(),
       history(),
       drawSelection(),
       dropCursor(),

--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -218,22 +218,6 @@
     }
   }
 
-  .sb-header-inside.sb-line-h1 {
-    text-indent: -2ch;
-  }
-
-  .sb-header-inside.sb-line-h2 {
-    text-indent: -3ch;
-  }
-
-  .sb-header-inside.sb-line-h3 {
-    text-indent: -4ch;
-  }
-
-  .sb-header-inside.sb-line-h4 {
-    text-indent: -5ch;
-  }
-
   .sb-checkbox>input[type="checkbox"] {
     width: 3ch;
   }
@@ -294,7 +278,7 @@
 
   .sb-wiki-link-page {
     border-radius: 5px;
-    padding: 0 5px;
+    padding: 0;
     // white-space: nowrap;
     text-decoration: none;
     cursor: pointer;
@@ -400,8 +384,8 @@
     cursor: pointer;
     margin: 0 3px;
   }
-  
-  .sb-code-copy-button > svg {
+
+  .sb-code-copy-button>svg {
     height: 1rem;
     width: 1rem;
   }

--- a/web/styles/hide_marks.scss
+++ b/web/styles/hide_marks.scss
@@ -1,0 +1,89 @@
+@layer main, hide;
+
+@layer main {
+
+  /* move this to main later */
+  html {
+    --editor-meta-unfocused-opacity: 50%;
+
+    .cm-line {
+
+      &.sb-line-h1 {
+        text-indent: -2ch;
+      }
+
+      &.sb-line-h2 {
+        text-indent: -3ch;
+      }
+
+      &.sb-line-h3 {
+        text-indent: -4ch;
+      }
+
+      &.sb-line-h4 {
+        text-indent: -5ch;
+      }
+    }
+
+    .cm-line:not(.sb-activeLine) {
+
+      .sb-meta,
+      .sb-url {
+        opacity: var(--editor-meta-unfocused-opacity);
+      }
+    }
+  }
+}
+
+@layer hide {
+
+  /* Automatically hide marks */
+  /* html[hide-marks="true"] < implement this for allowing toggle */
+  html {
+    /* comment or remove next 2 variables to disable hiding marks when they are not focused */
+    --editor-meta-unfocused-visibility: hidden;
+    --editor-meta-unfocused-display: none;
+
+    .cm-line:not(.sb-activeLine) {
+
+      .sb-meta,
+      .sb-url {
+        display: var(--editor-meta-unfocused-display);
+      }
+
+      &.sb-line-h1,
+      &.sb-line-h2,
+      &.sb-line-h3,
+      &.sb-line-h4 {
+        text-indent: -1ch;
+      }
+    }
+
+    .cm-line {
+
+      .sb-meta,
+      .sb-url {
+        opacity: unset;
+        display: initial;
+      }
+    }
+
+  }
+
+  /* Don't hide empty links */
+  .cm-ldine:has(*:not(.sb-meta)) {
+
+    .sb-meta,
+    .sb-url {
+      display: var(--editor-meta-unfocused-display);
+    }
+  }
+
+  .cm-ldine:has(*:not(.sb-meta)) {
+
+    .sb-meta,
+    .sb-url {
+      display: var(--editor-meta-unfocused-display);
+    }
+  }
+}

--- a/web/styles/main.scss
+++ b/web/styles/main.scss
@@ -2,6 +2,7 @@
 @use "modals";
 @use "theme";
 @use "colors";
+@use "hide_marks";
 
 @font-face {
   font-family: "iA-Mono";


### PR DESCRIPTION
Most of clean.ts can be replaced with good ol' css.

web/active_lines.ts applies a style to active and selected lines, replacing all the isCursorInRange checks, and iterating over the syntax tree and css does the rest.
A change in behavior is that marks now are visible whenever its line is active, instead of within the element. I don't think I can easily change this behavior to the old way, so if it's unacceptable, feel free to reject the pr. I just need to know if it's worth continuing to work on this.

End goal:
- Command for toggling mark hiding on and off
- Marks can be set to turn translucent instead of hiding

Checklist
- [x] Text formatting marks
- [x] Links
- [x] Headings
- [x] Lists
- [x] Wikilinks
- [ ] Codeblocks
- [ ] Blockquotes
- [ ] Frontmatter
- [ ] Toggle command
- [ ] Figure out if configuring through styles is good enough or if it needs settings