### PR TITLE
Export PDF through print.

### DIFF
--- a/plugs/markdown/preview.ts
+++ b/plugs/markdown/preview.ts
@@ -53,18 +53,16 @@ export async function updateMarkdownPreview() {
 }
 
 function renderToolbar(): string {
-  const printerIcon =
-    `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-        viewBox="0 0 24 24" fill="none" stroke="currentColor"
-        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-        class="feather feather-printer">
-      <polyline points="6 9 6 2 18 2 18 9"/>
-      <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/>
-      <rect x="6" y="14" width="12" height="8"/>
-     </svg>`;
   return `<div class="sb-markdown-toolbar">
-            <button onClick="(function(){window.print()})()">
-              ${printerIcon}
+            <button onClick="window.print()">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                  viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                  stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                  class="feather feather-printer">
+                <polyline points="6 9 6 2 18 2 18 9"/>
+                <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/>
+                <rect x="6" y="14" width="12" height="8"/>
+              </svg>
             </button>
           </div>`;
 }

--- a/plugs/markdown/preview.ts
+++ b/plugs/markdown/preview.ts
@@ -35,6 +35,7 @@ export async function updateMarkdownPreview() {
     },
   });
   const customStyles = await editor.getUiOption("customStyles");
+  const toolbar = renderToolbar();
   await editor.showPanel(
     "rhs",
     2,
@@ -45,10 +46,27 @@ export async function updateMarkdownPreview() {
         ${customStyles ?? ""}
       </style>
 
-      <div id="root" class="sb-preview">${html}</div>
+      <div id="root" class="sb-preview">${toolbar}${html}</div>
     `,
     js,
   );
+}
+
+function renderToolbar(): string {
+  const printerIcon =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+        viewBox="0 0 24 24" fill="none" stroke="currentColor"
+        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+        class="feather feather-printer">
+      <polyline points="6 9 6 2 18 2 18 9"/>
+      <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/>
+      <rect x="6" y="14" width="12" height="8"/>
+     </svg>`;
+  return `<div class="sb-markdown-toolbar">
+            <button onClick="(function(){window.print()})()">
+              ${printerIcon}
+            </button>
+          </div>`;
 }
 
 export async function previewClickHandler(e: any) {

--- a/web/styles/main.scss
+++ b/web/styles/main.scss
@@ -227,3 +227,21 @@ body {
     margin: 0;
   }
 }
+
+.sb-preview {
+  position: relative;
+}
+
+.sb-markdown-toolbar {
+  position: absolute;
+  opacity: 0;
+  transition: opacity 0.2s;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  box-sizing: border-box;
+}
+
+.sb-markdown-toolbar:hover {
+  opacity: 1;
+}


### PR DESCRIPTION
This resolves https://github.com/silverbulletmd/silverbullet/issues/635, sort of...

Usually when I export a page to PDF, I print the current page. This doesn't work in Silverbullet since panels are embedded in iframes. In Firefox, using default print will only print current screen(as shown below).

<img width="1056" alt="SCR-20240826-tzjt-2" src="https://github.com/user-attachments/assets/bad0989d-046b-420e-91ee-a300967580dd">

This PR tries to solve this with a few lines of hacks.

<img width="1054" alt="SCR-20240826-ualn-2" src="https://github.com/user-attachments/assets/a1c6257d-0ec2-4d3b-a71e-f49cd4d5e03b">

However I'm not sure if this is the best way to solve the problem, so I set this PR to draft. Here are a few thoughts.

1. This PR will add a Printer button to all panels. Though it doesn't bother me , I don't think this behavior is expected by everyone. A better way could be adding a command "Markdown: Print" in markdown plug. But DOM is not accessible in web workers. Besides I need to find a way to pass around the ref to panel.
2. Another way is to create a plugin and use some third-party html2pdf libs like https://github.com/parallax/jsPDF. 
- Pros: we can have more control over what could be exported. For example, not exporting internal links.
- Cons: involves importing third-party dependencies, which I'm not sure how it can be done in plugs yet. 
3. I noticed that you mentioned using pandoc in the issue.
- Pros: pandoc could support more formats.
- Cons: 
   1. Have to be supported by server side. 
   2. I think there is no simple way to add native dependencies to silverbullet besides modifying Dockerfile?

Could you give me some suggestions? Thanks!