### PR TITLE
feat(menu): Make menu responsive

### DIFF
--- a/plugs/editor/editor.plug.yaml
+++ b/plugs/editor/editor.plug.yaml
@@ -37,7 +37,7 @@ config:
     hideSyncButton:
       type: boolean
       nullable: true
-    menuClass:
+    mobileMenuStyle:
       type: string
       nullable: true
     actionButtons:

--- a/plugs/editor/editor.plug.yaml
+++ b/plugs/editor/editor.plug.yaml
@@ -37,6 +37,9 @@ config:
     hideSyncButton:
       type: boolean
       nullable: true
+    menuClass:
+      type: string
+      nullable: true
     actionButtons:
       type: array
       items:

--- a/type/config.ts
+++ b/type/config.ts
@@ -74,7 +74,7 @@ export const defaultConfig: Config = {
   actionButtons: [], // Actually defaults to defaultActionButtons
   autoCloseBrackets: "([{`",
   indentMultiplier: 1,
-  mobileMenuStyle: "mobile-vertical",
+  mobileMenuStyle: "hamburger",
 
   schema: {
     config: {

--- a/type/config.ts
+++ b/type/config.ts
@@ -50,7 +50,7 @@ export type Config = {
   autoCloseBrackets: string;
   smartQuotes?: SmartQuotesConfig;
   indentMultiplier?: number;
-  menuClass: string;
+  mobileMenuStyle: string;
 
   schema: SchemaConfig;
 
@@ -74,7 +74,7 @@ export const defaultConfig: Config = {
   actionButtons: [], // Actually defaults to defaultActionButtons
   autoCloseBrackets: "([{`",
   indentMultiplier: 1,
-  menuClass: "mobile-vertical",
+  mobileMenuStyle: "mobile-vertical",
 
   schema: {
     config: {

--- a/type/config.ts
+++ b/type/config.ts
@@ -50,6 +50,7 @@ export type Config = {
   autoCloseBrackets: string;
   smartQuotes?: SmartQuotesConfig;
   indentMultiplier?: number;
+  menuClass: string;
 
   schema: SchemaConfig;
 
@@ -73,6 +74,7 @@ export const defaultConfig: Config = {
   actionButtons: [], // Actually defaults to defaultActionButtons
   autoCloseBrackets: "([{`",
   indentMultiplier: 1,
+  menuClass: "mobile-vertical",
 
   schema: {
     config: {

--- a/web/components/top_bar.tsx
+++ b/web/components/top_bar.tsx
@@ -34,6 +34,7 @@ export function TopBar({
   rhs,
   pageNamePrefix,
   cssClass,
+  menuClass,
 }: {
   pageName?: string;
   unsavedChanges: boolean;
@@ -51,6 +52,7 @@ export function TopBar({
   rhs?: ComponentChildren;
   pageNamePrefix?: string;
   cssClass?: string;
+  menuClass?: string;
 }) {
   return (
     <div
@@ -101,7 +103,7 @@ export function TopBar({
                 ))}
               </div>
             )}
-            <div className="sb-actions">
+            <div className={"sb-actions " + (menuClass ? menuClass : "")}>
               {progressPerc !== undefined &&
                 (
                   <div

--- a/web/components/top_bar.tsx
+++ b/web/components/top_bar.tsx
@@ -34,7 +34,7 @@ export function TopBar({
   rhs,
   pageNamePrefix,
   cssClass,
-  menuClass,
+  mobileMenuStyle,
 }: {
   pageName?: string;
   unsavedChanges: boolean;
@@ -52,7 +52,7 @@ export function TopBar({
   rhs?: ComponentChildren;
   pageNamePrefix?: string;
   cssClass?: string;
-  menuClass?: string;
+  mobileMenuStyle?: string;
 }) {
   return (
     <div
@@ -103,7 +103,10 @@ export function TopBar({
                 ))}
               </div>
             )}
-            <div className={"sb-actions " + (menuClass ? menuClass : "")}>
+            <div
+              className={"sb-actions " +
+                (mobileMenuStyle ? mobileMenuStyle : "")}
+            >
               {progressPerc !== undefined &&
                 (
                   <div

--- a/web/editor_ui.tsx
+++ b/web/editor_ui.tsx
@@ -298,6 +298,15 @@ export class MainUI {
             }
           }}
           actionButtons={[
+            // Vertical menu button
+            ...(viewState.isMobile)
+              ? [{
+                icon: featherIcons.MoreVertical,
+                description: "Open Menu",
+                callback:
+                  () => {/* nothing to do, menu opens on hover/mobile click */},
+              }]
+              : [],
             // Sync button
             ...(!this.client.clientConfig.syncOnly &&
                 !viewState.config.hideSyncButton)

--- a/web/editor_ui.tsx
+++ b/web/editor_ui.tsx
@@ -300,7 +300,7 @@ export class MainUI {
           actionButtons={[
             // Vertical menu button
             ...(viewState.isMobile &&
-                viewState.config.mobileMenuStyle.includes("mobile-vertical"))
+                viewState.config.mobileMenuStyle.includes("hamburger"))
               ? [{
                 icon: featherIcons.MoreVertical,
                 description: "Open Menu",

--- a/web/editor_ui.tsx
+++ b/web/editor_ui.tsx
@@ -300,7 +300,7 @@ export class MainUI {
           actionButtons={[
             // Vertical menu button
             ...(viewState.isMobile &&
-                viewState.config.menuClass.includes("mobile-vertical"))
+                viewState.config.mobileMenuStyle.includes("mobile-vertical"))
               ? [{
                 icon: featherIcons.MoreVertical,
                 description: "Open Menu",
@@ -414,8 +414,8 @@ export class MainUI {
             ? viewState.current?.meta?.pageDecoration?.cssClasses
               .join(" ").replaceAll(/[^a-zA-Z0-9-_ ]/g, "")
             : ""}
-          menuClass={viewState.config?.menuClass
-            ? viewState.config?.menuClass
+          mobileMenuStyle={viewState.config?.mobileMenuStyle
+            ? viewState.config?.mobileMenuStyle
             : ""}
         />
         <div id="sb-main">

--- a/web/editor_ui.tsx
+++ b/web/editor_ui.tsx
@@ -299,7 +299,8 @@ export class MainUI {
           }}
           actionButtons={[
             // Vertical menu button
-            ...(viewState.isMobile)
+            ...(viewState.isMobile &&
+                viewState.config.menuClass.includes("mobile-vertical"))
               ? [{
                 icon: featherIcons.MoreVertical,
                 description: "Open Menu",
@@ -412,6 +413,9 @@ export class MainUI {
           cssClass={viewState.current?.meta?.pageDecoration?.cssClasses
             ? viewState.current?.meta?.pageDecoration?.cssClasses
               .join(" ").replaceAll(/[^a-zA-Z0-9-_ ]/g, "")
+            : ""}
+          menuClass={viewState.config?.menuClass
+            ? viewState.config?.menuClass
             : ""}
         />
         <div id="sb-main">

--- a/web/styles/main.scss
+++ b/web/styles/main.scss
@@ -2,6 +2,7 @@
 @use "modals";
 @use "theme";
 @use "colors";
+@use "top";
 
 @font-face {
   font-family: "iA-Mono";
@@ -47,101 +48,6 @@ body {
   width: 100%;
   height: 100%;
   background-color: var(--root-background-color);
-}
-
-#sb-top {
-  display: flex;
-  flex-direction: row;
-  z-index: 20;
-
-  height: 55px;
-
-  .main {
-    flex: 2;
-    max-width: 100%;
-
-    .inner {
-      // Hack to not have SCSS precompile this value but use proper CSS variables
-      max-width: var(--#{"editor-width"});
-      margin: auto;
-      font-size: 28px;
-      padding: 8px 0;
-      display: flex;
-      flex-direction: row;
-
-      .wrapper {
-        width: env(titlebar-area-width, 100%);
-        padding: 0 20px;
-        display: flex;
-        box-sizing: border-box;
-        position: relative;
-
-        .sb-notifications {
-          position: absolute;
-          right: 20px;
-          top: 50px;
-
-          font-size: 15px;
-          z-index: 100;
-
-          > div {
-            padding: 3px;
-            margin-bottom: 3px;
-            border-radius: 5px;
-          }
-        }
-      }
-    }
-
-    #sb-current-page {
-      flex: 1;
-
-      overflow: hidden;
-      white-space: nowrap;
-      text-align: left;
-      display: block;
-
-      -webkit-app-region: drag;
-
-      .cm-scroller {
-        font-family: var(--ui-font);
-      }
-
-      .cm-content {
-        padding: 0;
-
-        .cm-line {
-          padding: 0;
-          caret-color: var(--editor-caret-color);
-        }
-      }
-    }
-  }
-
-  .sb-actions {
-    display: flex;
-    flex: 0 0 auto;
-    text-align: right;
-  }
-
-  .progress-wrapper {
-    display: inline-block;
-    position: relative;
-    margin-top: 4px;
-    padding: 4px;
-    background-color: var(--top-background-color);
-  }
-
-  .progress-bar {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    font-size: 8px;
-  }
 }
 
 .sb-panel {

--- a/web/styles/top.scss
+++ b/web/styles/top.scss
@@ -72,7 +72,7 @@
     flex: 0 0 auto;
     text-align: right;
 
-    &.mobile-vertical button:first-of-type {
+    &.hamburger button:first-of-type {
       display: none;
     }
   }
@@ -99,11 +99,11 @@
 
 @media only screen and (max-width: 600px) {
   /* Style the menu as a vertical fly-out */
-  #sb-top .cm-scroller:has(.mobile-vertical) {
+  #sb-top .cm-scroller:has(.hamburger) {
     position: relative;
   }
 
-  #sb-top .sb-actions.mobile-vertical {
+  #sb-top .sb-actions.hamburger {
     position: absolute;
 
     top: 3px;
@@ -160,7 +160,7 @@
   }
 
   /* Style the menu as a bottom bar */
-  #sb-top .sb-actions.mobile-bar {
+  #sb-top .sb-actions.bottom-bar {
     position: fixed;
     bottom: 0;
     left: 0;

--- a/web/styles/top.scss
+++ b/web/styles/top.scss
@@ -1,0 +1,161 @@
+#sb-top {
+  display: flex;
+  flex-direction: row;
+  z-index: 20;
+
+  height: 55px;
+
+  .main {
+    flex: 2;
+    max-width: 100%;
+
+    .inner {
+      // Hack to not have SCSS precompile this value but use proper CSS variables
+      max-width: var(--#{"editor-width"});
+      margin: auto;
+      font-size: 28px;
+      padding: 8px 0;
+      display: flex;
+      flex-direction: row;
+
+      .wrapper {
+        width: env(titlebar-area-width, 100%);
+        padding: 0 20px;
+        display: flex;
+        box-sizing: border-box;
+        position: relative;
+
+        .sb-notifications {
+          position: absolute;
+          right: 20px;
+          top: 50px;
+
+          font-size: 15px;
+          z-index: 100;
+
+          >div {
+            padding: 3px;
+            margin-bottom: 3px;
+            border-radius: 5px;
+          }
+        }
+      }
+    }
+
+    #sb-current-page {
+      flex: 1;
+
+      overflow: hidden;
+      white-space: nowrap;
+      text-align: left;
+      display: block;
+
+      -webkit-app-region: drag;
+
+      .cm-scroller {
+        font-family: var(--ui-font);
+      }
+
+      .cm-content {
+        padding: 0;
+
+        .cm-line {
+          padding: 0;
+          caret-color: var(--editor-caret-color);
+        }
+      }
+    }
+  }
+
+  .sb-actions {
+    display: flex;
+    flex: 0 0 auto;
+    text-align: right;
+
+    button:first-of-type {
+      display: none;
+    }
+  }
+
+  .progress-wrapper {
+    display: inline-block;
+    position: relative;
+    margin-top: 4px;
+    padding: 4px;
+    background-color: var(--top-background-color);
+  }
+
+  .progress-bar {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    font-size: 8px;
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  /* Position the menu relative to .cm-scroller */
+  #sb-top .cm-scroller {
+    position: relative;
+  }
+
+  #sb-top .sb-actions {
+    position: absolute;
+
+    top: 3px;
+    right: 20px;
+    border-radius: 5px;
+    border: 1px solid #444;
+    width: 2.8rem;
+    background: color-mix(in srgb, var(--top-background-color) 90%, transparent);
+    backdrop-filter: blur(20px);
+    overflow: hidden;
+    flex-direction: column;
+    align-items: center;
+    z-index: 10;
+    transition: max-height 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+
+    /* Initial collapsed height */
+    max-height: 2.2rem;
+
+    .progress-wrapper {
+      order: 2;
+    }
+
+    button {
+      &:first-of-type {
+        display: initial;
+      }
+
+      &:not(.sb-code-copy-button) {
+        display: block;
+        height: 1.8rem;
+        text-align: center;
+        margin: 4px 0;
+        padding: 4px 0;
+      }
+
+      &:not(:first-of-type) {
+        margin: 8px 0;
+        opacity: 0;
+        transform: translateY(-10px);
+        transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
+      }
+    }
+
+    &:hover {
+      /* Expanded height limited to the viewport height minus some padding */
+      max-height: calc(100vh - 24px);
+      box-shadow: 0px 2px 15px rgba(0, 0, 0, 0.5);
+
+      button {
+        opacity: 1;
+        transform: translateY(0) translateX(0);
+      }
+    }
+  }
+}

--- a/web/styles/top.scss
+++ b/web/styles/top.scss
@@ -72,7 +72,7 @@
     flex: 0 0 auto;
     text-align: right;
 
-    button:first-of-type {
+    &.mobile-vertical button:first-of-type {
       display: none;
     }
   }
@@ -99,11 +99,11 @@
 
 @media only screen and (max-width: 600px) {
   /* Position the menu relative to .cm-scroller */
-  #sb-top .cm-scroller {
+  #sb-top .cm-scroller:has(.mobile-vertical) {
     position: relative;
   }
 
-  #sb-top .sb-actions {
+  #sb-top .sb-actions.mobile-vertical {
     position: absolute;
 
     top: 3px;

--- a/web/styles/top.scss
+++ b/web/styles/top.scss
@@ -98,7 +98,7 @@
 }
 
 @media only screen and (max-width: 600px) {
-  /* Position the menu relative to .cm-scroller */
+  /* Style the menu as a vertical fly-out */
   #sb-top .cm-scroller:has(.mobile-vertical) {
     position: relative;
   }
@@ -158,4 +158,27 @@
       }
     }
   }
-}
+
+  /* Style the menu as a bottom bar */
+  #sb-top .sb-actions.mobile-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    padding: 10px 0;
+    background: var(--top-background-color);
+    width: 100vw;
+    box-shadow: 0px 4px 8px black;
+    justify-content: space-around;
+    
+    button {
+      padding: 1em;
+      margin: 0;
+      height: unset;
+      width: unset;
+      
+      svg {
+        margin-bottom: -5px;
+      }
+    }
+  }
+}    

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -18,9 +18,9 @@ hideSyncButton: false
 hideEditButton: true # defaults to 'false'
 
 # Style the menu as a vertical fly-out on smaller screens (default)
-# Use `mobileMenuStyle: "mobile-bar"` to style it as a bar on the bottom of the screen
+# Use `mobileMenuStyle: "bottom-bar"` to style it as a bar on the bottom of the screen
 # Use `mobileMenuStyle: null` to prevent mobile-specific styling
-mobileMenuStyle: "mobile-vertical"
+mobileMenuStyle: "hamburger"
 
 # In PWA mode, SilverBullet automatically reopens the last opened page on boot, this can be disabled
 pwaOpenLastPage: true

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -17,6 +17,11 @@ hideSyncButton: false
 # Hide the edit button (available on mobile only)
 hideEditButton: true # defaults to 'false'
 
+# Style the menu as a vertical fly-out on smaller screens (default)
+# Use `mobileMenuStyle: "mobile-bar"` to style it as a bar on the bottom of the screen
+# Use `mobileMenuStyle: null` to prevent mobile-specific styling
+mobileMenuStyle: "mobile-vertical"
+
 # In PWA mode, SilverBullet automatically reopens the last opened page on boot, this can be disabled
 pwaOpenLastPage: true
 


### PR DESCRIPTION
Fixes #1033

Adapted the [implementation](https://community.silverbullet.md/t/collapsible-vertical-action-menu-for-mobilescreens-but-not-only/1552/7) by [Mr.Red](https://community.silverbullet.md/u/Mr.Red) and [Varenia](https://community.silverbullet.md/u/s-varenia) from the SB Community.

1. The mobile menu button is added directly in the Main UI ViewComponent's actionButtons property.
2. The styling for `#sb-top` is moved to its own file, so that the media query can stay close to it. Hopefully this makes it less likely that the mobile menu is forgotten when updating the top bar styling.
3. Use CSS nesting (original implementation did not use nesting)