### PR TITLE
Allow clicking Remember me label to toggle checkbox

### DIFF
--- a/web/auth.html
+++ b/web/auth.html
@@ -97,7 +97,7 @@
       </div>
       <div>
         <input type="checkbox" name="rememberMe" id="rememberMe" />
-        <label>Remember me</label>
+        <label for="rememberMe">Remember me</label>
       </div>
       <div>
         <input type="submit" value="Login" />


### PR DESCRIPTION
This adds the `for=""` attribute that allows the words "Remember me" to be clicked which will toggle the input checkbox next to it.