### PR TITLE
recognise tel: uri scheme as a non-local path

### DIFF
--- a/plug-api/lib/resolve.ts
+++ b/plug-api/lib/resolve.ts
@@ -52,7 +52,9 @@ export function isFederationPath(path: string): boolean {
 }
 
 export function isLocalPath(path: string): boolean {
-  return !path.includes("://") && !path.startsWith("mailto:");
+  return !path.includes("://") &&
+    !path.startsWith("mailto:") &&
+    !path.startsWith("tel:");
 }
 
 export function rewritePageRefs(tree: ParseTree, containerPageName: string) {


### PR DESCRIPTION
Fixes #1095 The tel URI scheme for telephone numbers not recognized in hyperlinks

This could cover all possible protocols like this:
```
return URL.parse(path)===null;
```
but that would block **lots** of page names containing a colon.