### PR TITLE
Fix blank space above tables issue

### DIFF
--- a/plugs/markdown/markdown_render.ts
+++ b/plugs/markdown/markdown_render.ts
@@ -437,7 +437,7 @@ function render(
         body: [
           {
             name: "tr",
-            body: cleanTags(mapRender(t.children!)),
+            body: cleanTags(mapRender(t.children!), true),
           },
         ],
       };
@@ -470,7 +470,7 @@ function render(
       }
       return {
         name: "tr",
-        body: cleanTags(mapRender(newChildren)),
+        body: cleanTags(mapRender(newChildren), true),
       };
     }
     case "Attribute":


### PR DESCRIPTION
Fix issue 
- https://github.com/silverbulletmd/silverbullet/issues/793
- https://github.com/silverbulletmd/silverbullet/issues/936 (closed by me because of duplication)

For the same markdown I used, it renders correctly.
```
# Title
|Header1                             |Header2                                              |
|---                                 |---                                                  |
|123                                 |456                                                  |
|123                                 |456                                                  |
```

![image](https://github.com/user-attachments/assets/8edb2a2d-fa8a-4ffb-8a16-39f06d20ec09)
