### PR TITLE
When insatiating the index page through the `client.navigate` function only builtin functions were considered

### DIFF
--- a/web/client.ts
+++ b/web/client.ts
@@ -1016,7 +1016,7 @@ export class Client implements ConfigContainer {
           this.config.indexPage,
           {},
           {},
-          builtinFunctions,
+          client.stateDataStore.functionMap,
         ),
       );
     }


### PR DESCRIPTION
Title