### PR TITLE
Add subscript and superscript

### DIFF
--- a/common/markdown_parser/customtags.ts
+++ b/common/markdown_parser/customtags.ts
@@ -29,3 +29,6 @@ export const NakedURLTag = Tag.define();
 
 export const DirectiveMarkTag = Tag.define();
 export const DirectiveTag = Tag.define();
+
+export const SubscriptTag = Tag.define();
+export const SuperscriptTag = Tag.define();

--- a/common/markdown_parser/parser.ts
+++ b/common/markdown_parser/parser.ts
@@ -8,6 +8,8 @@ import {
   Line,
   MarkdownConfig,
   Strikethrough,
+  Subscript,
+  Superscript,
 } from "@lezer/markdown";
 import { markdown } from "@codemirror/lang-markdown";
 import { StreamLanguage } from "@codemirror/language";
@@ -624,6 +626,8 @@ export const extendedMarkdownLanguage = markdown({
     Hashtag,
     TaskDeadline,
     NamedAnchor,
+    Superscript,
+    Subscript,
     {
       props: [
         foldNodeProp.add({
@@ -646,8 +650,9 @@ export const extendedMarkdownLanguage = markdown({
           Task: ct.TaskTag,
           TaskMark: ct.TaskMarkTag,
           Comment: ct.CommentTag,
-          "TableDelimiter SubscriptMark SuperscriptMark StrikethroughMark":
-            t.processingInstruction,
+          "Subscript": ct.SubscriptTag,
+          "Superscript": ct.SuperscriptTag,
+          "TableDelimiter StrikethroughMark": t.processingInstruction,
           "TableHeader/...": t.heading,
           TableCell: t.content,
           CodeInfo: ct.CodeInfoTag,

--- a/plugs/markdown/markdown_render.ts
+++ b/plugs/markdown/markdown_render.ts
@@ -477,6 +477,16 @@ function render(
         body: renderToText(t),
       };
     }
+    case "Superscript":
+      return {
+        name: "sup",
+        body: cleanTags(mapRender(t.children!)),
+      };
+    case "Subscript":
+      return {
+        name: "sub",
+        body: cleanTags(mapRender(t.children!)),
+      };
 
     // Text
     case undefined:

--- a/web/cm_plugins/hide_mark.ts
+++ b/web/cm_plugins/hide_mark.ts
@@ -21,6 +21,8 @@ const typesWithMarks = [
   "InlineCode",
   "Highlight",
   "Strikethrough",
+  "Superscript",
+  "Subscript",
 ];
 /**
  * The elements which are used as marks.
@@ -30,6 +32,8 @@ const markTypes = [
   "CodeMark",
   "HighlightMark",
   "StrikethroughMark",
+  "SuperscriptMark",
+  "SubscriptMark",
 ];
 
 /**

--- a/web/style.ts
+++ b/web/style.ts
@@ -53,6 +53,8 @@ export default function highlightStyles() {
     { tag: ct.NakedURLTag, class: "sb-naked-url" },
     { tag: ct.TaskDeadlineTag, class: "sb-task-deadline" },
     { tag: ct.NamedAnchorTag, class: "sb-named-anchor" },
+    { tag: ct.SubscriptTag, class: "sb-sub" },
+    { tag: ct.SuperscriptTag, class: "sb-sup" },
 
     { tag: ct.DirectiveMarkTag, class: "sb-directive-mark" },
     { tag: ct.DirectiveTag, class: "sb-directive" },

--- a/web/styles/colors.scss
+++ b/web/styles/colors.scss
@@ -218,9 +218,9 @@
   .sb-line-h3 .sb-meta,
   .sb-line-h4 .sb-meta,
   .sb-line-h5 .sb-meta,
-  .sb-line-h6 .sb-meta,
-  {
-  color: var(--editor-heading-meta-color);
+  .sb-line-h6 .sb-meta {
+    color: var(--editor-heading-meta-color);
+  }
 }
 
 .sb-hashtag,
@@ -384,6 +384,16 @@ tbody tr:nth-of-type(even) {
 
 .sb-strong {
   font-weight: 900;
+}
+
+.sb-sub {
+  vertical-align: sub;
+  font-size: smaller;
+}
+
+.sb-sup {
+  vertical-align: super;
+  font-size: smaller;
 }
 
 .sb-line-code-outside .sb-code-info {

--- a/web/styles/colors.scss
+++ b/web/styles/colors.scss
@@ -443,4 +443,3 @@ a.sb-wiki-link-page-missing,
 .sb-line-comment {
   background-color: var(--editor-code-comment-color); // rgba(255, 255, 0, 0.5);
 }
-}

--- a/website/Markdown/Extensions.md
+++ b/website/Markdown/Extensions.md
@@ -15,4 +15,5 @@ In addition to supporting [[Markdown/Basics|markdown basics]] as standardized by
 * [Task lists](https://www.markdownguide.org/extended-syntax/#task-lists)
 * [Highlight](https://www.markdownguide.org/extended-syntax/#highlight)
 * [Automatic URL linking](https://www.markdownguide.org/extended-syntax/#automatic-url-linking)
+* [Subscript](https://www.markdownguide.org/extended-syntax/#subscript) and [superscript](https://www.markdownguide.org/extended-syntax/#superscript)
 * Any addition custom markdown extensions provided by [[Plugs]]


### PR DESCRIPTION
This fixes #872

The syntax would look like this, which seems to be the one used by e.g. pandoc. The alternative would be  Github<sup>TM</sup>s `H<sub>2</sub>O`, but I think pandoc style looks neater. 
![image](https://github.com/silverbulletmd/silverbullet/assets/40832361/cdf1a93c-74d7-4dc5-a43c-76418682fedb)
