### PR TITLE
Implement native sharing

### DIFF
--- a/plugs/share/share.plug.yaml
+++ b/plugs/share/share.plug.yaml
@@ -12,6 +12,12 @@ functions:
     events:
       - share:options
 
+  handleShareTarget:
+    path: share.ts:handleShareTarget
+    env: client
+    events:
+      - http:request:/share_target
+
   clipboardMarkdownShare:
     path: share.ts:clipboardMarkdownShare
     events:
@@ -31,3 +37,10 @@ functions:
     path: publish.ts:publishShare
     events:
       - share:publish
+
+config:
+  # Built-in configuration schemas
+  schema.config.properties:
+    shareTargetPage:
+      type: string
+      format: page-ref

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -14,5 +14,15 @@
   "display_override": ["window-controls-overlay"],
   "scope": "/",
   "theme_color": "#e1e1e1",
-  "description": "Markdown as a platform"
+  "description": "Markdown as a platform",
+  "share_target": {
+    "action": "/_/share_target",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  }
 }

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -4,6 +4,8 @@ An attempt at documenting the changes/new features introduced in each release.
 
 ## Edge
 _These features are not yet properly released, you need to use [the edge builds](https://community.silverbullet.md/t/living-on-the-edge-builds/27) to try them._
+* Native [[Share]] functionality, allowing you to use your OS'es native share functionality to share data with SilverBullet.
+  Target page can be configured as `shareTargetPage` in [[^SETTINGS]].
 
 * (Security) Implemented a lockout mechanism after a number of failed login attempts for [[Authentication]] (configured via [[Install/Configuration#Authentication]]) (by [Peter Weston](https://github.com/silverbulletmd/silverbullet/pull/1152))
 

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -82,4 +82,8 @@ emoji:
   aliases:
     smile: 😀
     sweat_smile: 😅
+
+# Share Configuration
+# Page where shared content will be stored (defaults to "Shared Items")
+shareTargetPage: "Inbox"
 ```


### PR DESCRIPTION
Closes #1090 

- [x] Call `handleShareTarget` method when native sharing button is used
- [x] Return HTML to the client
- [x] Store shared data in a target page
- [x] Redirect user to target page
- [x] Make target page for shared data configurable
- [x] Allow using template variables in page name
- [ ] Make it work in offline mode
