### PR TITLE
fix(menu): Move sync progress wrapper outside of actions menu

### DIFF
--- a/web/components/top_bar.tsx
+++ b/web/components/top_bar.tsx
@@ -103,10 +103,7 @@ export function TopBar({
                 ))}
               </div>
             )}
-            <div
-              className={"sb-actions " +
-                (mobileMenuStyle ? mobileMenuStyle : "")}
-            >
+            <div className="sb-sync-progress">
               {progressPerc !== undefined &&
                 (
                   <div
@@ -121,6 +118,11 @@ export function TopBar({
                     </div>
                   </div>
                 )}
+            </div>
+            <div
+              className={"sb-actions " +
+                (mobileMenuStyle ? mobileMenuStyle : "")}
+            >
               {actionButtons.map((actionButton) => {
                 const button = (
                   <button

--- a/web/styles/top.scss
+++ b/web/styles/top.scss
@@ -78,9 +78,9 @@
   }
 
   .progress-wrapper {
-    display: inline-block;
     position: relative;
     margin-top: 4px;
+    margin-right: 6px;
     padding: 4px;
     background-color: var(--top-background-color);
   }
@@ -101,6 +101,10 @@
   /* Style the menu as a vertical fly-out */
   #sb-top .cm-scroller:has(.hamburger) {
     position: relative;
+  }
+
+  #sb-top .sb-sync-progress:has(~ .hamburger) {
+    margin-right: 1.8em;
   }
 
   #sb-top .sb-actions.hamburger {
@@ -125,10 +129,6 @@
 
     /* Initial collapsed height */
     max-height: 2.2rem;
-
-    .progress-wrapper {
-      order: 2;
-    }
 
     button {
       &.expander {


### PR DESCRIPTION
Move the sync progress wrapper outside of the container that holds the menu icons.
This way, sync progress is always visible, even on smaller screens where the menu might be hidden or moved.

Hamburger menu:
![image](https://github.com/user-attachments/assets/9250eb13-9c0a-4309-9ce0-443ff3885926)

Bottom bar:
![image](https://github.com/user-attachments/assets/1b2cf01a-ceb1-4cf4-ae99-1fe9d06058bd)
