### PR TITLE
Create "remember me" functionality for basic auth, which sets an unexpiring jwt and refreshes the cookie during requests

### DIFF
--- a/server/crypto.ts
+++ b/server/crypto.ts
@@ -60,12 +60,13 @@ export class JWTIssuer {
 
   createJWT(
     payload: Record<string, unknown>,
-    expirySeconds: number,
+    expirySeconds?: number,
   ): Promise<string> {
-    return create({ alg: "HS512", typ: "JWT" }, {
-      ...payload,
-      exp: getNumericDate(expirySeconds),
-    }, this.key);
+    const jwtPayload = { ...payload };
+    if (expirySeconds) {
+      jwtPayload.exp = getNumericDate(expirySeconds);
+    }
+    return create({ alg: "HS512", typ: "JWT" }, jwtPayload, this.key);
   }
 
   verifyAndDecodeJWT(jwt: string): Promise<Record<string, unknown>> {

--- a/server/http_server.ts
+++ b/server/http_server.ts
@@ -379,7 +379,7 @@ export class HttpServer {
           return c.redirect(typeof from === "string" ? from : "/");
         } else {
           console.error("Authentication failed, redirecting to auth page.");
-          return c.redirect("/.auth?error=1", 401);
+          return c.redirect("/.auth?error=1");
         }
       },
     ).all((c) => {

--- a/web/auth.html
+++ b/web/auth.html
@@ -96,6 +96,10 @@
         />
       </div>
       <div>
+        <input type="checkbox" name="rememberMe" id="rememberMe" />
+        <label>Remember me</label>
+      </div>
+      <div>
         <input type="submit" value="Login" />
       </div>
       <footer>


### PR DESCRIPTION
One source of mild frustration for me using Silverbullet is the necessity of re-logging-in every week (at least since I'm currently using basic authentication). This PR adds the ability to stay logged in, as log as the user opens Silverbullet on a given device during the one-week window.

To the `crypto.ts` file, `createJWT()` is updated to make `expirySeconds` an optional parameter, making a JWT that doesn't expire if it's not passed.

A checkbox is added to `auth.html` to the login form to mark "remember me".

In `http_server.ts`, logging in with the "remember me" checkbox checked saves an additional cookie that, if it exists, signifies the server to refresh the cookie on subsequent requests. Thus, visits to a page (given the cookies aren't expired) will move the expiration date back to a week past the current date. This cookie is deleted alongside the auth cookie at logout.