### PR TITLE
Add support for application/xml content type in lua http.request

### DIFF
--- a/web/syscalls/fetch.ts
+++ b/web/syscalls/fetch.ts
@@ -49,7 +49,7 @@ export function sandboxFetchSyscalls(
       let body: any;
       if (resp.headers.get("Content-Type")?.startsWith("application/json")) {
         body = await resp.json();
-      } else if (resp.headers.get("Content-Type")?.startsWith("text/")) {
+      } else if (resp.headers.get("Content-Type")?.startsWith("application/xml") || resp.headers.get("Content-Type")?.startsWith("text/")) {
         body = await resp.text();
       } else {
         body = new Uint8Array(await resp.arrayBuffer());


### PR DESCRIPTION
Doing http requests to application/xml returns integer array instead of text. This would return text we can parse. issue (#1319) 