### PR TITLE
Add an in-memory cache of the file list for disk spaces

### DIFF
--- a/common/spaces/disk_space_primitives.ts
+++ b/common/spaces/disk_space_primitives.ts
@@ -17,7 +17,7 @@ const excludedFiles = ["data.db", "data.db-journal", "sync.json"];
 export class DiskSpacePrimitives implements SpacePrimitives {
   rootPath: string;
   fileListCache: FileMeta[] = [];
-  fileListCacheTime: number = 0;
+  fileListCacheTime = 0;
   fileListCacheUpdating: AbortController | null = null;
 
   constructor(rootPath: string) {
@@ -137,7 +137,7 @@ export class DiskSpacePrimitives implements SpacePrimitives {
   }
 
   async fetchFileList(): Promise<FileMeta[]> {
-    console.log("Fetching file list");
+    // console.log("Fetching file list");
     const startTime = performance.now();
 
     // If the file list cache is less than 60 seconds old, return it
@@ -154,7 +154,7 @@ export class DiskSpacePrimitives implements SpacePrimitives {
     const allFiles: FileMeta[] = await this.getFileList();
 
     const endTime = performance.now();
-    console.log("Fetched uncached file list in", endTime - startTime, "ms");
+    console.info("Fetched uncached file list in", endTime - startTime, "ms");
 
     this.fileListCache = allFiles;
     this.fileListCacheTime = startTime;
@@ -207,10 +207,10 @@ export class DiskSpacePrimitives implements SpacePrimitives {
 
       this.fileListCache = allFiles;
       this.fileListCacheTime = performance.now();
-      console.log(
-        "Updated file list cache in background, ",
+      console.info(
+        "Updated file list cache in background:",
         allFiles.length,
-        "files",
+        "files found",
       );
     }).catch((error) => {
       if (abortController.signal.aborted) return;


### PR DESCRIPTION
Related to #947 

_(background note:  my primary sb instance is on a server with a network file system and can be kind of slow when accessing 100s or 1000s of small files)_

Basically this caches the file list in a variable.  

The cache is emptied every time a file is deleted or saved.

Every time fetchFileList is called, the cache is returned if it's less than 1 minute old.  A background sync of the cache is also triggered.  This could be on a timer instead, I'm not sure if it's needed or not?  The client triggers syncs pretty regularly, but if there are no clients connected, I'm not sure if there's a reason to constantly update the file list.

I haven't really tested this much with sync-mode and being offline for an extended period of time, but in my tests so far - /index.json is consistently returned much quicker now.

To test:

- create a new empty directory to use as a space
- create a bunch of files: `for x in `seq 1 5000`;do echo $x;date > testnote-$x.md; done`
- in getFileList(), uncomment `await new Promise((resolve) => setTimeout(resolve, 1));` to cause the file list to take longer