### PR TITLE
Enabler to make scripts loaded from CDN more secure

### DIFF
--- a/web/components/panel_html.ts
+++ b/web/components/panel_html.ts
@@ -90,9 +90,13 @@ function updateHeight() {
   }
 }
 
-function loadJsByUrl(url) {
+function loadJsByUrl(url,integrity=null) {
   const script = document.createElement("script");
   script.src = url;
+  if(integrity){
+    script.integrity=integrity
+  }
+  
 
   return new Promise((resolve) => {
     script.onload = resolve;

--- a/web/components/panel_html.ts
+++ b/web/components/panel_html.ts
@@ -94,7 +94,8 @@ function loadJsByUrl(url,integrity=null) {
   const script = document.createElement("script");
   script.src = url;
   if(integrity){
-    script.integrity=integrity
+    script.integrity=integrity;
+    script.crossorigin="anonymous";
   }
   
 


### PR DESCRIPTION
This adds the possibility to set an integrity hash for the script tag that is e.g. used by the mermaid plug. If properly used, this will prevent manipulated CDN sources from being loaded into silverbullet.