### PR TITLE
WIP: Refresh visuals of auth page

### DIFF
--- a/web/auth.html
+++ b/web/auth.html
@@ -76,6 +76,9 @@
     <form action="/.auth" method="POST" id="login">
       <div class="error-message"></div>
       <div>
+        <label for="username">
+          Username
+        </label>
         <input
           type="text"
           name="username"
@@ -84,15 +87,16 @@
           autocorrect="off"
           autocapitalize="off"
           autofocus
-          placeholder="Username"
         />
       </div>
       <div>
+        <label for="password">
+          Password
+        </label>
         <input
           type="password"
           name="password"
           id="password"
-          placeholder="Password"
         />
       </div>
       <div>

--- a/web/auth.html
+++ b/web/auth.html
@@ -9,8 +9,18 @@
     <link rel="icon" type="image/x-icon" href="/favicon.png" />
     <title>Login to SilverBullet</title>
     <style>
-      html,
-      body {
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      * {
+        padding: 0;
+        margin: 0;
+      }
+
+      html {
         font-family:
           -apple-system,
           BlinkMacSystemFont,
@@ -24,88 +34,147 @@
           "Segoe UI Emoji",
           "Segoe UI Symbol",
           "Noto Color Emoji";
-        border: 0;
-        margin: 0;
+        background-color: #fefefe;
+        --primary-button-color: #eee;
+        --primary-button-background-color: #464cfc;
+        --primary-button-hover-background-color: color-mix(
+          in srgb,
+          var(--primary-button-background-color),
+          black 35%
+        );
+        --primary-button-border-color: transparent;
+        --modal-border-color: #6c6c6c;
+        }
+
+      header {
+        position: absolute;
+        padding: 1rem;
+        font-size: 1.2rem;
       }
 
       footer {
-        margin-top: 10px;
-      }
-
-      header {
-        background-color: #e1e1e1;
-        border-bottom: #cacaca 1px solid;
+        text-align: center;
       }
 
       h1 {
-        margin: 0;
-        margin: 0 auto;
-        max-width: 800px;
-        padding: 8px;
-        font-size: 28px;
+        font-size: 1.5rem;
         font-weight: normal;
       }
 
-      form {
-        max-width: 800px;
-        margin: 0 auto;
-        padding: 10px;
-      }
-
       input {
-        font-size: 18px;
+        font-family: inherit;
+        font-size: inherit;
+        padding: 0.5em;
       }
 
       form > div {
-        margin-bottom: 5px;
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+      }
+
+      button {
+        background: var(--primary-button-background-color);
+        color: var(--primary-button-color);
+        box-shadow: 0 0 0.2em rgba(0, 0, 0, 0.05);
+        border: 1px solid var(--border-color);
+        padding: 0.7em;
+        border-radius: 0.5em;
+
+        &:hover {
+          background-color: var(--primary-button-hover-background-color);
+        }
+
+        &:focus {
+          outline: 2px solid var(--primary-button-color);
+          outline-offset: -3px;
+        }
       }
 
       .error-message {
         color: red;
       }
+
+      .center {
+        height: 100vh;
+        display: grid;
+        place-items: center;
+      }
+
+      @media (min-width: 28em) {
+        html {
+          --top-color:  #66A3BB;
+          --bottom-color:  #0B3A69;
+          background: linear-gradient(var(--top-color), var(--bottom-color));
+        }
+
+        .floating-island {
+          padding: 3em;
+          border-radius: 8px;
+          box-shadow: rgba(0, 0, 0, 0.35) 0px 20px 20px;
+          background-color: white;
+          border: var(--modal-border-color) 1px solid;      }
+        }
+      }
+
+      .flow {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+      }
+
+      .flow > * {
+        margin-block: 0;
+      }
+
+      .flow > * + * {
+        margin-block-start: var(--space, 1rem);
+      }
     </style>
   </head>
 
   <body>
-    <header>
+    <div class="center">
+      <div class="flow floating-island">
       <h1>
         Login to <img src="/.client/logo.png" style="height: 1ch" />
         SilverBullet
-      </h1>
-    </header>
-    <form action="/.auth" method="POST" id="login">
-      <div class="error-message"></div>
-      <div>
-        <label for="username">
-          Username
-        </label>
-        <input
-          type="text"
-          name="username"
-          id="username"
-          autocomplete="off"
-          autocorrect="off"
-          autocapitalize="off"
-          autofocus
-        />
+      </h1>  
+        <form action="/.auth" method="POST" id="login" class="flow">
+          <div class="error-message"></div>
+          <div>
+            <label for="username">
+              Username
+            </label>
+            <input
+              type="text"
+              name="username"
+              id="username"
+              autocomplete="off"
+              autocorrect="off"
+              autocapitalize="off"
+              autofocus
+            />
+          </div>
+          <div>
+            <label for="password">
+              Password
+            </label>
+            <input
+              type="password"
+              name="password"
+              id="password"
+            />
+          </div>
+          <div style="--space: 1.8rem">
+            <button>Login</button>
+          </div>
+        </form>
+        <footer>
+          <a href="https://silverbullet.md">What is SilverBullet?</a>
+        </footer>
       </div>
-      <div>
-        <label for="password">
-          Password
-        </label>
-        <input
-          type="password"
-          name="password"
-          id="password"
-        />
-      </div>
-      <div>
-        <input type="submit" value="Login" />
-      </div>
-      <footer>
-        <a href="https://silverbullet.md">What is SilverBullet?</a>
-      </footer>
-    </form>
+    </div>
 
     <script>
       const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
Hi! I thought the auth page needed some love. I'm not a programmer, but I know enough to maybe get something started. Before continuing any further I wanted input from you.

This is what I've done so far:
- Removed placeholders in favor of proper labels
- Center the form
- When screen is large enough:
  - Style the form to look like modals
  - Add a gradient in background based on the logo

Here is a comparison of what the auth page looks like currently and with this PR:

Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/da305de8-47a8-49c8-a615-ad231fb8335d)  |  ![Skärmbild från 2024-10-19 13-35-42](https://github.com/user-attachments/assets/2daf5eee-2082-471b-aa86-0fe76acc6382)

(And on a narrow screen:)
![Skärmbild från 2024-10-19 13-36-36](https://github.com/user-attachments/assets/12645adc-7946-4cfc-8c73-9f7a428fbd1d)

I'm unsure what I think about the gradient. With it dropped, it could look something like this (disregard the h1 only saying "Log in"):

![Skärmbild från 2024-10-19 13-16-20](https://github.com/user-attachments/assets/5b1b1f84-811e-4118-8b07-6d530e023de6)

We could also drop the modal styling so it always look like the narrow screen screenshot.

More improvements I've been thinking about:
- Split the "Login to SilverBullet" string
  - Maybe only saying "Login" in the form and having the logo at the top of the page (similar to Proton, see image below)
  ![Skärmbild från 2024-10-19 13-37-28](https://github.com/user-attachments/assets/0ba0ea34-ae98-41f8-aed8-0f9e21e2ee06)
- Right now, I redefine many variables from `theme.scss`. This file could maybe be imported to minimize duplication.
- A dark variant would be nice. (Do we want potential future theming to be displayed here as well? Then the gradient is a no-go.)
- The logo is too small and not really aligned with the text
- There's no favicon in the browser tab

What do you think?