### PR TITLE
Add option to personalize toc header

### DIFF
--- a/plugs/index/toc.ts
+++ b/plugs/index/toc.ts
@@ -15,6 +15,7 @@ type TocConfig = {
   // Don't show the TOC if there are more than this many headers
   maxHeaders?: number;
   header?: boolean;
+  headerText?: string;
 };
 
 export async function widget(
@@ -58,7 +59,7 @@ export async function widget(
     // Too many headers, not showing TOC
     return null;
   }
-  let headerText = "# Table of Contents\n";
+  let headerText = config.headerText ?? "# Table of Contents\n";
   if (config.header === false) {
     headerText = "";
   }

--- a/website/Table of Contents.md
+++ b/website/Table of Contents.md
@@ -16,6 +16,7 @@ To have a ToC added to all pages with a larger (e.g. 3) number of headings, it i
 In the body of the `toc` code widget you can configure a few options:
 
 * `header`: by default a “Table of Contents” header is added to the ToC, set this to `false` to disable rendering this header
+* `headerText`: by default "# Table of Contents\n". Change it to change the rendering of this header
 * `minHeaders`: only renders a ToC if the number of headers in the current page exceeds this number, otherwise renders an empty widget
 * `maxHeaders`: only renders a ToC if the number of headers in the current page is below this number, otherwise renders an empty widget
 


### PR DESCRIPTION
Hellow,

I'm setting up silverbullet to see if it can replace Obsidian in my life, and I needed to change what heading level the table of content header was. So, here's a PR that **is** backward compatible (since we could remove `header` and instruct to set `headerText` to `""` to achieve the same effect)

I'm not happy with the wording I came up with for the documentation, suggestions very much welcome.