### PR TITLE
Update tag_page.ts explanation string

### DIFF
--- a/plugs/index/tag_page.ts
+++ b/plugs/index/tag_page.ts
@@ -10,7 +10,7 @@ export async function readFileTag(
     tagPrefix.length,
     name.length - ".md".length,
   );
-  const text = `These are all objects in your space tagged with #${tagName}.
+  const text = `All objects in your space tagged with #${tagName}:
 \`\`\`template
 template: |
     {{#if .}}


### PR DESCRIPTION
"These are all objects..." is a bit vague in English.

We could either have "These are all *the* objects", or just "All objects..."
If the latter, a colon makes sense.