### PR TITLE
Add the Intl DateTimeFormat polyfill for space scripts without overwriting other Intl classes

### DIFF
--- a/common/space_script.ts
+++ b/common/space_script.ts
@@ -9,7 +9,7 @@ Date.prototype.toTemporalInstant = toTemporalInstant;
 // @ts-ignore: Temporal polyfill
 globalThis.Temporal = Temporal;
 // @ts-ignore: Intl polyfill
-globalThis.Intl = Intl;
+Object.apply(globalThis.Intl, Intl);
 
 type FunctionDef = {
   name: string;


### PR DESCRIPTION
The Intl polyfill provided by `js-temporal` only includes the `DateTimeFormat` class. Because the global Intl is replaced with it, the other classes provided by Intl are not accessible.

I changed it, so the Intl polyfill gets applied to the global Intl, therefore only replacing the `DateTimeFormat`.