### PR TITLE
FIX: Frontmatter wikilinks should be resolved from root

### DIFF
--- a/plugs/index/page_links.ts
+++ b/plugs/index/page_links.ts
@@ -231,9 +231,9 @@ export async function indexLinks({ name, tree }: IndexTreeEvent) {
             asTemplate: false,
           };
           if (looksLikePathWithExtension(url)) {
-            link.toFile = resolvePath(name, url);
+            link.toFile = resolvePath(name, "/" + url);
           } else {
-            link.toPage = resolvePath(name, parsePageRef(url).page);
+            link.toPage = resolvePath(name, "/" + parsePageRef(url).page);
           }
           if (alias) {
             link.alias = alias;


### PR DESCRIPTION
Related to this [PR](https://github.com/silverbulletmd/silverbullet/pull/1066)
This PR fixes frontmatter wikilink path resolution from relative to absolute.