### PR TITLE
Open external links in a new tab

### DIFF
--- a/plugs/markdown/markdown_render.ts
+++ b/plugs/markdown/markdown_render.ts
@@ -233,6 +233,7 @@ function render(
         name: "a",
         attrs: {
           href: url,
+          target: "_blank",
         },
         body: cleanTags(mapRender(linkTextChildren)),
       };
@@ -255,6 +256,7 @@ function render(
         name: "a",
         attrs: {
           href: url,
+          target: "_blank",
         },
         body: url,
       };
@@ -333,6 +335,7 @@ function render(
         name: "a",
         attrs: {
           href: url,
+          target: "_blank",
         },
         body: url,
       };


### PR DESCRIPTION
Fixes https://github.com/silverbulletmd/silverbullet/issues/1228. This matches the generated HTML to the current behavior of editor.openUrl.