### PR TITLE
Only prepend attachmentUrlPrefix if url doesnt already start with it

### DIFF
--- a/plugs/markdown/markdown_render.ts
+++ b/plugs/markdown/markdown_render.ts
@@ -208,7 +208,12 @@ function render(
       }
       let url = urlNode.children![0].text!;
       if (url.indexOf("://") === -1) {
-        url = `${options.attachmentUrlPrefix || ""}${url}`;
+        if (
+          options.attachmentUrlPrefix &&
+          !url.startsWith(options.attachmentUrlPrefix)
+        ) {
+          url = `${options.attachmentUrlPrefix}${url}`;
+        }
       }
       return {
         name: "a",
@@ -226,7 +231,12 @@ function render(
       }
       let url = urlNode!.children![0].text!;
       if (url.indexOf("://") === -1) {
-        url = `${options.attachmentUrlPrefix || ""}${url}`;
+        if (
+          options.attachmentUrlPrefix &&
+          !url.startsWith(options.attachmentUrlPrefix)
+        ) {
+          url = `${options.attachmentUrlPrefix}${url}`;
+        }
       }
       return {
         name: "img",


### PR DESCRIPTION
While using silverbullet-pub, I had issues getting images to work.  If I used absolute paths in markdown like `![](/Commands/2024-03-09_04-01-31-chat-example.gif)` it would work in SB, but the html would render as `<img src="//Commands/2024-03-09_04-01-31-chat-example.gif">` with a double slash in front, causing the image not to load.

I couldn't find anywhere else that uses `options.attachmentUrlPrefix`, so I'm assuming it was added for pub and hoping this would always be expected behavior.