### PR TITLE
Expose render parse tree to plugs/space scripts

### DIFF
--- a/common/syscalls/markdown.ts
+++ b/common/syscalls/markdown.ts
@@ -1,12 +1,15 @@
 import type { SysCallMapping } from "../../lib/plugos/system.ts";
 import { parse } from "../markdown_parser/parse_tree.ts";
-import type { ParseTree } from "../../plug-api/lib/tree.ts";
+import { type ParseTree, renderToText } from "../../plug-api/lib/tree.ts";
 import { extendedMarkdownLanguage } from "../markdown_parser/parser.ts";
 
 export function markdownSyscalls(): SysCallMapping {
   return {
     "markdown.parseMarkdown": (_ctx, text: string): ParseTree => {
       return parse(extendedMarkdownLanguage, text);
+    },
+    "markdown.renderParseTree": (_ctx, tree: ParseTree): string => {
+      return renderToText(tree);
     },
   };
 }

--- a/plug-api/syscalls/markdown.ts
+++ b/plug-api/syscalls/markdown.ts
@@ -9,3 +9,12 @@ import type { ParseTree } from "../lib/tree.ts";
 export function parseMarkdown(text: string): Promise<ParseTree> {
   return syscall("markdown.parseMarkdown", text);
 }
+
+/**
+ * Renders a ParseTree to markdown.
+ * @param tree the parse tree
+ * @returns the rendered markdown of a passed parse tree
+ */
+export function renderParseTree(tree: ParseTree): Promise<string> {
+  return syscall("markdown.renderParseTree", tree);
+}


### PR DESCRIPTION
We expose `markdown.parseMarkdown` to plugs and space scripts. Why not the reverse direction, too?