### PR TITLE
readme MIT license link corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SilverBullet...
 * Provides a platform for [end-user programming](https://www.inkandswitch.com/end-user-programming/) through its support for Objects, Live Queries and Live Templates.
 * Robust extension mechanism using [plugs](https://silverbullet.md/Plugs).
 * **Self-hosted**: you own your data. All content is stored as plain files in a folder on disk. Back up, sync, edit, publish, script with any additional tools you like.
-* SilverBullet is [open source, MIT licensed](https://github.com/silverbulletmd/silverbullet) software.
+* SilverBullet is [open source, MIT licensed](https://opensource.org/license/MIT) software.
 
 ## Installing SilverBullet
 Check out the [instructions](https://silverbullet.md/Install).


### PR DESCRIPTION
This is a follow-up to issue [#1165 ](https://github.com/silverbulletmd/silverbullet/issues/1165). The corrected link to the MIT license is in the readme. 