### PR TITLE
Fixes panel border espacially for dark mode

### DIFF
--- a/web/styles/colors.scss
+++ b/web/styles/colors.scss
@@ -31,13 +31,22 @@
   color: var(--top-loading-color);
 }
 
-.sb-panel {
-  border-left: 1px solid var(--panel-border-color);
-  background-color: var(--panel-background-color);
+#sb-main {
+  .sb-panel:last-child {
+    border-left: 1px solid var(--panel-border-color);
+  }
+
+  .sb-panel:first-child {
+    border-right: 1px solid var(--panel-border-color);
+  }
+
+  .sb-panel {
+    background-color: var(--panel-background-color);
+  }
 }
 
 .sb-bhs {
-  border-top: var(--bhs-border-color) 1px solid;
+  border-top: 1px solid var(--bhs-border-color);
   background-color: var(--bhs-background-color);
 }
 

--- a/web/styles/theme.scss
+++ b/web/styles/theme.scss
@@ -154,11 +154,11 @@ html[data-theme="dark"] {
   --top-unsaved-color: #c7c7c7;
   --top-loading-color: #c7c7c7;
 
-  --panel-background-color: #fff;
-  --panel-border-color: #fff;
+  --panel-background-color: #111;
+  --panel-border-color: rgb(62, 62, 62);
 
-  --bhs-background-color: #fff;
-  --bhs-border-color: rgb(193, 193, 193);
+  --bhs-background-color: #111;
+  --bhs-border-color: rgb(62, 62, 62);
 
   --modal-color: #ccc;
   --modal-background-color: #262626;


### PR DESCRIPTION
So currently the border around panels is wrong in many cases
![image](https://github.com/silverbulletmd/silverbullet/assets/40832361/40d76435-b53b-437d-84ab-a2d4bdbaddd7)
Especially in the `bhs` and `lhs` case
![image](https://github.com/silverbulletmd/silverbullet/assets/40832361/f9a03383-12ec-490d-becc-42d42cd7c693)
It's most noticeable in dark mode, because in white mode the border color is the same as the background (white)

This PR fixes both the position of the border and the color of the border in dark mode
![image](https://github.com/silverbulletmd/silverbullet/assets/40832361/66daf8dc-3eba-4c48-908e-729f64ad6c03)
