### PR TITLE
Do not use standardKeymap in vim mode

### DIFF
--- a/web/editor_state.ts
+++ b/web/editor_state.ts
@@ -367,7 +367,7 @@ export function createKeyBindings(client: Client): Extension {
     ...createCommandKeyBindings(client),
     ...createSmartQuoteKeyBindings(client),
     ...closeBracketsKeymap,
-    ...standardKeymap,
+    ...client.ui.viewState.uiOptions.vimMode ? [] : standardKeymap,
     ...completionKeymap,
     indentWithTab,
   ]);


### PR DESCRIPTION
The standard keymap conflicts with the vim mode, e.g. not allowing arrow keys to move through the vim commandline for `/` and `:` commands. The keys described in
https://codemirror.net/docs/ref/#commands.standardKeymap seem to work just fine without it in vim mode.

Fixes https://github.com/silverbulletmd/silverbullet/issues/976