### PR TITLE
Fix case sensitive cross origin attribute

### DIFF
--- a/web/components/panel_html.ts
+++ b/web/components/panel_html.ts
@@ -95,7 +95,7 @@ function loadJsByUrl(url,integrity=null) {
   script.src = url;
   if(integrity){
     script.integrity=integrity;
-    script.crossorigin="anonymous";
+    script.crossOrigin="anonymous"; //for some weird reason this attribute is case sensitive when used in JS
   }
   
 


### PR DESCRIPTION
Seems like for some browsers the cross origin property is case sensitive when using it in Javascript and not HTML.

This PR should fix [silverbullet/silverbullet-mermaid#5](https://github.com/silverbulletmd/silverbullet-mermaid/issues/5) and also contribute to the fix of the topic discussed [here](https://community.silverbullet.md/t/recent-problem-with-mermaid-plug/1296/5)