### PR TITLE
WIP: Quick and dirty fix for the ".conflicted." pages navigation issue

### DIFF
--- a/plug-api/lib/page_ref.test.ts
+++ b/plug-api/lib/page_ref.test.ts
@@ -31,6 +31,7 @@ Deno.test("Page utility functions", () => {
 
   try {
     validatePageName("perfectly fine page name");
+    validatePageName("this is special case of a.conflicted.page")
   } catch (error) {
     throw new AssertionError(`Something is very wrong with the validatePageName function: ${error}`);
   }

--- a/plug-api/lib/page_ref.ts
+++ b/plug-api/lib/page_ref.ts
@@ -1,3 +1,24 @@
+
+/** 
+ * Possible HACK.
+ * 
+ * Normally we don't want to allow pages have dots in their names,
+ * because we need to serve files with extensions. But there are special cases like
+ * "conflicted" pages. Maybe there will be some more special cases in future. This 
+ * is why this function exists.
+ * 
+ */
+export function isThisPageSpecial(name: string): boolean {
+  const namePatterns: RegExp[] = [
+    /\.conflicted\./
+  ];
+  return namePatterns.some(expr => expr.test(name));
+}
+
+export function looksLikeFileName(name: string): boolean {
+  return /\.[a-zA-Z0-9]+$/.test(name) && !isThisPageSpecial(name)
+}
+
 export function validatePageName(name: string) {
   // Page can not be empty and not end with a file extension (e.g. "bla.md")
   if (name === "") {
@@ -6,7 +27,7 @@ export function validatePageName(name: string) {
   if (name.startsWith(".")) {
     throw new Error("Page name cannot start with a '.'");
   }
-  if (/\.[a-zA-Z0-9]+$/.test(name)) {
+  if (looksLikeFileName(name)) {
     throw new Error("Page name can not end with a file extension");
   }
 }


### PR DESCRIPTION
This will allow user to Ctrl-K to conflicted page, but refreshing the page still gives 404.

Input is much appreciated