### PR TITLE
Vim Mode and Read Only Fixes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -48,6 +48,7 @@
     "watch-web": "deno run -A --check build_web.ts --watch",
     "watch-server": "deno run -A --unstable-kv  --unstable-worker-options --check --watch silverbullet.ts",
     "watch-plugs": "deno run -A --check build_plugs.ts -w",
+    "watch-all": "deno task watch-web & deno task watch-server & deno task watch-plugs",
 
     "bundle": "deno run -A build_bundle.ts",
 

--- a/deno.json
+++ b/deno.json
@@ -48,7 +48,7 @@
     "watch-web": "deno run -A --check build_web.ts --watch",
     "watch-server": "deno run -A --unstable-kv  --unstable-worker-options --check --watch silverbullet.ts",
     "watch-plugs": "deno run -A --check build_plugs.ts -w",
-    "watch-all": "deno task watch-web & deno task watch-server & deno task watch-plugs",
+    "watch-all": "deno task watch-web & deno task watch-plugs & deno task watch-server",
 
     "bundle": "deno run -A build_bundle.ts",
 

--- a/web/editor_ui.tsx
+++ b/web/editor_ui.tsx
@@ -39,7 +39,6 @@ export class MainUI {
           return;
         }
         console.log("Delegated keydown", ev, "to editor");
-        client.focus();
         if (runScopeHandlers(client.editorView, ev, "editor")) {
           ev.preventDefault();
         }
@@ -154,6 +153,8 @@ export class MainUI {
                       client.focus();
                     }
                   });
+              } else {
+                setTimeout(() => client.focus());
               }
             }}
             commands={client.getCommandsByContext(viewState)}

--- a/web/syscalls/editor.ts
+++ b/web/syscalls/editor.ts
@@ -287,6 +287,7 @@ export function editorSyscalls(client: Client): SysCallMapping {
         key,
         value,
       });
+      client.reloadPage();
     },
     "editor.vimEx": (_ctx, exCommand: string) => {
       const cm = vimGetCm(client.editorView)!;


### PR DESCRIPTION
Currently in vim mode if the editor isn't selected and I hit `j` it will cause the editor to gain focus and insert the j character before entering vim normal mode. Read only mode is broken when toggling vim mode.  This PR attempts to fix those issues.  I don't know if there's a better way to fix the read only mode than calling reloadPage but it seems to work

- remove client.focus call from global keydown handler. This call is what breaks vim mode

- add client.reloadPage call to setUiOption syscall. This appears to fix read only mode that is completely broken without the above focus call. It also seems to fix the issue when toggling vim mode

- add client.focus call to CommandPalette onTrigger if no cmd is selected. Without the client.focus call above, the editor is no longer selected when exiting the command palette with escape - this call fixes that

- add watch-all task to deno.json to run all 3 watches in 1 terminal window