### PR TITLE
Fixed greedy parsing of settings block

### DIFF
--- a/common/settings.ts
+++ b/common/settings.ts
@@ -4,7 +4,7 @@ import { SpacePrimitives } from "./spaces/space_primitives.ts";
 import { expandPropertyNames } from "../plug-api/lib/json.ts";
 import type { BuiltinSettings } from "../type/web.ts";
 
-const yamlSettingsRegex = /^(```+|~~~+)ya?ml\r?\n([\S\s]+)\1/m;
+const yamlSettingsRegex = /^(```+|~~~+)ya?ml\r?\n([\S\s]+?)\1/m;
 
 /**
  * Parses YAML settings from a Markdown string.


### PR DESCRIPTION
This alters the regex for getting the settings block to not parse the content of the block greedily, because this could lead to problems where two consecutive blocks would be captured as one. [Example](https://regex101.com/r/4eekHd/1)