### PR TITLE
Fix up validatePageName routine

### DIFF
--- a/plug-api/lib/page_ref.test.ts
+++ b/plug-api/lib/page_ref.test.ts
@@ -30,20 +30,20 @@ Deno.test("Page utility functions", () => {
   // Page name validation
 
   try {
-    validatePageName("perfectly fine page name")
+    validatePageName("perfectly fine page name");
   } catch (error) {
     throw new AssertionError(`Something is very wrong with the validatePageName function: ${error}`);
   }
 
-  assertThrows(() => validatePageName(""), Error)
-  assertThrows(() => validatePageName(".hidden"), Error)
-  assertThrows(() => validatePageName(".."), Error)
+  assertThrows(() => validatePageName(""), Error);
+  assertThrows(() => validatePageName(".hidden"), Error);
+  assertThrows(() => validatePageName(".."), Error);
 
   for (let extension in ["md", "txt", "exe", "cc", "ts"]) {
-    assertThrows(() => validatePageName(`extensions-are-not-welcome.${extension}`), Error)
+    assertThrows(() => validatePageName(`extensions-are-not-welcome.${extension}`), Error);
   }
 
   for (let extension in ["db2", "woff2", "sqlite3", "42", "0"]) {
-    assertThrows(() => validatePageName(`extensions-can-contain-numbers-too.${extension}`), Error)
+    assertThrows(() => validatePageName(`extensions-can-contain-numbers-too.${extension}`), Error);
   }
 });

--- a/plug-api/lib/page_ref.test.ts
+++ b/plug-api/lib/page_ref.test.ts
@@ -1,5 +1,5 @@
 import { encodePageRef, parsePageRef, validatePageName } from "./page_ref.ts";
-import { assert, assertEquals, assertThrows, AssertionError } from "$std/testing/asserts.ts";
+import { assertEquals, assertThrows, AssertionError } from "$std/testing/asserts.ts";
 
 Deno.test("Page utility functions", () => {
   // Base cases
@@ -39,11 +39,11 @@ Deno.test("Page utility functions", () => {
   assertThrows(() => validatePageName(".hidden"), Error);
   assertThrows(() => validatePageName(".."), Error);
 
-  for (let extension in ["md", "txt", "exe", "cc", "ts"]) {
+  for (const extension of ["md", "txt", "exe", "cc", "ts"]) {
     assertThrows(() => validatePageName(`extensions-are-not-welcome.${extension}`), Error);
   }
 
-  for (let extension in ["db2", "woff2", "sqlite3", "42", "0"]) {
+  for (const extension of ["db2", "woff2", "sqlite3", "42", "0"]) {
     assertThrows(() => validatePageName(`extensions-can-contain-numbers-too.${extension}`), Error);
   }
 });

--- a/plug-api/lib/page_ref.test.ts
+++ b/plug-api/lib/page_ref.test.ts
@@ -30,7 +30,7 @@ Deno.test("Page utility functions", () => {
   // Page name validation
 
   try {
-    validatePageName("perfecty fine page name")
+    validatePageName("perfectly fine page name")
   } catch (error) {
     throw new AssertionError(`Something is very wrong with the validatePageName function: ${error}`);
   }
@@ -43,7 +43,7 @@ Deno.test("Page utility functions", () => {
     assertThrows(() => validatePageName(`extensions-are-not-welcome.${extension}`), Error)
   }
 
-  for (let extension in ["db2", "woff2", "sqlite3"]) {
+  for (let extension in ["db2", "woff2", "sqlite3", "42", "0"]) {
     assertThrows(() => validatePageName(`extensions-can-contain-numbers-too.${extension}`), Error)
   }
 });

--- a/plug-api/lib/page_ref.test.ts
+++ b/plug-api/lib/page_ref.test.ts
@@ -1,5 +1,5 @@
-import { encodePageRef, parsePageRef } from "./page_ref.ts";
-import { assertEquals } from "$std/testing/asserts.ts";
+import { encodePageRef, parsePageRef, validatePageName } from "./page_ref.ts";
+import { assert, assertEquals, assertThrows, AssertionError } from "$std/testing/asserts.ts";
 
 Deno.test("Page utility functions", () => {
   // Base cases
@@ -26,4 +26,24 @@ Deno.test("Page utility functions", () => {
   assertEquals(encodePageRef({ page: "foo", pos: 10 }), "foo@10");
   assertEquals(encodePageRef({ page: "foo", anchor: "bar" }), "foo$bar");
   assertEquals(encodePageRef({ page: "foo", header: "bar" }), "foo#bar");
+
+  // Page name validation
+
+  try {
+    validatePageName("perfecty fine page name")
+  } catch (error) {
+    throw new AssertionError(`Something is very wrong with the validatePageName function: ${error}`);
+  }
+
+  assertThrows(() => validatePageName(""), Error)
+  assertThrows(() => validatePageName(".hidden"), Error)
+  assertThrows(() => validatePageName(".."), Error)
+
+  for (let extension in ["md", "txt", "exe", "cc", "ts"]) {
+    assertThrows(() => validatePageName(`extensions-are-not-welcome.${extension}`), Error)
+  }
+
+  for (let extension in ["db2", "woff2", "sqlite3"]) {
+    assertThrows(() => validatePageName(`extensions-can-contain-numbers-too.${extension}`), Error)
+  }
 });

--- a/plug-api/lib/page_ref.ts
+++ b/plug-api/lib/page_ref.ts
@@ -6,7 +6,7 @@ export function validatePageName(name: string) {
   if (name.startsWith(".")) {
     throw new Error("Page name cannot start with a '.'");
   }
-  if (/\.[a-zA-Z]+$/.test(name)) {
+  if (/\.[a-zA-Z0-9]+$/.test(name)) {
     throw new Error("Page name can not end with a file extension");
   }
 }


### PR DESCRIPTION
File extensions can contain numbers too.
My main motivation was to enable myself hosting `woff2` files right from my space, like I do for `ttf` files.

Also added some tests.