### PR TITLE
add rebuildEditorState function to the syscalls

### DIFF
--- a/plug-api/syscalls/editor.ts
+++ b/plug-api/syscalls/editor.ts
@@ -119,6 +119,13 @@ export function reloadUI(): Promise<void> {
 }
 
 /**
+ * Rebuilds the editor state to ensure the dispatch updates the state.
+ */
+export function rebuildEditorState() {
+  return syscall("editor.rebuildEditorState");
+}
+
+/**
  * Reloads the config and commands, also in the server
  */
 export function reloadConfigAndCommands(): Promise<void> {

--- a/web/syscalls/editor.ts
+++ b/web/syscalls/editor.ts
@@ -64,6 +64,9 @@ export function editorSyscalls(client: Client): SysCallMapping {
     "editor.reloadUI": () => {
       location.reload();
     },
+    "editor.rebuildEditorState": () => {
+      client.rebuildEditorState();
+    },
     "editor.reloadConfigAndCommands": async () => {
       await client.loadConfig();
 


### PR DESCRIPTION
This commit exposes `client.rebuildEditorState()` function to the syscalls.
