### PR TITLE
Allow tab press to autocomplete

### DIFF
--- a/web/editor_state.ts
+++ b/web/editor_state.ts
@@ -7,6 +7,7 @@ import {
   standardKeymap,
 } from "@codemirror/commands";
 import {
+  acceptCompletion,
   autocompletion,
   closeBrackets,
   closeBracketsKeymap,
@@ -381,6 +382,7 @@ export function createKeyBindings(client: Client): Extension {
       ]
       : standardKeymap,
     ...completionKeymap,
+    { key: "Tab", run: acceptCompletion },
     indentWithTab,
   ]);
 }


### PR DESCRIPTION
Accept auto-complete suggestions on tab press similar to code editors. Falls back to indent if no autocompletion context. 