### PR TITLE
Space config for smart quotes (close #1114)

### DIFF
--- a/type/client.ts
+++ b/type/client.ts
@@ -39,3 +39,9 @@ export type ActionButton = {
 export type EmojiConfig = {
   aliases: string[][];
 };
+
+export type SmartQuotesConfig = {
+  enabled?: boolean;
+  double?: { left?: string; right?: string };
+  single?: { left?: string; right?: string };
+};

--- a/type/config.ts
+++ b/type/config.ts
@@ -1,4 +1,9 @@
-import type { ActionButton, EmojiConfig, Shortcut } from "./client.ts";
+import type {
+  ActionButton,
+  EmojiConfig,
+  Shortcut,
+  SmartQuotesConfig,
+} from "./client.ts";
 
 export interface ConfigContainer {
   config: Config;
@@ -30,6 +35,7 @@ export type LibraryDef = {
 export type Config = {
   indexPage: string;
   shortcuts?: Shortcut[];
+  // DEPRECATED: Use smartQuotes instead
   useSmartQuotes?: boolean;
   maximumAttachmentSize?: number;
   libraries?: LibraryDef[];
@@ -44,6 +50,7 @@ export type Config = {
   spaceIgnore?: string;
   emoji?: EmojiConfig;
   autoCloseBrackets: string;
+  smartQuotes?: SmartQuotesConfig;
 
   schema: SchemaConfig;
 

--- a/web/cm_plugins/smart_quotes.ts
+++ b/web/cm_plugins/smart_quotes.ts
@@ -81,12 +81,36 @@ function keyBindingForQuote(
 }
 
 export function createSmartQuoteKeyBindings(client: Client): KeyBinding[] {
-  if (client.config?.useSmartQuotes === false) {
+  // Also check the deprecated useSmartQuotes, default is true so either can disable
+  if (
+    client.config?.useSmartQuotes === false ||
+    client.config?.smartQuotes?.enabled === false
+  ) {
     return [];
   }
 
+  let doubleLeft = "“";
+  let doubleRight = "”";
+  let singleLeft = "‘";
+  let singleRight = "’";
+  const config = client.config?.smartQuotes;
+  if (config) {
+    if (typeof config.double?.left === "string") {
+      doubleLeft = config.double!.left;
+    }
+    if (typeof config.double?.right === "string") {
+      doubleRight = config.double!.right;
+    }
+    if (typeof config.single?.left === "string") {
+      singleLeft = config.single!.left;
+    }
+    if (typeof config.single?.right === "string") {
+      singleRight = config.single!.right;
+    }
+  }
+
   return [
-    keyBindingForQuote('"', "“", "”"),
-    keyBindingForQuote("'", "‘", "’"),
+    keyBindingForQuote('"', doubleLeft, doubleRight),
+    keyBindingForQuote("'", singleLeft, singleRight),
   ];
 }

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -56,10 +56,17 @@ shortcuts:
 - command: "{[Upload: File]}"
   priority: 1
 
-# Toggles between “smart” ‘quotes’ (left and right) and "simple" 'quotes' (good ol' ASCII)
-useSmartQuotes: true
 # Choose which characters to auto-close
 autoCloseBrackets: "([{`"
+# Options for “smart” ‘quotes’ (left and right) used outside of code fragments, these are the defaults:
+smartQuotes:
+  enabled: true # Set to false for "simple" 'quotes' (good ol' ASCII)
+  double:
+    left: '“'
+    right: '”'
+  single:
+    left: "‘"
+    right: "’"
 
 # Defines files to ignore in a format compatible with .gitignore
 spaceIgnore: |


### PR DESCRIPTION
Also deprecate `useSmartQuotes` in favour of `smartQuotes.enabled` for more logical hierarchy