### PR TITLE
Use aliased preact import in Panel component.

### DIFF
--- a/web/components/panel.tsx
+++ b/web/components/panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "https://esm.sh/preact@10.11.1/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import { Client } from "../client.ts";
 import { PanelConfig } from "../../type/web.ts";
 import { panelHtml } from "./panel_html.ts";


### PR DESCRIPTION
This was causing multiple Preact versions to be imported, creating an error when opening panels. Fixes #986.