### PR TITLE
Use writer to ensure the entire file is written

### DIFF
--- a/common/spaces/disk_space_primitives.ts
+++ b/common/spaces/disk_space_primitives.ts
@@ -87,13 +87,14 @@ export class DiskSpacePrimitives implements SpacePrimitives {
       });
 
       // Actually write the file
-      await file.write(data);
+      const writer = file.writable.getWriter();
+      await writer.write(data);
 
       if (meta?.lastModified) {
         // console.log("Seting mtime to", new Date(meta.lastModified));
         await file.utime(new Date(), new Date(meta.lastModified));
       }
-      file.close();
+      await writer.close();
 
       // Invalidate cache and trigger an update
       this.fileListCache = [];


### PR DESCRIPTION
Using `file.write` directly once doesn't guarantee the entire file is written; see https://docs.deno.com/examples/writing_files/

Noticed this while trawling through the code working trying to reason about sync issues