### PR TITLE
Fallback to index page if unable to parse the indexPage config option

### DIFF
--- a/server/http_server.ts
+++ b/server/http_server.ts
@@ -246,8 +246,12 @@ export class HttpServer {
         url.pathname === "/"
       ) {
         // Serve the UI (index.html)
-        const indexPage =
-          parsePageRef(this.spaceServer.config?.indexPage!).page;
+        let indexPage = "index";
+        try {
+          indexPage = parsePageRef(this.spaceServer.config?.indexPage!).page;
+        } catch (e: any) {
+          console.error("Error parsing index page from config", e);
+        }
         return this.renderHtmlPage(this.spaceServer, indexPage, c);
       }
       try {


### PR DESCRIPTION
Related to https://github.com/silverbulletmd/silverbullet/issues/1010

While testing, I noticed an invalid `indexPage` value would cause an error like this:

```
TypeError: name.startsWith is not a function
    at parsePageRef (file:///Users/justyns/dev/silverbullet/query-perf/plug-api/lib/page_ref.ts:48:12)
    at file:///Users/justyns/dev/silverbullet/query-perf/server/http_server.ts:250:11
    at dispatch (https://deno.land/x/hono@v3.12.2/compose.ts:45:23)
    at https://deno.land/x/hono@v3.12.2/compose.ts:18:12
    at https://deno.land/x/hono@v3.12.2/hono-base.ts:338:31
    at Hono.dispatch (https://deno.land/x/hono@v3.12.2/hono-base.ts:348:6)
    at fetch (https://deno.land/x/hono@v3.12.2/hono-base.ts:361:17)
    at ext:deno_http/00_serve.ts:364:24
    at ext:deno_http/00_serve.ts:553:29
    at eventLoopTick (ext:core/01_core.js:168:7)
```

Silverbullet just showed a 500 internal server error too.

There might be another fix, but this just falls back to using 'index' if `parsePageRef` fails.