### PR TITLE
Prevent remote space script reload when syncOnly is enabled

### DIFF
--- a/common/syscalls/system.ts
+++ b/common/syscalls/system.ts
@@ -113,7 +113,7 @@ export function systemSyscalls(
     "system.loadSpaceScripts": async () => {
       // Reload scripts locally
       await commonSystem.loadSpaceScripts();
-      if (client) {
+      if (client && !globalThis.silverBulletConfig.syncOnly) {
         // Reload scripts remotely
         await proxySyscall(
           {},


### PR DESCRIPTION
This also fixes a side effect where the library update status notification would never show up.