### PR TITLE
Change selection behaviour

### DIFF
--- a/web/cm_plugins/fenced_code.ts
+++ b/web/cm_plugins/fenced_code.ts
@@ -6,7 +6,6 @@ import {
   decoratorStateField,
   invisibleDecoration,
   isCursorInRange,
-  shouldRenderAsCode,
 } from "./util.ts";
 import { MarkdownWidget } from "./markdown_widget.ts";
 import { IFrameWidget } from "./iframe_widget.ts";
@@ -18,7 +17,7 @@ export function fencedCodePlugin(editor: Client) {
     syntaxTree(state).iterate({
       enter({ from, to, name, node }) {
         if (name === "FencedCode") {
-          if (shouldRenderAsCode(state, [from, to])) {
+          if (isCursorInRange(state, [from, to])) {
             // Don't render the widget if the cursor is inside the fenced code
             return;
           }

--- a/web/cm_plugins/util.ts
+++ b/web/cm_plugins/util.ts
@@ -24,10 +24,6 @@ export class LinkWidget extends WidgetType {
 
     // Mouse handling
     anchor.addEventListener("click", (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-    });
-    anchor.addEventListener("mouseup", (e) => {
       if (e.button !== 0) {
         return;
       }

--- a/web/cm_plugins/util.ts
+++ b/web/cm_plugins/util.ts
@@ -89,10 +89,8 @@ export function decoratorStateField(
     },
 
     update(value: DecorationSet, tr: Transaction) {
-      // if (tr.docChanged || tr.selection) {
+      if (tr.isUserEvent("select.pointer")) return value;
       return stateToDecoratorMapper(tr.state);
-      // }
-      // return value;
     },
 
     provide: (f) => EditorView.decorations.from(f),
@@ -159,21 +157,6 @@ export function isCursorInRange(state: EditorState, range: [number, number]) {
   return state.selection.ranges.some((selection) =>
     checkRangeOverlap(range, [selection.from, selection.to])
   );
-}
-
-export function shouldRenderAsCode(
-  state: EditorState,
-  range: [number, number],
-) {
-  const mainSelection = state.selection.main;
-  // When the selection is empty, we need to check if the cursor is inside the fenced code
-  if (mainSelection.empty) {
-    return checkRangeOverlap(range, [mainSelection.from, mainSelection.to]);
-  } else {
-    // If the selection is encompassing the fenced code we render as code, or vice versa
-    return checkRangeSubset([mainSelection.from, mainSelection.to], range) ||
-      checkRangeSubset(range, [mainSelection.from, mainSelection.to]);
-  }
 }
 
 /**

--- a/web/cm_plugins/util.ts
+++ b/web/cm_plugins/util.ts
@@ -53,6 +53,13 @@ export class LinkWidget extends WidgetType {
     anchor.href = this.options.href || "#";
     return anchor;
   }
+
+  eq(other: WidgetType): boolean {
+    return other instanceof LinkWidget &&
+      this.options.text === other.options.text &&
+      this.options.href === other.options.href &&
+      this.options.title === other.options.title;
+  }
 }
 
 export class HtmlWidget extends WidgetType {

--- a/web/cm_plugins/wiki_link.ts
+++ b/web/cm_plugins/wiki_link.ts
@@ -87,9 +87,11 @@ export function cleanWikiLinkPlugin(client: Client) {
                 callback: (e) => {
                   if (e.altKey) {
                     // Move cursor into the link
-                    return client.editorView.dispatch({
+                    client.editorView.dispatch({
                       selection: { anchor: from + firstMark.length },
                     });
+                    client.focus();
+                    return;
                   }
                   // Dispatch click event to navigate there without moving the cursor
                   const clickEvent: ClickEvent = {

--- a/web/editor_state.ts
+++ b/web/editor_state.ts
@@ -21,7 +21,6 @@ import {
 } from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
 import {
-  drawSelection,
   dropCursor,
   EditorView,
   highlightSpecialChars,
@@ -115,7 +114,6 @@ export function createEditorState(
       codeCopyPlugin(client),
       highlightSpecialChars(),
       history(),
-      drawSelection(),
       dropCursor(),
       codeFolding({
         placeholderText: "…",

--- a/web/editor_state.ts
+++ b/web/editor_state.ts
@@ -200,7 +200,7 @@ export function createEditorState(
           touchCount = 0;
         },
 
-        mousedown: (event: MouseEvent, view: EditorView) => {
+        click: (event: MouseEvent, view: EditorView) => {
           const pos = view.posAtCoords(event);
           if (event.button !== 0) {
             return;

--- a/web/editor_ui.tsx
+++ b/web/editor_ui.tsx
@@ -60,6 +60,12 @@ export class MainUI {
         });
       }
     });
+
+    globalThis.addEventListener("mouseup", (_) => {
+      setTimeout(() => {
+        client.editorView.dispatch({});
+      })
+    });
   }
 
   ViewComponent() {

--- a/web/styles/colors.scss
+++ b/web/styles/colors.scss
@@ -174,10 +174,12 @@
 #sb-editor {
   .cm-content {
     font-family: var(--editor-font);
+    caret-color: var(--editor-caret-color);
   }
 
-  .cm-selectionBackground {
+  ::selection {
     background-color: var(--editor-selection-background-color);
+    caret-color: var(--editor-caret-color);
   }
 
   .cm-panels-bottom {

--- a/web/styles/colors.scss
+++ b/web/styles/colors.scss
@@ -4,7 +4,8 @@
   color: var(--root-color);
 }
 
-.cm-cursor {
+.cm-cursor,
+.cm-dropCursor {
   border-left: 1.2px solid var(--editor-caret-color) !important;
 }
 
@@ -174,12 +175,11 @@
 #sb-editor {
   .cm-content {
     font-family: var(--editor-font);
-    caret-color: var(--editor-caret-color);
+    caret-color: transparent;
   }
 
   ::selection {
     background-color: var(--editor-selection-background-color);
-    caret-color: var(--editor-caret-color);
   }
 
   .cm-panels-bottom {

--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -401,6 +401,10 @@
   }
 
   .sb-line-code-outside .sb-code-info {
+    &::selection {
+      background-color: transparent;
+    }
+
     display: block;
     float: right;
     font-size: 90%;
@@ -408,6 +412,10 @@
   }
 
   .sb-code-copy-button {
+    &::selection {
+      background-color: transparent;
+    }
+
     float: right;
     cursor: pointer;
     margin: 0 3px;


### PR DESCRIPTION
Ok, this is more of shot into the blind. It does a few things:
- It filters out all `select.pointer` events and fires an empty transaction on `mouseup`, which basically replicates obsidians behaviour for selections, meaning while you still hold down the mouse nothing happens and only when you let go, the view updates. This removes all the weird jitter/feed-back loops when selecting.
- You can now select part of a widgets code and part of the outside text and it will still render the widget code.
- Change all events for different kind of links to `click` as that is also the normal behaviour of `<a>`s. It just seems weird that sometimes stuff happens on `mouseup` and sometimes on `mousedown` (Maybe there is a reason, but I couldn't think of one). This also sometimes caused problems: When you for example select some text and end on a link with the cursor, that link triggered.
- Remove the `drawSelection()` extension. This maybe controversial and is definitely up for debate, but to me the default browser selection behaviour just seems more natural and we aren't using multi cursor/selection stuff anyways.

I'd love some feedback on this