### PR TITLE
Expose determineItemBounds and ensureNewLine from editor plug

### DIFF
--- a/plugs/editor/editor.plug.yaml
+++ b/plugs/editor/editor.plug.yaml
@@ -329,6 +329,12 @@ functions:
       name: "Editor: Find in Page"
       key: "Ctrl-f"
       mac: "Cmd-f"
+  
+  # Outline helper functions
+  determineItemBounds:
+    path: ./outline.ts:determineItemBounds
+  ensureNewLine:
+    path: ./outline.ts:ensureNewLine
 
   # Undo/redo
   undoCommand:

--- a/plugs/editor/outline.ts
+++ b/plugs/editor/outline.ts
@@ -180,7 +180,7 @@ export async function outdentItem() {
   }
 }
 
-function ensureNewLine(s: string) {
+export function ensureNewLine(s: string) {
   if (!s.endsWith("\n")) {
     return s + "\n";
   } else {
@@ -188,7 +188,7 @@ function ensureNewLine(s: string) {
   }
 }
 
-function determineItemBounds(
+export function determineItemBounds(
   text: string,
   pos: number,
   minIndentLevel?: number,


### PR DESCRIPTION
I have a space script where I am using `determineItemBounds` currently, but to use it I had to copy the full function into the space script.

I'd rather expose/export it so that I don't need to duplicate that code.   I tested this and can use it like this:

```
async function refile(targetPage, targetHeading) {
  try {
    const cursorPos = await syscall("editor.getCursor");
    const text = await syscall("editor.getText");
    const currentItemBounds = await syscall("system.invokeFunction", "editor.determineItemBounds", text, cursorPos);
    const currentItemText = text.slice(currentItemBounds.from, currentItemBounds.to);
...
```

Of course, let me know if there's a better way to do it