### PR TITLE
markdown_parser: allow comma and semicolon in naked URLs

### DIFF
--- a/common/markdown_parser/parser.ts
+++ b/common/markdown_parser/parser.ts
@@ -577,7 +577,7 @@ const NakedURL = regexParser(
   {
     firstCharCode: 104, // h
     regex:
-      /^https?:\/\/[-a-zA-Z0-9@:%._\+~#=]{1,256}([-a-zA-Z0-9()@:%_\+.~#?&=\/]*)/,
+      /^https?:\/\/[-a-zA-Z0-9@:%._\+~#=,;]{1,256}([-a-zA-Z0-9()@:%_\+.,;~#?&=\/]*)/,
     nodeType: "NakedURL",
     className: "sb-naked-url",
     tag: NakedURLTag,


### PR DESCRIPTION
related to issue #1160

Without this change, copy&pasting CodeSearch URLs like the following into SilverBullet breaks them: https://cs.opensource.google/go/go/+/master:src/archive/zip/reader.go;l=25;drc=9cfe3a86d34f7f4a401dae9a22389b12f7e8bb2e

I.e., they are cut off and do not link to the right target:

<img width="808" alt="Screenshot 2024-11-20 at 23 20 55" src="https://github.com/user-attachments/assets/17dae853-34dd-4f9f-9bfc-8ec3c3016f8f">
