### PR TITLE
Fix `allKnownFiles` not being updated for `pageExists()`

### DIFF
--- a/common/query_functions.ts
+++ b/common/query_functions.ts
@@ -11,11 +11,6 @@ export function buildQueryFunctions(
   system: System<any>,
 ): FunctionMap {
   const pageCache = new LimitedMap<string>(10);
-  allKnownFiles = new Set(
-    [...allKnownFiles].flatMap((file) =>
-      (file.endsWith(".md")) ? [file.slice(0, -3)] : []
-    ),
-  );
 
   return {
     ...builtinFunctions,
@@ -28,7 +23,14 @@ export function buildQueryFunctions(
         // Let's assume federated pages exist, and ignore template variable ones
         return true;
       }
-      return allKnownFiles.has(name);
+
+      const flattendFiles = new Set(
+        [...allKnownFiles].flatMap((file) =>
+          (file.endsWith(".md")) ? [file.slice(0, -3)] : []
+        ),
+      );
+
+      return flattendFiles.has(name);
     },
     async template(template: unknown, obj: unknown) {
       if (typeof template !== "string") {


### PR DESCRIPTION
The mapping of the files to page names has to happen with every call to `pageExists()` as the underling array will change. Initially it's even empty and never updating it will cause the resulting mapped set to stay empty. This would mean `pageExists()` returnes `false` every time.

This issue was introduced with 1f94915 and is thus still pretty new, which is probably why it was unnoticed until now.