### PR TITLE
Fix frontmatter indexing error when a tag is a number

### DIFF
--- a/plug-api/lib/frontmatter.ts
+++ b/plug-api/lib/frontmatter.ts
@@ -115,8 +115,18 @@ export async function extractFrontmatter(
     return undefined;
   });
 
-  // Strip # from tags
-  data.tags = [...new Set([...tags.map((t) => t.replace(/^#/, ""))])];
+  try {
+    data.tags = [
+      ...new Set([...tags.map((t) => {
+        // Always treat tags as strings
+        const tagAsString = String(t);
+        // Strip # from tags
+        return tagAsString.replace(/^#/, "");
+      })]),
+    ];
+  } catch (e) {
+    console.error("Error while processing tags", e);
+  }
 
   // console.log("Extracted tags", data.tags);
   // Expand property names (e.g. "foo.bar" => { foo: { bar: true } })

--- a/plugs/markdown/html_render.ts
+++ b/plugs/markdown/html_render.ts
@@ -7,6 +7,10 @@ export type Tag = {
 } | string;
 
 function htmlEscape(s: string): string {
+  if (typeof s !== "string") {
+    return s;
+  }
+
   s = s.replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")


### PR DESCRIPTION
This fixes two issues I ran into.   I had several markdown files with frontmatter like this:

```markdown
---
# Other keys
tags:
  - 2017
  - conference
---
```

The `2017` tag would get parsed as a number instead of a string, so during indexing it'd throw these errors:

```
   3924 An error occurred while indexing tasks: TypeError: i.replace is not a function
   3925     at data:application/javascript;base64,dmFyIHhlPU9iamVjdC5k......e3luIGFzIHBsdWd9Owo=:3:772
   3926     at Array.map (<anonymous>)
   3927     at _ (data:application/javascript;base64,dmFyIHhlPU9iamVjdC5k......e3luIGFzIHBsdWd9Owo=:3:763)
   3928     at eventLoopTick (ext:core/01_core.js:153:7)
   3929     at async ie (data:application/javascript;base64,dmFyIHhlPU9iamVjdC5k......e3luIGFzIHBsdWd9Owo=:3:1416)
   3930     at async data:application/javascript;base64,dmFyIHhlPU9iamVjdC5k......e3luIGFzIHBsdWd9Owo=:1:605
   3931 Error indexing paragraphs: TypeError: a.replace is not a function
   3932     at data:application/javascript;base64,dmFyIFlyPU9iamVjdC5k......dHtscCBhcyBwbHVnfTsK:4:772
   3933     at Array.map (<anonymous>)
   3934     at D (data:application/javascript;base64,dmFyIFlyPU9iamVjdC5k......dHtscCBhcyBwbHVnfTsK:4:763)
   3935     at eventLoopTick (ext:core/01_core.js:153:7)
   3936     at async er (data:application/javascript;base64,dmFyIFlyPU9iamVjdC5k......dHtscCBhcyBwbHVnfTsK:4:1822)
   3937     at async data:application/javascript;base64,dmFyIFlyPU9iamVjdC5k......dHtscCBhcyBwbHVnfTsK:1:617
```

As far as I can tell, both of these happened because the tag wasn't being treated as a string.