### PR TITLE
Add settings to configure auto close brackets

### DIFF
--- a/type/config.ts
+++ b/type/config.ts
@@ -43,6 +43,7 @@ export type Config = {
   // Format: compatible with docker ignore
   spaceIgnore?: string;
   emoji?: EmojiConfig;
+  autoCloseBrackets: string;
 
   schema: SchemaConfig;
 
@@ -64,6 +65,7 @@ export const defaultConfig: Config = {
   maximumAttachmentSize: 10, // MiB
   defaultLinkStyle: "wikilink", // wikilink [[]] or markdown []()
   actionButtons: [], // Actually defaults to defaultActionButtons
+  autoCloseBrackets: "([{`",
 
   schema: {
     config: {

--- a/web/editor_state.ts
+++ b/web/editor_state.ts
@@ -100,7 +100,9 @@ export function createEditorState(
         addKeymap: true,
       }),
       extendedMarkdownLanguage.data.of({
-        closeBrackets: { brackets: ["(", "{", "[", "`"] },
+        closeBrackets: {
+          brackets: client.config?.autoCloseBrackets.split(""),
+        },
       }),
       syntaxHighlighting(customMarkdownStyle()),
       autocompletion({

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -58,6 +58,8 @@ shortcuts:
 
 # Toggles between “smart” ‘quotes’ (left and right) and "simple" 'quotes' (good ol' ASCII)
 useSmartQuotes: true
+# Choose which characters to auto-close
+autoCloseBrackets: "([{`"
 
 # Defines files to ignore in a format compatible with .gitignore
 spaceIgnore: |


### PR DESCRIPTION
This PR creates a `autoCloseBrackets` setting that allows to configure which brackets to automatic close (or to set it empty to disable auto-closing)