### PR TITLE
Improve Plug distribution through GitHub Releases (fix #975)

### DIFF
--- a/website/Plug Management.md
+++ b/website/Plug Management.md
@@ -8,4 +8,4 @@ The [[Plugs/Editor]] plug has support for the following URI prefixes for plugs:
 
 * `https:` loading plugs via HTTPS, e.g. `[https://](https://raw.githubusercontent.com/silverbulletmd/silverbullet-github/main/github.plug.js)`
 * `github:org/repo/file.plug.js` internally rewritten to a `https` url as above.
-* `ghr:org/repo/version` to fetch a plug from a Github release
+* `ghr:org/repo/version` to fetch a plug from a Github release. Will fetch latest version, if it was omitted.

--- a/website/Plugs/Development.md
+++ b/website/Plugs/Development.md
@@ -48,4 +48,6 @@ Once you’re happy with your plug, you can distribute it in various ways:
 - You can put it on github by simply committing the resulting `.plug.js` file there and instructing users to point to by adding
   `- github:yourgithubuser/yourrepo/yourplugname.plug.js` to their `PLUGS` file
 - Add a release in your github repo and instruct users to add the release as `- ghr:yourgithubuser/yourrepo` or if they need a specific release `- ghr:yourgithubuser/yourrepo/release-name`
+  - You need to upload the plug file as asset in the release, with a name matching your repository, e.g, `yourrepo.plug.js`
+  - If your repository name starts with "silverbullet-", like `silverbullet-foo`, both `silverbullet-foo.plug.js` and `foo.plug.js` asset names will be tried
 - You can put it on any other web server, and tell people to load it via https, e.g., `- https://mydomain.com/mypugname.plug.js`.


### PR DESCRIPTION
Summary:
- fixed the problem with `ghr` uri not ending with `.plug.js`
- the release manifest is always downloaded (instead of only doing that for latest) to give more descriptive errors
- since *every* repository in [Plugs#Third-party plugs](https://silverbullet.md/Plugs#Third-party%20plugs) is named with the `silverbullet-` prefix, this is handled and documented