### PR TITLE
Add simple /ping endpoint instead of /index.json, change default fetch timeout to 30s

### DIFF
--- a/common/spaces/http_space_primitives.ts
+++ b/common/spaces/http_space_primitives.ts
@@ -200,7 +200,7 @@ export class HttpSpacePrimitives implements SpacePrimitives {
   // Used to check if the server is reachable and the user is authenticated
   // If not: throws an error or invokes a redirect
   async ping() {
-    await this.authenticatedFetch(`${this.url}/ping`, {
+    await this.authenticatedFetch(`${this.url}/.ping`, {
       method: "GET",
       headers: {
         Accept: "application/json",

--- a/common/spaces/http_space_primitives.ts
+++ b/common/spaces/http_space_primitives.ts
@@ -2,7 +2,7 @@ import type { SpacePrimitives } from "./space_primitives.ts";
 import type { FileMeta } from "../../plug-api/types.ts";
 import { flushCachesAndUnregisterServiceWorker } from "../sw_util.ts";
 
-const fetchTimeout = 5000;
+const defaultFetchTimeout = 30000; // 30 seconds
 
 export class HttpSpacePrimitives implements SpacePrimitives {
   constructor(
@@ -15,6 +15,7 @@ export class HttpSpacePrimitives implements SpacePrimitives {
   public async authenticatedFetch(
     url: string,
     options: RequestInit,
+    fetchTimeout: number = defaultFetchTimeout,
   ): Promise<Response> {
     if (!options.headers) {
       options.headers = {};
@@ -199,11 +200,11 @@ export class HttpSpacePrimitives implements SpacePrimitives {
   // Used to check if the server is reachable and the user is authenticated
   // If not: throws an error or invokes a redirect
   async ping() {
-    await this.authenticatedFetch(`${this.url}/index.json`, {
+    await this.authenticatedFetch(`${this.url}/ping`, {
       method: "GET",
       headers: {
         Accept: "application/json",
       },
-    });
+    }, 5000);
   }
 }

--- a/server/http_server.ts
+++ b/server/http_server.ts
@@ -497,6 +497,13 @@ export class HttpServer {
       }
     });
 
+    // Simple ping health endpoint
+    this.app.get("/ping", (c) => {
+      return c.text("OK", 200, {
+        "Cache-Control": "no-cache",
+      });
+    });
+
     // RPC shell
     this.app.post("/.rpc/shell", async (c) => {
       const req = c.req;

--- a/server/http_server.ts
+++ b/server/http_server.ts
@@ -498,7 +498,7 @@ export class HttpServer {
     });
 
     // Simple ping health endpoint
-    this.app.get("/ping", (c) => {
+    this.app.get("/.ping", (c) => {
       return c.text("OK", 200, {
         "Cache-Control": "no-cache",
       });


### PR DESCRIPTION
related to #947 and #1012 

ping() seems to only be called once when the client first loads, this swaps /index.json for a simple static response from /.ping which shouldn't depend on disk i/o speed and pretty much always return quickly.

Kept this ping timeout at 5s, but changed the default fetch timeout for everything else from 5s to 30s.  ping timeout could probably be even lower.