### PR TITLE
Space lua: os.date add support for %U, %V and %W

### DIFF
--- a/common/space_lua/stdlib/os_test.lua
+++ b/common/space_lua/stdlib/os_test.lua
@@ -6,4 +6,8 @@ end
 
 -- Basic OS functions
 assert(os.time() > 0)
-assert(os.date("%Y-%m-%d", os.time({ year = 2020, month = 1, day = 1 })) == "2020-01-01") 
+assert(os.date("%Y-%m-%d", os.time({ year = 2020, month = 1, day = 1 })) == "2020-01-01")
+
+-- Week calculations
+assert(os.date("%U %V %W", os.time({ year = 2051, month = 1, day = 1 })) == "01 52 00")
+assert(os.date("%U %V %W", os.time({ year = 2025, month = 2, day = 18})) == "07 08 07")

--- a/website/API/os.md
+++ b/website/API/os.md
@@ -35,6 +35,9 @@ Format specifiers:
 - `%A`: Full weekday name (e.g., "Sunday")
 - `%a`: Abbreviated weekday name (e.g., "Sun")
 - `%w`: Weekday (0-6, Sunday is 0)
+- `%U`: Week of the year, starting with the first Sunday as the first day of week 01 (00-53)
+- `%W`: Week of the year, starting with the first Monday as the first day of week 01 (00-53)
+- `%V`: ISO 8601 week of the year (01-53) (see [Wikipedia](https://en.wikipedia.org/wiki/ISO_week_date))
 - `%j`: Day of year (001-366)
 - `%Z`: Time zone name
 - `%z`: Time zone offset from UTC


### PR DESCRIPTION
Add support to format dates using the week number format specifiers:

- `%U`: US format - week 01 of the year starts on the first Sunday of the year. Days in the year prior to that week are in week 00. (00 to 53)
- `%W`: week 01 of the year starts on the first Monday of the year. Days in the year prior to that week are in week 00. (00 to 53)
- `%V`: EU / ISO 8601 format - week 01 of the year is the week containing January 4th. Days in the year prior to that week are in the last week of the year prior. (01 to 53)

