### PR TITLE
Support arm64 arch for Linux

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Compile for all platforms
         run: |
           deno task server:dist:linux-x86_64
+          deno task server:dist:linux-aarch64
           deno task server:dist:darwin-x86_64
           deno task server:dist:darwin-aarch64
           deno task server:dist:windows-x86_64

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -20,6 +20,7 @@
     // Compile
     "compile": "deno task bundle && deno compile -A --unstable-kv --unstable-worker-options -o silverbullet dist/silverbullet.js",
     "server:dist:linux-x86_64": "deno task bundle && deno compile -A --unstable-kv --unstable-worker-options --target x86_64-unknown-linux-gnu -o silverbullet dist/silverbullet.js && zip silverbullet-server-linux-x86_64.zip silverbullet",
+    "server:dist:linux-aarch64": "deno task bundle && deno compile -A --unstable-kv --unstable-worker-options --target aarch64-unknown-linux-gnu -o silverbullet dist/silverbullet.js && zip silverbullet-server-linux-aarch64 silverbullet",
     "server:dist:darwin-x86_64": "deno task bundle && deno compile -A --unstable-kv  --unstable-worker-options --target x86_64-apple-darwin -o silverbullet dist/silverbullet.js && zip silverbullet-server-darwin-x86_64.zip silverbullet",
     "server:dist:darwin-aarch64": "deno task bundle && deno compile -A --unstable-kv --unstable-worker-options --target aarch64-apple-darwin -o silverbullet dist/silverbullet.js  && zip silverbullet-server-darwin-aarch64.zip silverbullet",
     "server:dist:windows-x86_64": "deno task bundle && deno compile -A --unstable-kv --unstable-worker-options --target x86_64-pc-windows-msvc -o silverbullet.exe dist/silverbullet.js && zip silverbullet-server-windows-x86_64.zip silverbullet.exe"

--- a/install.sh
+++ b/install.sh
@@ -10,10 +10,7 @@ fi
 case $(uname -sm) in
 "Darwin x86_64") target="darwin-x86_64" ;;
 "Darwin arm64") target="darwin-aarch64" ;;
-"Linux aarch64")
-    echo "Error: Official SilverBullet builds for Linux aarch64 are not available." 1>&2
-    exit 1
-    ;;
+"Linux arm64") target="linux-aarch64" ;;
 *) target="linux-x86_64" ;;
 esac
 


### PR DESCRIPTION
Since deno version 1.1.41 has been released, [ARM64 architecture for Linux is supported](https://deno.com/blog/v1.41#linux-arm64-support).

This PR proposes to support and provide a binary for this architecture.