### PR TITLE
Redirects to initial url after authentication and cleans up auth code

### DIFF
--- a/plugs/editor/clean.ts
+++ b/plugs/editor/clean.ts
@@ -10,5 +10,5 @@ export async function cleanCommand() {
   }
   await editor.flashNotification("Now wiping all state and logging out...");
   await debug.cleanup();
-  await editor.openUrl("/.auth?logout", true);
+  await editor.openUrl("/.logout", true);
 }

--- a/web/auth.html
+++ b/web/auth.html
@@ -76,9 +76,22 @@
 
   <script>
     const params = new URLSearchParams(window.location.search);
+
     const error = params.get('error');
-    if (error === "1") {
+    if (error === "0") {
+      document.querySelector('.error-message').innerText = "The sent data was invalid";
+    } else if (error === "1") {
       document.querySelector('.error-message').innerText = "Invalid username or password";
+    }
+
+    const from = params.get("from");
+    if (from) {
+      var input = document.createElement("input");
+      input.setAttribute("type", "hidden");
+      input.setAttribute("name", "from");
+      input.setAttribute("value", from);
+
+      document.getElementById("login").appendChild(input);
     }
   </script>
 </body>

--- a/web/service_worker.ts
+++ b/web/service_worker.ts
@@ -97,7 +97,11 @@ self.addEventListener("fetch", (event: any) => {
 
       const pathname = requestUrl.pathname;
 
-      if (pathname === "/.auth" || pathname === "/index.json") {
+      if (
+        pathname === "/.auth" ||
+        pathname === "/.logout" ||
+        pathname === "/index.json"
+      ) {
         return fetch(request);
       } else if (/\/.+\.[a-zA-Z]+$/.test(pathname)) {
         // If this is a /*.* request, this can either be a plug worker load or an attachment load


### PR DESCRIPTION
Things this changes:
- This uses query parameters to redirect to the requested url after authentication. There are probably a 100 ways to implement this, hope this is ok. (Fixes #886)
- I also separated the logout into it's own route as I don't see a reason why it would be a query parameter.
- I also changed the `.all` and if else code into the proper honojs code and used a hono validator to validate the form data. in the auth route handler
- vscode also did some formatting, which changed the indenting of some blocks, which is why the diff looks kinda insane