### PR TITLE
Few dark mode fixes and top bar improvements

### DIFF
--- a/web/components/top_bar.tsx
+++ b/web/components/top_bar.tsx
@@ -68,8 +68,8 @@ export function TopBar({
               className={(isLoading
                 ? "sb-loading"
                 : unsavedChanges
-                ? "sb-unsaved"
-                : "sb-saved") +
+                  ? "sb-unsaved"
+                  : "sb-saved") +
                 (cssClass ? " sb-decorated-object " + cssClass : "")}
             >
               <MiniEditor
@@ -103,16 +103,16 @@ export function TopBar({
             )}
             <div className="sb-actions">
               {progressPerc !== undefined &&
-                (
-                  <div className="progress-wrapper" title={`${progressPerc}%`}>
+                  (
+                  <div className="progress-wrapper" title={`Sync Progress: ${progressPerc}%`}>
                     <div
                       className="progress-bar"
-                      style={`background: radial-gradient(closest-side, white 79%, transparent 80% 100%), conic-gradient(#282828 ${progressPerc}%, #adadad 0);`}
+                      style={`background: radial-gradient(closest-side, var(--top-background-color) 79%, transparent 80% 100%), conic-gradient(var(--button-color) ${progressPerc}%, var(--button-background-color) 0);`}
                     >
-                      {progressPerc}%
+                      {progressPerc}
                     </div>
                   </div>
-                )}
+              )}
               {actionButtons.map((actionButton) => {
                 const button = (
                   <button

--- a/web/components/top_bar.tsx
+++ b/web/components/top_bar.tsx
@@ -68,8 +68,8 @@ export function TopBar({
               className={(isLoading
                 ? "sb-loading"
                 : unsavedChanges
-                  ? "sb-unsaved"
-                  : "sb-saved") +
+                ? "sb-unsaved"
+                : "sb-saved") +
                 (cssClass ? " sb-decorated-object " + cssClass : "")}
             >
               <MiniEditor
@@ -103,7 +103,7 @@ export function TopBar({
             )}
             <div className="sb-actions">
               {progressPerc !== undefined &&
-                  (
+                (
                   <div className="progress-wrapper" title={`Sync Progress: ${progressPerc}%`}>
                     <div
                       className="progress-bar"
@@ -112,7 +112,7 @@ export function TopBar({
                       {progressPerc}
                     </div>
                   </div>
-              )}
+                )}
               {actionButtons.map((actionButton) => {
                 const button = (
                   <button

--- a/web/styles/colors.scss
+++ b/web/styles/colors.scss
@@ -73,8 +73,11 @@
 }
 
 .sb-actions button {
+  width: 28px;
+  height: 28px;
   border: 0;
-  margin: 3px;
+  margin: 2px;
+  margin-top: 6px;
   padding: 5px;
   background-color: var(--action-button-background-color);
   color: var(--action-button-color);

--- a/web/styles/main.scss
+++ b/web/styles/main.scss
@@ -65,7 +65,7 @@ body {
       max-width: var(--#{"editor-width"});
       margin: auto;
       font-size: 28px;
-      padding: 10px 0;
+      padding: 8px 0;
       display: flex;
       flex-direction: row;
 
@@ -119,7 +119,6 @@ body {
 
   .sb-actions {
     display: flex;
-    align-items: baseline;
     flex: 0 0 auto;
     text-align: right;
   }
@@ -127,10 +126,9 @@ body {
   .progress-wrapper {
     display: inline-block;
     position: relative;
-    top: -6px;
+    margin-top: 4px;
     padding: 4px;
     background-color: var(--top-background-color);
-    margin-right: -2px;
   }
 
   .progress-bar {
@@ -138,15 +136,11 @@ body {
     justify-content: center;
     align-items: center;
 
-    width: 20px;
-    height: 20px;
+    width: 24px;
+    height: 24px;
     border-radius: 50%;
-    font-size: 6px;
+    font-size: 8px;
   }
-
-  // .progress-bar::before {
-  //   content: "66%";
-  // }
 }
 
 .sb-panel {

--- a/web/styles/main.scss
+++ b/web/styles/main.scss
@@ -112,6 +112,7 @@ body {
 
         .cm-line {
           padding: 0;
+          caret-color: var(--editor-caret-color);
         }
       }
     }


### PR DESCRIPTION
Fixes #1129

- The progress bar now uses variable colors that align with the other nearby buttons' colors.
- The spacings in the header bar, like the Sync button when enabled, has been improved.
- The caret color being black on the note name in dark mode has been fixed.

I'm not really sure these are the correct ways to fix it since I'm not really familiar with SilverBullet's codebase,  Codemirror, Deno, etc. :sweat_smile:  