### PR TITLE
[Change]: Catch event in capturing phase instead of bubbling phase inside document editors

### DIFF
--- a/web/document_editor_skeleton.ts
+++ b/web/document_editor_skeleton.ts
@@ -68,8 +68,9 @@ export const html = `<!DOCTYPE html>
 
       if (keyEvent.defaultPrevented) {
         event.preventDefault();
+        event.stopPropagation();
       }
-    });
+    }, true);
 
     globalThis.silverbullet = document.createDocumentFragment();
 


### PR DESCRIPTION
This is should be the default behaviour as silverbullet keybinds should always have priority over keybinds implemented by document editors.

*(When properly developing more complex things one notices a few things)*