### PR TITLE
Allow middle click to open link

### DIFF
--- a/web/cm_plugins/link.ts
+++ b/web/cm_plugins/link.ts
@@ -58,6 +58,7 @@ export function linkPlugin(client: Client) {
             attributes: {
               href: cleanLink,
               title: `Click to visit ${cleanLink}`,
+              contenteditable: "false",
             },
           }).range(from + 1, from + cleanAnchor.length + 1),
         );


### PR DESCRIPTION
Middle clicking on links just puts the cursor into the link. I set `contenteditable` to `false`, like on wiki-links to make middle click also work to open links.