### PR TITLE
Remove dollar before commands in "shell" block

### DIFF
--- a/website/Deployments/Caddy.md
+++ b/website/Deployments/Caddy.md
@@ -3,17 +3,17 @@ The most straightforward way to add TLS on top of SilverBulet is to use [Caddy](
 When you’re deploying on a public server accessible to the Internet, you can do this as follows:
 
 ```shell
-$ sudo caddy reverse-proxy --to :3000 --from yourdomain.com:443
+sudo caddy reverse-proxy --to :3000 --from yourdomain.com:443
 ```
 
 If you’re deploying on a local network and accessing your server via a VPN, this is a bit more tricky. The recommended setup here is to use [Tailscale](https://tailscale.com/), which now [supports TLS certificates for your VPN servers](https://tailscale.com/kb/1153/enabling-https/). Once you have this enabled, get a certificate via:
 
 ```shell
-$ tailscale cert yourserver.yourtsdomain.ts.net
+tailscale cert yourserver.yourtsdomain.ts.net
 ```
 
 Caddy can automatically find these certificates once provisioned, so you can just run:
 
 ```shell
-$ sudo caddy reverse-proxy --to :3000 --from yourserver.yourtsdomain.ts.net:443
+sudo caddy reverse-proxy --to :3000 --from yourserver.yourtsdomain.ts.net:443
 ```

--- a/website/Deployments/ngrok.md
+++ b/website/Deployments/ngrok.md
@@ -12,24 +12,24 @@ It is **absolutely key** to enable [[Authentication]] on SilverBullet, otherwise
 
 Generally the steps are to run SilverBullet (e.g. via Deno) (see [[Install]] for more options) — note the port here (`3000`):
 
-```bash
-$ silverbullet -p 3000 --user mysuser:mypassword path/to/space
+```shell
+silverbullet -p 3000 --user mysuser:mypassword path/to/space
 ```
 
 Then, create a free [ngrok](https://dashboard.ngrok.com/) account, and follow the instructions to download the ngrok client for your platform, and authenticate it (look for the `ngrok config add-authtoken` command).
 
 Then, in another terminal run `ngrok`:
 
-```bash
-$ ngrok http 3000
+```shell
+ngrok http 3000
 ```
 
 This will give you a `https://xxx.ngrok-free.app` style URL you can open in your browser.
 
 Note that this URL changes every time, which is inconvenient. Therefore it’s **recommended you create a domain** as well (you get 1 for free). Follow the [instructions on the domains page](https://dashboard.ngrok.com/cloud-edge/domains) in the ngrok dashboard on how to do this. Once you created your domain, you can launch `ngrok` as follows:
 
-```bash
-$ ngrok http --domain=your-domain.ngrok-free.app 3000
+```shell
+ngrok http --domain=your-domain.ngrok-free.app 3000
 ```
 
 Enjoy!

--- a/website/Install/Deno Deploy.md
+++ b/website/Install/Deno Deploy.md
@@ -19,13 +19,13 @@ Make sure you have [installed Deno locally](https://docs.deno.com/runtime/manual
 Then, install `deployctl` via:
 
 ```shell
-$ deno install -Arf https://deno.land/x/deploy/deployctl.ts
+deno install -Arf https://deno.land/x/deploy/deployctl.ts
 ```
 
 To deploy, run:
 
 ```shell
-$ deployctl deploy -p=your-project --entrypoint=https://silverbullet.md/silverbullet.js --include= --prod
+deployctl deploy -p=your-project --entrypoint=https://silverbullet.md/silverbullet.js --include= --prod
 ```
 
 This will ask you to authenticate with your Deno Deploy account, and then deploy SilverBullet.

--- a/website/Install/Deno.md
+++ b/website/Install/Deno.md
@@ -2,14 +2,14 @@ The SilverBullet is implemented using a JavaScript runtime called [Deno](https:/
 
 To run SilverBullet directly on your host system (so not in a [[Install/Docker]] container), you need to [install Deno](https://docs.deno.com/runtime/manual/getting_started/installation) 1.40 or later:
 
-```bash
-$ curl -fsSL https://deno.land/install.sh | sh
+```shell
+curl -fsSL https://deno.land/install.sh | sh
 ```
 
 After having installed Deno, run:
 
 ```shell
-$ deno install -f --name silverbullet  --unstable-kv --unstable-worker-options -A https://get.silverbullet.md
+deno install -f --name silverbullet  --unstable-kv --unstable-worker-options -A https://get.silverbullet.md
 ```
 
 You only have to do this once. This will download the currently _released_ version of SilverBullet onto your machine.
@@ -21,7 +21,7 @@ While you have [[Install/Configuration|options as to where and how to store your
 After creating a folder, run the following command in your terminal:
 
 ```shell
-$ silverbullet <pages-path>
+silverbullet <pages-path>
 ```
 
 By default, SilverBullet will bind to port `3000`; to use a different port, use the `-p` flag (e.g. `-p8080`).
@@ -34,7 +34,7 @@ Once downloaded and booted, SilverBullet will print out a URL to open in your br
 SilverBullet is regularly updated. To get the latest and greatest, simply run:
 
 ```shell
-$ silverbullet upgrade
+silverbullet upgrade
 ```
 
 And restart SilverBullet. You should be good to go.

--- a/website/Install/Docker.md
+++ b/website/Install/Docker.md
@@ -18,9 +18,9 @@ For your first run, you can run the following:
 
 ```shell
 # Create a local folder "space" to keep files in
-$ mkdir -p space
+mkdir -p space
 # Run the SilverBullet docker container in the foreground
-$ sudo docker run -it -p 3000:3000 -v ./space:/space zefhemel/silverbullet
+sudo docker run -it -p 3000:3000 -v ./space:/space zefhemel/silverbullet
 ```
 
 This will run SilverBullet in the foreground, interactively, so you can see the logs and instructions. 
@@ -30,7 +30,7 @@ If this all works fine, just kill the thing with `Ctrl-c` (don’t worry, it’s
 Now you probably want to run the container in daemon (background) mode, give it a name, and automatically have it restart after you e.g. reboot your machine:
 
 ```shell
-$ docker run -d --restart unless-stopped --name silverbullet -p 3000:3000 -v ./space:/space zefhemel/silverbullet
+docker run -d --restart unless-stopped --name silverbullet -p 3000:3000 -v ./space:/space zefhemel/silverbullet
 ```
 
 There you go!
@@ -45,13 +45,13 @@ You can upgrade SilverBullet as follows:
 
 ```shell
 # Pull the latest version of the image
-$ docker pull zefhemel/silverbullet
+docker pull zefhemel/silverbullet
 # Kill the running container
-$ docker kill silverbullet
+docker kill silverbullet
 # Remove the old container
-$ docker rm silverbullet
+docker rm silverbullet
 # Start a fresh one (same command as before)
-$ docker run -d --restart unless-stopped --name silverbullet -p 3000:3000 -v $PW/space:/space zefhemel/silverbullet
+docker run -d --restart unless-stopped --name silverbullet -p 3000:3000 -v $PW/space:/space zefhemel/silverbullet
 ```
 
 Since this is somewhat burdensome, it is recommended you use a tool like [watchtower](https://github.com/containrrr/watchtower) to automatically update your docker images and restart them. However, if we go there — we may as well use a tool like _docker compose_ to manage your containers, no?
@@ -86,11 +86,11 @@ services:
 Boot this up via:
 
 ```shell
-$ docker-compose up -d
+docker-compose up -d
 ```
 
 And watch for logs with:
 
 ```shell
-$ docker-compose logs -f
+docker-compose logs -f
 ```


### PR DESCRIPTION
With the blocks consistently having the `shell` specifier, the dollar sign is not needed to indicate these lines are terminal commands. There is also no need to differentiate user `$` and root `#` shell, since the lines contain `sudo` whenever root privileges are required.

This significantly improves UX considering #735

Credit goes to Russ Williams (rlw1138) for suggesting this https://community.silverbullet.md/t/copy-to-clipboard/351

---

Since the majority of command blocks used the `shell` info string, I changed the few `bash` ones to match (as a proud `zsh` user).