### PR TITLE
Feature/move lines up down

### DIFF
--- a/plug-api/syscalls/editor.ts
+++ b/plug-api/syscalls/editor.ts
@@ -399,6 +399,14 @@ export function deleteLine(): Promise<void> {
   return syscall("editor.deleteLine");
 }
 
+export function moveLineUp(): Promise<void> {
+  return syscall("editor.moveLineUp");
+}
+
+export function moveLineDown(): Promise<void> {
+  return syscall("editor.moveLineDown");
+}
+
 // Vim-mode specific syscalls
 
 /**

--- a/plugs/editor/editor.plug.yaml
+++ b/plugs/editor/editor.plug.yaml
@@ -351,14 +351,14 @@ functions:
   outlineMoveUp:
     path: ./outline.ts:moveItemUp
     command:
-      name: "Outline: Move Up"
+      name: "Move Outline Item or Line Up"
       key: "Alt-ArrowUp"
       requireMode: rw
 
   outlineMoveDown:
     path: ./outline.ts:moveItemDown
     command:
-      name: "Outline: Move Down"
+      name: "Move Outline Item or Line Down"
       key: "Alt-ArrowDown"
       requireMode: rw
 

--- a/plugs/editor/editor.plug.yaml
+++ b/plugs/editor/editor.plug.yaml
@@ -351,14 +351,14 @@ functions:
   outlineMoveUp:
     path: ./outline.ts:moveItemUp
     command:
-      name: "Move Outline Item or Line Up"
+      name: "Outline: Move Up"
       key: "Alt-ArrowUp"
       requireMode: rw
 
   outlineMoveDown:
     path: ./outline.ts:moveItemDown
     command:
-      name: "Move Outline Item or Line Down"
+      name: "Outline: Move Down"
       key: "Alt-ArrowDown"
       requireMode: rw
 

--- a/plugs/editor/outline.ts
+++ b/plugs/editor/outline.ts
@@ -1,5 +1,4 @@
 import { editor } from "@silverbulletmd/silverbullet/syscalls";
-import { moveLineDown, moveLineUp } from "../../plug-api/syscalls/editor.ts";
 
 export async function moveItemUp() {
   const cursorPos = await editor.getCursor();
@@ -10,7 +9,9 @@ export async function moveItemUp() {
     try {
       currentItemBounds = determineItemBounds(text, cursorPos);
     } catch {
-      moveLineUp();
+      // If `determineItemBounds()` throws, that likely means the cursor is NOT in a bullet list,
+      // so we fall back to `moveLineUp()`
+      editor.moveLineUp();
       return;
     }
     let previousItemBounds: ReturnType<typeof determineItemBounds> | undefined;
@@ -80,7 +81,9 @@ export async function moveItemDown() {
     try {
       currentItemBounds = determineItemBounds(text, cursorPos);
     } catch {
-      moveLineDown();
+      // If `determineItemBounds()` throws, that likely means the cursor is NOT in a bullet list,
+      // so we fall back to `moveLineDown()`
+      editor.moveLineDown();
       return;
     }
     let nextItemBounds: ReturnType<typeof determineItemBounds> | undefined;

--- a/plugs/editor/outline.ts
+++ b/plugs/editor/outline.ts
@@ -1,11 +1,18 @@
 import { editor } from "@silverbulletmd/silverbullet/syscalls";
+import { moveLineDown, moveLineUp } from "../../plug-api/syscalls/editor.ts";
 
 export async function moveItemUp() {
   const cursorPos = await editor.getCursor();
   const text = await editor.getText();
 
   try {
-    const currentItemBounds = determineItemBounds(text, cursorPos);
+    let currentItemBounds: ReturnType<typeof determineItemBounds> | undefined;
+    try {
+      currentItemBounds = determineItemBounds(text, cursorPos);
+    } catch {
+      moveLineUp();
+      return;
+    }
     let previousItemBounds: ReturnType<typeof determineItemBounds> | undefined;
 
     try {
@@ -69,7 +76,13 @@ export async function moveItemDown() {
   const text = await editor.getText();
 
   try {
-    const currentItemBounds = determineItemBounds(text, cursorPos);
+    let currentItemBounds: ReturnType<typeof determineItemBounds> | undefined;
+    try {
+      currentItemBounds = determineItemBounds(text, cursorPos);
+    } catch {
+      moveLineDown();
+      return;
+    }
     let nextItemBounds: ReturnType<typeof determineItemBounds> | undefined;
     try {
       nextItemBounds = determineItemBounds(

--- a/web/syscalls/editor.ts
+++ b/web/syscalls/editor.ts
@@ -6,7 +6,14 @@ import {
   unfoldAll,
   unfoldCode,
 } from "@codemirror/language";
-import { deleteLine, isolateHistory, redo, undo } from "@codemirror/commands";
+import {
+  deleteLine,
+  isolateHistory,
+  moveLineDown,
+  moveLineUp,
+  redo,
+  undo,
+} from "@codemirror/commands";
 import type { Transaction } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { getCM as vimGetCm, Vim } from "@replit/codemirror-vim";
@@ -305,6 +312,18 @@ export function editorSyscalls(client: Client): SysCallMapping {
     },
     "editor.deleteLine": () => {
       deleteLine(client.editorView);
+    },
+    "editor.moveLineUp": () => {
+      return moveLineUp({
+        state: client.editorView.state,
+        dispatch: client.editorView.dispatch,
+      });
+    },
+    "editor.moveLineDown": () => {
+      return moveLineDown({
+        state: client.editorView.state,
+        dispatch: client.editorView.dispatch,
+      });
     },
     // Folding
     "editor.fold": () => {


### PR DESCRIPTION
I'd like to be able to move _all_ lines up/down with the same shortcut (alt+up/down) as "Outline: move up/down".

The problem is that Silverbullet doesn't support having 2 commands bound to the same shortcut (is that correct?), so this PR alters the `outline.moveItemUp()` to fallback on the simpler "move line up/down" commands when possible.

Even though it works, I'm not super satisfied with that solution, so advice is welcome :)

[silverlineup.webm](https://github.com/user-attachments/assets/e54b1a2c-b4b7-4f34-842d-8077f6bc0c29)

