### PR TITLE
fix(quote): prevent extra indent when first word is not an admonition

### DIFF
--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -666,6 +666,7 @@
   .sb-admonition {
     border-left-width: 4px !important;
     border-left-style: solid;
+    padding-left: 5px;
   }
 
   .sb-admonition-type::before {
@@ -674,11 +675,13 @@
     -webkit-mask: var(--admonition-icon) no-repeat;
     mask-size: cover;
     -webkit-mask-size: cover;
-    width: 1.1em;
+
+    /* used in (custom) admonition definitions */
+    --admonition-width: 1.1em;
+    width: 0em;
     height: 1.1em;
     display: inline-flex;
     vertical-align: middle;
-    margin-left: 5px;
   }
 
   .sb-frontmatter-marker {

--- a/web/styles/theme.scss
+++ b/web/styles/theme.scss
@@ -269,8 +269,14 @@ html[data-theme="dark"] {
 }
 
 .sb-admonition[admonition="note"] {
-  .sb-admonition-type * {
-    display: none;
+  .sb-admonition-type {
+    &::before {
+      width: var(--admonition-width) !important;
+    }
+
+    * {
+      display: none;
+    }
   }
 
   --admonition-icon: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>');
@@ -278,8 +284,14 @@ html[data-theme="dark"] {
 }
 
 .sb-admonition[admonition="warning"] {
-  .sb-admonition-type * {
-    display: none;
+  .sb-admonition-type {
+    &::before {
+      width: var(--admonition-width) !important;
+    }
+
+    * {
+      display: none;
+    }
   }
 
   --admonition-icon: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>');

--- a/website/Markdown/Admonitions.md
+++ b/website/Markdown/Admonitions.md
@@ -14,6 +14,10 @@ Custom admonitions can be added in a [[Space Style]] using the following format:
 // Replace the keyword with a word or phrase of your choice
 .sb-admonition[admonition="keyword"] {
   .sb-admonition-type * { display: none; }
+  .sb-admonition-type::before { 
+    width: var(--admonition-width) !important;
+  }
+
     // The icon can be a link or an embedded image like shown here
   --admonition-icon: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><path d="M19.5 12L14.5 17M19.5 12L14.5 7M19.5 12L9.5 12C7.83333 12 4.5 11 4.5 7" stroke="%231C274C" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></g></svg>'); 
   // The accent color

--- a/website/Markdown/Admonitions.md
+++ b/website/Markdown/Admonitions.md
@@ -11,16 +11,16 @@ Silverbullet supports [admonitions](https://github.com/community/community/discu
 Custom admonitions can be added in a [[Space Style]] using the following format:
 
 ```space-style
-// Replace the keyword with a word or phrase of your choice
+/* Replace the keyword with a word or phrase of your choice */
 .sb-admonition[admonition="keyword"] {
   .sb-admonition-type * { display: none; }
   .sb-admonition-type::before { 
     width: var(--admonition-width) !important;
   }
 
-    // The icon can be a link or an embedded image like shown here
+    /* The icon can be a link or an embedded image like shown here */
   --admonition-icon: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><path d="M19.5 12L14.5 17M19.5 12L14.5 7M19.5 12L9.5 12C7.83333 12 4.5 11 4.5 7" stroke="%231C274C" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></g></svg>'); 
-  // The accent color
+  /* The accent color */
   --admonition-color: green;
 }
 ```


### PR DESCRIPTION
Fixes #792 (Incorrectly formatted bold text inside a quote)

Also update the comments in the `space-style` block for the admonition documentation.
This makes it possible to copy the whole block and only change the parts that need to change.
With the old "javascript" style comments, the space-style would not load successfully.