### PR TITLE
fix(editor): allow multi selection while in vim mode

### DIFF
--- a/web/editor_state.ts
+++ b/web/editor_state.ts
@@ -77,7 +77,12 @@ export function createEditorState(
 
       // Enable vim mode, or not
       [
-        ...client.ui.viewState.uiOptions.vimMode ? [vim({ status: true })] : [],
+        ...client.ui.viewState.uiOptions.vimMode
+          ? [
+            vim({ status: true }),
+            EditorState.allowMultipleSelections.of(true),
+          ]
+          : [],
       ],
       [
         ...(readOnly || client.ui.viewState.uiOptions.forcedROMode)


### PR DESCRIPTION
This fixes an issue with visual block selection in vim mode:

Current:
https://github.com/user-attachments/assets/5ed2afe2-c997-406e-b9bf-475b1b6862de


Fixed version:
https://github.com/user-attachments/assets/4e118863-2077-444c-aac5-9329c625e457


Closes #1217
