### PR TITLE
Use setText instead of replacing entire editor state

### DIFF
--- a/web/client.ts
+++ b/web/client.ts
@@ -75,6 +75,7 @@ import { lezerToParseTree } from "$common/markdown_parser/parse_tree.ts";
 import { findNodeMatching } from "@silverbulletmd/silverbullet/lib/tree";
 import type { LinkObject } from "../plugs/index/page_links.ts";
 import type { Config, ConfigContainer } from "../type/config.ts";
+import { editor } from "@silverbulletmd/silverbullet/syscalls";
 
 const frontMatterRegex = /^---\n(([^\n]|\n)*?)---\n/;
 
@@ -1131,17 +1132,21 @@ export class Client implements ConfigContainer {
       });
     }).catch(console.error);
 
-    const editorState = createEditorState(
-      this,
-      pageName,
-      doc.text,
-      doc.meta.perm === "ro",
-    );
-    editorView.setState(editorState);
-    if (editorView.contentDOM) {
-      this.tweakEditorDOM(editorView.contentDOM);
+    if (loadingDifferentPage) {
+      const editorState = createEditorState(
+        this,
+        pageName,
+        doc.text,
+        doc.meta.perm === "ro",
+      );
+      editorView.setState(editorState);
+      if (editorView.contentDOM) {
+        this.tweakEditorDOM(editorView.contentDOM);
+      }
+      this.space.watchPage(pageName);
+    } else {
+      await editor.setText(doc.text);
     }
-    this.space.watchPage(pageName);
 
     // Note: these events are dispatched asynchronously deliberately (not waiting for results)
     if (loadingDifferentPage) {

--- a/web/cm_util.ts
+++ b/web/cm_util.ts
@@ -1,4 +1,4 @@
-import diff, { DELETE, INSERT } from "fast-diff";
+import diff, { DELETE, EQUAL, INSERT } from "fast-diff";
 import type { ChangeSpec } from "@codemirror/state";
 
 export function diffAndPrepareChanges(
@@ -14,10 +14,12 @@ export function diffAndPrepareChanges(
   for (const part of diffs) {
     if (part[0] === INSERT) {
       changes.push({ from: startIndex, insert: part[1] });
+    } else if (part[0] === EQUAL) {
+      startIndex += part[1].length;
     } else if (part[0] === DELETE) {
       changes.push({ from: startIndex, to: startIndex + part[1].length });
+      startIndex += part[1].length;
     }
-    startIndex += part[1].length;
   }
   return changes;
 }

--- a/web/syscalls/editor.ts
+++ b/web/syscalls/editor.ts
@@ -6,7 +6,7 @@ import {
   unfoldAll,
   unfoldCode,
 } from "@codemirror/language";
-import { deleteLine, redo, undo } from "@codemirror/commands";
+import { deleteLine, isolateHistory, redo, undo } from "@codemirror/commands";
 import type { Transaction } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { getCM as vimGetCm, Vim } from "@replit/codemirror-vim";
@@ -30,6 +30,7 @@ export function editorSyscalls(client: Client): SysCallMapping {
       const allChanges = diffAndPrepareChanges(currentText, newText);
       client.editorView.dispatch({
         changes: allChanges,
+        annotations: isolateHistory.of("full"),
       });
     },
     "editor.getCursor": (): number => {


### PR DESCRIPTION
Piggy-backing off of #1055, this PR uses `editor.setText()` instead of creating an entirely new `editorState` when new changes are received from the server. It's maybe not the most elegant solution but until there is a better one, this at least lets you keep typing away and keeps your cursor position when new changes are retrieved. I've also updated the editor.setText() to be an isolated transaction, this way when you lose your local changes you can undo to get them back then redo to get the server changes in.