### PR TITLE
Treat Chinese ideograms as separate words

### DIFF
--- a/plugs/search/engine.test.ts
+++ b/plugs/search/engine.test.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from "$std/testing/asserts.ts";
+import { tokenize } from "./engine.ts";
+
+Deno.test("Test search tokenizer", () => {
+  assertEquals(tokenize("two words"), ["two", "words"]);
+  assertEquals(tokenize("Two wOrDs"), ["two", "words"]);
+  assertEquals(
+    tokenize("interpunction, ignored!"),
+    ["interpunction", "ignored"],
+  );
+
+  // Treat each ideogram as a word
+  assertEquals(tokenize("汉字"), ["汉", "字"]); // Chinese
+  assertEquals(tokenize("漢字"), ["漢", "字"]); // Japanese
+
+  assertEquals(tokenize("mix English, 中文 and 日本語"), [
+    "mix",
+    "english",
+    "中",
+    "文",
+    "and",
+    "日",
+    "本",
+    "語",
+  ]);
+});

--- a/plugs/search/engine.ts
+++ b/plugs/search/engine.ts
@@ -9,21 +9,28 @@ type ResultObject = {
 const stopWords = ["and", "or", "the", "a", "an"];
 
 // Tokenize text into words
-function tokenize(text: string): string[] {
-  return text.toLowerCase().split(/[^\p{L}]+/u);
+export function tokenize(text: string): string[] {
+  // Capture group in the regex to both separate on ideograms and keep them
+  // Ideograms identified here with ISO 15924 script: Han (Hanzi, Kanji, Hanja)
+  return text
+    .toLowerCase()
+    .split(/[^\p{L}]+|(\p{Script=Han})/u)
+    .filter((w) => w !== "" && w !== undefined); // filter out separators
 }
 
 // Remove stop words from array of words
 function removeStopWords(words: string[]): string[] {
-  return words.filter((word) =>
-    word.length > 2 &&
-    !stopWords.includes(word) && /^\p{L}+$/u.test(word)
+  return words.filter((word) => ((word.length > 2 &&
+    !stopWords.includes(word) && /^\p{L}+$/u.test(word)) ||
+    /\p{Script=Han}/u.test(word))
   );
 }
 
 // Basic stemming function
 function stem(word: string): string {
-  return stemmer(word);
+  if (/\p{Script=Han}/u.test(word)) {
+    return word;
+  } else return stemmer(word);
 }
 
 // Index an array of documents

--- a/website/Full Text Search.md
+++ b/website/Full Text Search.md
@@ -1,3 +1,8 @@
 While, honestly not amazing, SilverBullet does have full-text search support.
 
 To use it, run the {[Search Space]} command.
+
+## Content indexing
+The pages are searched by full words (as separated by non-letter characters), except Chinese ideograms which are treated each as a separate word. Any other text is normalized to be case-insensitive and various forms (like “word”/“words”) brought together using [Porter Stemming Algorithm](https://tartarus.org/martin/PorterStemmer/).
+
+What constitutes a “Chinese ideogram” is any character of the [Han script in Unicode](https://unicode.org/iso15924/iso15924-codes.html), which includes Chinese Hanzi, Japanese Kanji and Korean Hanja.


### PR DESCRIPTION
As requested on Community: [The Search function does not support Chinese characters - General - SilverBullet Community](https://community.silverbullet.md/t/the-search-function-does-not-support-chinese-characters/367/2), the discussion whether this makes sense or not continues there

Had to `export` the `tokenizer` to write tests in a separate file, is this how it's supposed to be done?