### PR TITLE
added ToC min+maxLevel (second attempt, fixes #1226)

### DIFF
--- a/plugs/index/toc.ts
+++ b/plugs/index/toc.ts
@@ -16,6 +16,8 @@ type TocConfig = {
   maxHeaders?: number;
   header?: boolean;
   headerText?: string;
+  maxLevel?: number;
+  minLevel?: number;
 };
 
 export async function widget(
@@ -65,16 +67,18 @@ export async function widget(
   }
   // console.log("Headers", headers);
   // Adjust level down if only sub-headers are used
-  const minLevel = headers.reduce(
+
+  let minLevel = headers.reduce(
     (min, header) => Math.min(min, header.level),
     6,
   );
-  const renderedMd = headerText +
-    headers.map((header) =>
-      `${
-        " ".repeat((header.level - minLevel) * 2)
-      }* [[${page}@${header.pos}|${header.name}]]`
-    ).join("\n");
+  if (config.minLevel && config.minLevel > minLevel) { minLevel = config.minLevel ;}
+  let renderedMd = headerText + "\n";
+  for (const header of headers) {
+	  if (config.maxLevel && header.level > config.maxLevel || (config.minLevel && header.level < config.minLevel)) { continue; }
+	  renderedMd = renderedMd + " ".repeat((header.level - minLevel) * 2)  + "[[" + page + "@" + header.pos + "|" + header.name + "]]\n";
+  }
+
   // console.log("Markdown", renderedMd);
   return {
     markdown: renderedMd,

--- a/website/Table of Contents.md
+++ b/website/Table of Contents.md
@@ -19,6 +19,8 @@ In the body of the `toc` code widget you can configure a few options:
 * `headerText`: by default "# Table of Contents\n". Change it to change the rendering of this header
 * `minHeaders`: only renders a ToC if the number of headers in the current page exceeds this number, otherwise renders an empty widget
 * `maxHeaders`: only renders a ToC if the number of headers in the current page is below this number, otherwise renders an empty widget
+* `minLevel`: only renders a ToC for headers below that level (if you do not want to display e.g. the first header)
+* `maxLevel`: only renders a ToC down to this level (e.g. if you have too many sublevels.)
 
 Example:
 ```toc


### PR DESCRIPTION
adds two new config-options to the "Table of Contents" plug:
maxLevel and minLevel.

So you are able to restrict the displayed levels to your needs.

(Second attempt for PR, this time with all tests and checks completed :-) )