### PR TITLE
fix: strike through links in tasks

### DIFF
--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -218,7 +218,8 @@
     /* U+2022 BULLET */
   }
 
-  .cm-task-checked {
+  .cm-task-checked,
+  .sb-line-task:has(.cm-task-checked) .sb-wiki-link-page {
     text-decoration: line-through !important;
   }
 


### PR DESCRIPTION
When the body of a task contains a wiki style link [[]] and is checked, the link is not styled:

![image psd](https://github.com/user-attachments/assets/7a951c47-a182-45ce-9b13-a1eb67838556)

This uses the sort of new css `:has()` selector which is supported by most browsers: https://caniuse.com/css-has