### PR TITLE
fix(menu): only hide expander button and show button on (small) desktop

### DIFF
--- a/web/editor_ui.tsx
+++ b/web/editor_ui.tsx
@@ -299,11 +299,11 @@ export class MainUI {
           }}
           actionButtons={[
             // Vertical menu button
-            ...(viewState.isMobile &&
-                viewState.config.mobileMenuStyle.includes("hamburger"))
+            ...(viewState.config.mobileMenuStyle.includes("hamburger"))
               ? [{
                 icon: featherIcons.MoreVertical,
                 description: "Open Menu",
+                class: "expander",
                 callback:
                   () => {/* nothing to do, menu opens on hover/mobile click */},
               }]

--- a/web/styles/top.scss
+++ b/web/styles/top.scss
@@ -72,7 +72,7 @@
     flex: 0 0 auto;
     text-align: right;
 
-    &.hamburger button:first-of-type {
+    &.hamburger button.expander {
       display: none;
     }
   }
@@ -131,7 +131,7 @@
     }
 
     button {
-      &:first-of-type {
+      &.expander {
         display: initial;
       }
 


### PR DESCRIPTION
The expander button was only shown on mobile devices (if no mouse is detected), but the menu is a responsive menu.
Therefore on desktop, it hid the sync button instead.

1. By adding a class to the button, we can hide it explicitly, reducing the chances of hiding the wrong button.
2. Remove the check on `viewState.isMobile` to also show the button on desktop (under 600px wide).

Thanks to @MrMugame for the bug report.
