### PR TITLE
Check only the primary pointing device's accuracy

### DIFF
--- a/web/reducer.ts
+++ b/web/reducer.ts
@@ -19,7 +19,7 @@ export default function reducer(
         },
       };
     case "page-loaded": {
-      const mouseDetected = window.matchMedia("(any-pointer:fine)").matches;
+      const mouseDetected = window.matchMedia("(pointer:fine)").matches;
       return {
         ...state,
         isLoading: false,


### PR DESCRIPTION
This pull request changes `mouseDetected` to check only the primary pointing device and retains the existing logic.

I tested this change on my physical Samsung phone and a few different emulated iPhones in Firefox DevTools.

**Context**: I couldn't get the mobile-only buttons (including read-only mode) to appear in Firefox for Android, DuckDuckGo, or Samsung Internet on a Samsung Galaxy S22. `any-pointer:fine` evaluates to `true` even though I don't have a mouse connected. Based on [this article](https://www.ctrl.blog/entry/css-media-hover-samsung.html), Samsung devices might be reporting the presence of both a touchscreen and a nonexistent touchpad.

I also tried various combinations of `any-hover:hover`, `hover:hover`, `pointer:fine`, and `any-pointer:fine`.
* For some reason, `const mouseDetected = window.matchMedia("(hover:hover) and (any-pointer:fine)").matches;` worked in Firefox for Android but not other browsers.
* `const mouseDetected = window.matchMedia("(hover:hover) and (pointer:fine)").matches;` worked but `pointer:fine` by itself already works.
* No change with `any-hover:hover` by itself or other combinations