### PR TITLE
Docs fix

### DIFF
--- a/website/Expression Language.md
+++ b/website/Expression Language.md
@@ -95,7 +95,7 @@ Simple boolean expression: {{"pete" = "pete" or "hank" = "pete"}}
 * `in` member of a list (e.g. `prop in ["foo", "bar"]`)
 * `+` addition (can also concatenate strings), e.g. `10 + 12` or `name + "!!!"`
 * `-` subtraction, e.g. `10 - 12`
-* `/` addition, e.g. `10 / 12`
+* `/` division, e.g. `10 / 12`
 * `*` multiplication, e.g. `10 * 12`
 * `%` modulo, e.g. `10 % 12`
 * `not <expression>` or `!<expression>` to negate the truthiness value


### PR DESCRIPTION
In expressions, "/" was described as "addition" rather than "division"
Note that "arithmatic" was left unchanged but could be a typo of "arithmetic"