### PR TITLE
Fix space on end of page name creates two pages, one shadowed #615

### DIFF
--- a/common/spaces/http_space_primitives.ts
+++ b/common/spaces/http_space_primitives.ts
@@ -34,14 +34,18 @@ export class HttpSpacePrimitives implements SpacePrimitives {
         throw new Error("Offline");
       }
       if (result.redirected) {
-        // Got a redirect, we'll assume this is due to invalid credentials and redirecting to an auth page
-        console.log(
-          "Got a redirect via the API so will redirect to URL",
-          result.url,
-        );
-        alert("You are not authenticated, redirecting to login page...");
-        location.href = result.url;
-        throw new Error("Not authenticated");
+        if (result.status === 401) {
+          console.log(
+            "Received unauthorized status and got a redirect via the API so will redirect to URL",
+            result.url,
+          );
+          alert("You are not authenticated, redirecting to login page...");
+          location.href = result.url;
+          throw new Error("Not authenticated");
+        } else {
+          location.href = result.url;
+          throw new Error("Redirected");
+        }
       }
       if (result.status === 401) {
         location.reload();


### PR DESCRIPTION
## Context

Fixes #615.

## Proposed solution

1. Disallow PUT on filename with filenames surrounded with spaces;
2. If the filename provided on GET is surrounded by spaces, redirect to its trimmed version;
3. In case of required authentication, return a 401 (UNAUTHORIZED) + redirect;

## Other

If you want me to create tests, I would like to know if there already exists files places I can put them in.