### PR TITLE
Fix passing URL parameters when proxying

### DIFF
--- a/server/http_server.ts
+++ b/server/http_server.ts
@@ -695,7 +695,11 @@ export class HttpServer {
         if (this.spaceServer.readOnly) {
           return c.text("Read only mode, no federation proxy allowed", 405);
         }
-        let url = req.param("uri")!.slice(1);
+
+        // Get the full URL including query parameters
+        const originalUrl = new URL(req.url);
+        let url = req.param("uri")!.slice(1) + originalUrl.search;
+
         if (!req.header("X-Proxy-Request")) {
           // Direct browser request, not explicity fetch proxy request
           if (!looksLikePathWithExtension(url)) {


### PR DESCRIPTION
@zefhemel my Readwise plug needs to use paging in order to get all pages from Readwise.
Readwise's paging is implemented by passing a `?page=2` URL parameter, which before this PR did not make it through the proxy.
This PR reads the URL params in the proxy route and appends it to the outgoing request URL.