### PR TITLE
Content-Type header in HTTP custom endpoint response handlers are now respected

### DIFF
--- a/server/http_server.ts
+++ b/server/http_server.ts
@@ -227,7 +227,9 @@ export class HttpServer {
           }
         }
         ctx.status(response.status as any || 200);
-        if (typeof response.body === "string") {
+        if (response.headers["Content-Type"]) {
+          return ctx.body(response.body);
+        } else if (typeof response.body === "string") {
           return ctx.text(response.body);
         } else if (response.body instanceof Uint8Array) {
           return ctx.body(response.body.buffer as ArrayBuffer);


### PR DESCRIPTION
see [commit message](https://github.com/silverbulletmd/silverbullet/commit/0b8cdd17aabef256117eee0dd29e7028d1d21681)
```
Content-Type header in HTTP custom endpoint response handlers are now respected
Before the commit, adding a Content-Type header in the reponse from the handler of a http:request:foobar event would be ignored and set to text/plain because of using ctx.text to return the request. ctx.text will set Content-Type to text/plain.

Now, if a Content-Type header is detected it will use a plain ctx.body response which does not alter Content-Type.
```