### PR TITLE
Fix diffAndPrepareChanges

### DIFF
--- a/web/cm_util.ts
+++ b/web/cm_util.ts
@@ -1,4 +1,4 @@
-import diff, { DELETE, INSERT } from "fast-diff";
+import diff, { DELETE, EQUAL, INSERT } from "fast-diff";
 import type { ChangeSpec } from "@codemirror/state";
 
 export function diffAndPrepareChanges(
@@ -14,10 +14,12 @@ export function diffAndPrepareChanges(
   for (const part of diffs) {
     if (part[0] === INSERT) {
       changes.push({ from: startIndex, insert: part[1] });
+    } else if (part[0] === EQUAL) {
+      startIndex += part[1].length;
     } else if (part[0] === DELETE) {
       changes.push({ from: startIndex, to: startIndex + part[1].length });
+      startIndex += part[1].length;
     }
-    startIndex += part[1].length;
   }
   return changes;
 }


### PR DESCRIPTION
I found some erratic behavior when using editor.setText() that seems to be caused by the underlying `diffAndPrepareChanges`. To test this, I've set up this test page content:

```
This is a page with several lines.

This is one of the lines.

This is another one of the lines.
```

And a space-script that updates it:

```
silverbullet.registerCommand({name:'Test Command'}, async() => {
  await editor.setText(`I've modified this line.

This is one of the lines.

And also this line.`);
});
```

Running the command with this text results in:

```
Error running command Invalid change range 90 to 101 (in doc of length 98)
```

If I modify the new string to:

```
This is a cage with several lines.

This is one of the lines.

With another one of the lines.
```

It becomes more clear what's going on because after running the command:

```
This is a page with several lines.

This is one of the lines.

This is another one of the lines.
-----
Apply:
Array [ 0, "This is a " ]
Array [ -1, "p" ]
Array [ 1, "c" ]
Array [ 0, "age with several lines.\n\nThis is one of the lines.\n\n" ]
Array [ -1, "T" ]
Array [ 1, "Wit" ]
-----
This is a cage with several lines.

This is one of the lines.

TWitis is another one of the lines.
-----
Apply:
Array [ 0, "h" ]
Array [ -1, "is is" ]
Array [ 0, " another one of the lines." ]
-----
This is a cage with several lines.

This is one of the lines.

TWitis ither one of the lines.
```

It seems to be because CodeMirror expects that from/to on changes should be on the index *of the existing page content*, not on the changed content. So, I initially updated the code to pair up deletions/insertions and move the startIndex by the deleted text content instead. Insertions that don't have a paired deletion won't move the startIndex at all. But then I realized, that's exactly the same as simply not moving startIndex on inserts, so I did that instead. To retest, I changed the new string to:

```
This is a cage with several lines.

This is one of the lines.

With another one of the grinds.
```

Just so I can see if later changes are also affected, and now it works correctly.