### PR TITLE
Mark the page as changed on setText

### DIFF
--- a/web/syscalls/editor.ts
+++ b/web/syscalls/editor.ts
@@ -32,6 +32,8 @@ export function editorSyscalls(client: Client): SysCallMapping {
         changes: allChanges,
         annotations: isolateHistory.of("full"),
       });
+      client.ui.viewDispatch({ type: "page-changed" });
+      client.save();
     },
     "editor.getCursor": (): number => {
       return client.editorView.state.selection.main.from;


### PR DESCRIPTION
I noticed an issue where the syscall editor.setText() would not cause the page to save. In fact, it doesn't mark the page as changed at all, which means navigating away from the page wouldn't even trigger the save since it won't save unless there are changes:

web/client.ts line 660:
```ts
            if (
              !this.ui.viewState.unsavedChanges ||
              this.ui.viewState.uiOptions.forcedROMode
            ) {
```

This means that even the "Remove Completed Tasks" function from the tasks plug will lose its changes if you navigate away. Only thing I'm not totally sure about here is whether we should also include this client.save() call or just let it be handled either manually by the userdev or by the auto-save but then that won't trigger until the page is navigated away from.