### PR TITLE
fix(transclusions): don't slice if it is the last heading on the page

### DIFF
--- a/common/query_functions.ts
+++ b/common/query_functions.ts
@@ -135,10 +135,9 @@ export function buildQueryFunctions(
               `[^#]#{1,${headingLevel}} [^\n]*\n`,
               "g",
             );
-            const endPos = page.slice(headingLevel).search(headRegex) +
-              headingLevel;
-            if (endPos) {
-              page = page.slice(0, endPos);
+            const endPos = page.slice(headingLevel).search(headRegex);
+            if (endPos >= 0) {
+              page = page.slice(0, endPos + headingLevel);
             }
           }
 


### PR DESCRIPTION
The check if a match was found by the heading regex was incorrect. `string.search(regex)` returns `-1` which is "truethy". 
Instead use a check if it's greater or equal than 0 (technically correct, but in practice it will even be bigger, because a next heading is at least a newline away).

Fixes #1086 