### PR TITLE
Fix build on windows

### DIFF
--- a/build_plugs.ts
+++ b/build_plugs.ts
@@ -27,7 +27,7 @@ if (import.meta.main) {
       debug: args.debug,
       reload: args.reload,
       info: args.info,
-      configPath: new URL("deno.json", import.meta.url).pathname,
+      configPath: path.resolve("./deno.json"),
     },
   );
   esbuild.stop();

--- a/build_plugs.ts
+++ b/build_plugs.ts
@@ -3,6 +3,7 @@ import * as esbuild from "esbuild";
 import { compileManifests } from "./cmd/compile.ts";
 import { builtinPlugNames } from "./plugs/builtin_plugs.ts";
 import { parseArgs } from "@std/cli/parse-args";
+import { fileURLToPath } from "node:url";
 
 if (import.meta.main) {
   const args = parseArgs(Deno.args, {
@@ -27,7 +28,7 @@ if (import.meta.main) {
       debug: args.debug,
       reload: args.reload,
       info: args.info,
-      configPath: path.resolve("./deno.json"),
+      configPath: fileURLToPath(new URL("deno.json", import.meta.url)),
     },
   );
   esbuild.stop();

--- a/build_web.ts
+++ b/build_web.ts
@@ -1,4 +1,5 @@
 import { copy } from "@std/fs";
+import * as path from "@std/path";
 
 import sass from "denosass";
 import { bundleFolder } from "./lib/asset_bundle/builder.ts";
@@ -105,7 +106,7 @@ async function buildCopyBundleAssets() {
     jsxFragment: "Fragment",
     jsxImportSource: "https://esm.sh/preact@10.23.1",
     plugins: denoPlugins({
-      configPath: new URL("./deno.json", import.meta.url).pathname,
+      configPath: path.resolve("./deno.json"),
     }),
   });
 

--- a/build_web.ts
+++ b/build_web.ts
@@ -1,5 +1,5 @@
 import { copy } from "@std/fs";
-import * as path from "@std/path";
+import { fileURLToPath } from "node:url";
 
 import sass from "denosass";
 import { bundleFolder } from "./lib/asset_bundle/builder.ts";
@@ -106,7 +106,7 @@ async function buildCopyBundleAssets() {
     jsxFragment: "Fragment",
     jsxImportSource: "https://esm.sh/preact@10.23.1",
     plugins: denoPlugins({
-      configPath: path.resolve("./deno.json"),
+      configPath: fileURLToPath(new URL("./deno.json", import.meta.url)),
     }),
   });
 


### PR DESCRIPTION
This fixes the build on windows, where `new URL("deno.json", import.meta.url).pathname` starts with `/C:/` which isn't a valid path.

First time with deno, so not sure this is idomatic.