### PR TITLE
Correctly extract hashtag content in links and Page Picker filter

### DIFF
--- a/plugs/markdown/markdown_render.ts
+++ b/plugs/markdown/markdown_render.ts
@@ -15,6 +15,7 @@ import { Fragment, renderHtml, type Tag } from "./html_render.ts";
 import { isLocalPath } from "@silverbulletmd/silverbullet/lib/resolve";
 import type { PageMeta } from "@silverbulletmd/silverbullet/types";
 import * as TagConstants from "../../plugs/index/constants.ts";
+import { extractHashtag } from "@silverbulletmd/silverbullet/lib/tags";
 
 export type MarkdownRenderOptions = {
   failOnUnknown?: true;
@@ -342,8 +343,8 @@ function render(
         name: "a",
         attrs: {
           class: "hashtag sb-hashtag",
-          "data-tag-name": tagText.replace("#", ""),
-          href: `/${TagConstants.tagPrefix}${tagText.replace("#", "")}`,
+          "data-tag-name": extractHashtag(tagText),
+          href: `/${TagConstants.tagPrefix}${extractHashtag(tagText)}`,
         },
         body: tagText,
       };

--- a/web/cm_plugins/widget_util.ts
+++ b/web/cm_plugins/widget_util.ts
@@ -1,6 +1,7 @@
 import { parsePageRef } from "@silverbulletmd/silverbullet/lib/page_ref";
 import type { Client } from "../client.ts";
 import { tagPrefix } from "../../plugs/index/constants.ts";
+import { extractHashtag } from "@silverbulletmd/silverbullet/lib/tags";
 
 export function attachWidgetEventHandlers(
   div: HTMLElement,
@@ -45,7 +46,7 @@ export function attachWidgetEventHandlers(
         return;
       }
       client.navigate({
-        page: `${tagPrefix}${el.innerText.slice(1)}`,
+        page: `${tagPrefix}${extractHashtag(el.innerText)}`,
         pos: 0,
       });
     });

--- a/web/components/page_navigator.tsx
+++ b/web/components/page_navigator.tsx
@@ -4,8 +4,9 @@ import type {
   CompletionContext,
   CompletionResult,
 } from "@codemirror/autocomplete";
-import type { PageMeta } from "../../plug-api/types.ts";
+import type { PageMeta } from "@silverbulletmd/silverbullet/types";
 import { tagRegex as mdTagRegex } from "$common/markdown_parser/constants.ts";
+import { extractHashtag } from "@silverbulletmd/silverbullet/lib/tags";
 
 const tagRegex = new RegExp(mdTagRegex.source, "g");
 
@@ -151,7 +152,7 @@ export function PageNavigator({
           const allTags = phrase.match(tagRegex);
           if (allTags) {
             // Search phrase contains hash tags, let's pre-filter the results based on this
-            const filterTags = allTags.map((t) => t.slice(1));
+            const filterTags = allTags.map((t) => extractHashtag(t));
             options = options.filter((pageMeta) => {
               if (!pageMeta.tags) {
                 return false;


### PR DESCRIPTION
This fixes #1196

Also went through the code and looked at all instances of `replace("#`, `replace('#`, and `slice(1` to find other locations where `extractHashtag` should be used. I think now it should be good.

Also, is there a preference between imports starting with `../../plug-api` and `@silverbulletmd/silverbullet`? I see both throughout the codebase, and seems to me that Deno uses one or the other for automatic imports. I'd say that the second option is easier to copy into other files.