### PR TITLE
Add spacing to headlines

### DIFF
--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -1,4 +1,4 @@
-@use "./partials/spacing";
+@use "./partials/spacing" as spacing;
 
 .cm-focused {
   outline: none !important;

--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -1,3 +1,5 @@
+@use "./partials/spacing";
+
 .cm-focused {
   outline: none !important;
 }
@@ -23,6 +25,8 @@
     &.sb-line-h4,
     &.sb-line-h5,
     &.sb-line-h6 {
+      @include spacing.headline;
+
       font-weight: bold;
       padding: 2px;
     }
@@ -58,6 +62,8 @@
 
   // If a header only contains a tag, it's likely a line containging "#" which may turn into a hashtag, so style it as such instead of a header
   .sb-line-h1:has(> span.sb-hashtag:only-child) {
+    margin-block: 0;
+
     font-size: 1em;
     padding: 0;
     font-weight: normal;
@@ -352,7 +358,7 @@
   }
 
   .sb-task-deadline {
-    background-color: rgba(22, 22, 22, 0.07)
+    background-color: rgba(22, 22, 22, 0.07);
   }
 
   .sb-line-frontmatter-outside,
@@ -411,7 +417,6 @@
     padding: 8px;
     white-space: nowrap;
   }
-
 
   // dont apply background color twice for (fenced) code blocks
   .sb-line-code .sb-code {
@@ -584,7 +589,6 @@
       button:last-of-type {
         margin-right: 2px;
       }
-
     }
   }
 

--- a/web/styles/main.scss
+++ b/web/styles/main.scss
@@ -1,4 +1,4 @@
-@use "./partials/spacing";
+@use "./partials/spacing" as spacing;
 @use "editor";
 @use "modals";
 @use "theme";

--- a/web/styles/main.scss
+++ b/web/styles/main.scss
@@ -1,3 +1,4 @@
+@use "./partials/spacing";
 @use "editor";
 @use "modals";
 @use "theme";
@@ -225,5 +226,16 @@ body {
     height: 100%;
     padding: 0;
     margin: 0;
+  }
+}
+
+.sb-preview {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @include spacing.headline;
   }
 }

--- a/web/styles/partials/_spacing.scss
+++ b/web/styles/partials/_spacing.scss
@@ -1,0 +1,3 @@
+@mixin headline {
+  margin-block: 1.2em 0.2em;
+}


### PR DESCRIPTION
Block direction margin has been added to headlines in this PR to improve the readability and visual structure, especially in large text documents.

I chose to use the `em` unit for the margin to be relative to each headline font size.

Hope it is okay that I added the spacing values to a separate partial. Did that so that there is one place of truth which needs to be edited if these should be changed in the future.

Also let's talk about the values if they feel off. I tried to get a good compromise without adding "handcrafted" margins to each headline separately.