### PR TITLE
Auto complete folder in Page Picker

### DIFF
--- a/web/components/filter.tsx
+++ b/web/components/filter.tsx
@@ -160,7 +160,15 @@ export function FilterList({
                 return true;
               case " ": {
                 const text = view.state.sliceDoc();
-                if (completePrefix && text === "") {
+                if (e.shiftKey) {
+                  // Operate on the highlighted option, ignoring prompt
+                  const option = matchingOptions[selectedOption].name;
+                  // Get the folder it's nested in, keeping the trailing /
+                  const folderPath = option.slice(0, option.lastIndexOf("/") + 1);
+                  // If the option wasn't in a folder, make it a folder
+                  setText(folderPath !== "" ? folderPath : option + "/");
+                  return true;
+                } else if (completePrefix && text === "") {
                   setText(completePrefix);
                   // updateFilter(completePrefix);
                   return true;

--- a/website/Page Picker.md
+++ b/website/Page Picker.md
@@ -23,6 +23,9 @@ When entering a filter phrase, the best matches should appear closer to the top,
   * If the currently opened page is nested in a [[Folders|folder]], it will auto complete the current folder name in its place.
   * If the currently opened page name starts with an emoji, it will complete that emoji in its place.
   * Otherwise, it will complete the full page name of the currently open page.
+* `Shift-Space`: auto complete folder from highlighted page:
+  * If the currently highlighted page is nested in a [[Folders|folder]], it will auto complete its folder name
+  * Otherwise, it will auto complete that page name with a `/` added at the end
 * `ArrowUp`/`ArrowDown`: move up and down the highlighted page list
 * `PageUp`/`PageDown`: move up and down 5 entries in the page list in one go
 * `Home`: moves to the start of the list


### PR DESCRIPTION
Add another shortcut to Page Picker to make it easier to create pages in existing folders.

[Started a thread on Community](https://community.silverbullet.md/t/folder-auto-complete/686) to link for the original idea author.