### PR TITLE
Follow-up for parsing YAML dates

### DIFF
--- a/plug-api/lib/json.test.ts
+++ b/plug-api/lib/json.test.ts
@@ -18,4 +18,6 @@ Deno.test("utils", () => {
   assertEquals(cleanupJSON({ a: [{ "a.b": 1 }] }), {
     a: [{ a: { b: 1 } }],
   });
+  assertEquals(cleanupJSON(new Date("2023-05-13T12:30:00Z")), "2023-05-13T12:30:00.000Z");
+  assertEquals(cleanupJSON(new Date("2023-05-03T00:00:00Z")), "2023-05-03");
 });

--- a/plug-api/lib/json.ts
+++ b/plug-api/lib/json.ts
@@ -36,20 +36,13 @@ export function deepEqual(a: any, b: any): boolean {
 
 // Converts a Date object to a date string in the format YYYY-MM-DD if it just contains a date (and no significant time), or a full ISO string otherwise
 export function cleanStringDate(d: Date): string {
-  function pad(n: number) {
-    let s = String(n);
-    if (s.length === 1) {
-      s = "0" + s;
-    }
-    return s;
-  }
-
   // If no significant time, return a date string only
   if (
     d.getUTCHours() === 0 && d.getUTCMinutes() === 0 && d.getUTCSeconds() === 0
   ) {
-    return d.getFullYear() + "-" + pad(d.getMonth() + 1) + "-" +
-      pad(d.getDate());
+    return d.getFullYear() + "-" +
+      String(d.getMonth() + 1).padStart(2, "0") + "-" +
+      String(d.getDate()).padStart(2, "0");
   } else {
     return d.toISOString();
   }


### PR DESCRIPTION
Small follow-up commit for https://github.com/silverbulletmd/silverbullet/commit/2eb7e25854000090bdb3a8729aed3c3c1f06e381#

- removes `pad` function in favour of `String.prototype.padStart`
- adds test cases for the date formatting

Thank you @zefhemel for not only taking the time to respond but also to fix a small bug in date parsing (discussion here https://community.silverbullet.md/t/struggling-with-yaml-frontmatter-date-attribute-and-date-comparison-query-in-silverbullet/454/13)

I thought I would also thank you for putting some of my time in. Let me know if this looks OK or if you want me to make any changes.

Since this is a pure refactoring, there doesn't have to be any CHANGELOG entry 👍 