### PR TITLE
Link Embeds

### DIFF
--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -570,6 +570,14 @@
     }
   }
 
+  .sb-markdown-widget-inline {
+    margin: 0 0 0 0;
+
+    &:hover .button-bar {
+      display: none !important;
+    }
+  }
+
   .sb-fenced-code-iframe {
     background-color: transparent;
 


### PR DESCRIPTION
right now page embeds work in editor view with support for sectional embeds with #headers @position or $anchor links.

Todo: embedding in Markdown preview

I'm not sure if this is the best way either, because I was also trying to add support for embedding other file types, like videos and pdfs. I was thinking to do that by reading mimetype of the file, but haven't figured out how to only fetch the file once, maybe merge the inline image widget and the embed codeblock into one all-purpose widget?