### PR TITLE
Add setting for smart quotes

### DIFF
--- a/type/web.ts
+++ b/type/web.ts
@@ -18,6 +18,7 @@ export type BuiltinSettings = {
   shortcuts?: Shortcut[];
   hideSyncButton?: boolean;
   hideEditButton?: boolean;
+  useSmartQuotes?: boolean;
   maximumAttachmentSize?: number;
   defaultLinkStyle?: string;
   actionButtons: ActionButton[];

--- a/web/cm_plugins/smart_quotes.ts
+++ b/web/cm_plugins/smart_quotes.ts
@@ -1,6 +1,7 @@
 import { KeyBinding } from "@codemirror/view";
 import { syntaxTree } from "@codemirror/language";
 import { EditorSelection } from "@codemirror/state";
+import { Client } from "../client.ts";
 
 const straightQuoteContexts = [
   "CommentBlock",
@@ -78,7 +79,13 @@ function keyBindingForQuote(
   };
 }
 
-export const smartQuoteKeymap: KeyBinding[] = [
-  keyBindingForQuote('"', "“", "”"),
-  keyBindingForQuote("'", "‘", "’"),
-];
+export function createSmartQuoteKeyBindings(client: Client): KeyBinding[] {
+  if (client.settings.useSmartQuotes === false) {
+    return [];
+  }
+
+  return [
+    keyBindingForQuote('"', "“", "”"),
+    keyBindingForQuote("'", "‘", "’"),
+  ];
+}

--- a/web/editor_state.ts
+++ b/web/editor_state.ts
@@ -30,7 +30,7 @@ import { Client } from "./client.ts";
 import { inlineImagesPlugin } from "./cm_plugins/inline_content.ts";
 import { cleanModePlugins } from "./cm_plugins/clean.ts";
 import { lineWrapper } from "./cm_plugins/line_wrapper.ts";
-import { smartQuoteKeymap } from "./cm_plugins/smart_quotes.ts";
+import { createSmartQuoteKeyBindings } from "./cm_plugins/smart_quotes.ts";
 import { ClickEvent } from "../plug-api/types.ts";
 import {
   attachmentExtension,
@@ -345,7 +345,7 @@ export function createCommandKeyBindings(client: Client): KeyBinding[] {
 export function createKeyBindings(client: Client): Extension {
   return keymap.of([
     ...createCommandKeyBindings(client),
-    ...smartQuoteKeymap,
+    ...createSmartQuoteKeyBindings(client),
     ...closeBracketsKeymap,
     ...standardKeymap,
     ...completionKeymap,

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -1,6 +1,6 @@
 #meta
 
-This page contains settings for configuring SilverBullet and its Plugs. Changing any of these will go into effect immediately in most cases except `indexPage` which requires a page reload.
+This page contains settings for configuring SilverBullet and its Plugs. Changing any of these will go into effect immediately in most cases, some require a page reload.
 
 ```yaml
 # Initial page to load when launching SB, can contain template variables
@@ -59,6 +59,9 @@ shortcuts:
 pageDecorations:
 - where: 'tags = "plug"'
   prefix: "🔌 "
+
+# Toggles between “smart” ‘quotes’ (left and right) and "simple" 'quotes' (good ol' ASCII)
+useSmartQuotes: true
 
 # Defines files to ignore in a format compatible with .gitignore
 spaceIgnore: |


### PR DESCRIPTION
As discussed in [Unwanted Unicode quotation marks - Troubleshooting - SilverBullet Community](https://community.silverbullet.md/t/unwanted-unicode-quotation-marks/669)

**Needs a refresh for the setting to take effect.** I noticed that syscalls don't work in the `web` folder, so I reworked the array into function like `createCommandKeyBindings`.

I don't know nice ways to save the reference to client and check the current setting when the shortcut is triggered ¿I would use `var` to save reference to client inside the function? I don't know...

If we accept that this needs a reload, I could make it a bit simpler.
