### PR TITLE
Add support for Lua templating in SB_INDEX_PAGE [#1325]

### DIFF
--- a/cmd/server.test.ts
+++ b/cmd/server.test.ts
@@ -1,0 +1,78 @@
+import { assertEquals } from "@std/assert";
+import { LuaStackFrame, LuaTable } from "../common/space_lua/runtime.ts";
+import { luaBuildStandardEnv } from "../common/space_lua/stdlib.ts";
+
+// Helper function to set up a Lua environment with standard library functions
+function setupLuaEnv() {
+  const env = luaBuildStandardEnv();
+  const sf = new LuaStackFrame(env, null);
+  sf.threadLocal.set("_GLOBAL", env);
+  return { env, sf };
+}
+
+Deno.test("SB_INDEX_PAGE template interpolation", async (t) => {
+  await t.step("simple string - no interpolation", async () => {
+    const { env, sf } = setupLuaEnv();
+    const result = await env.get("spacelua").get("interpolate").call(
+      sf,
+      "Journal",
+      new LuaTable(),
+    );
+    assertEquals(result, "Journal", "Simple string is returned as-is");
+  });
+
+  await t.step("default behavior - no interpolation", async () => {
+    const { env, sf } = setupLuaEnv();
+    const result = await env.get("spacelua").get("interpolate").call(
+      sf,
+      "index",
+      new LuaTable(),
+    );
+    assertEquals(result, "index", "Default index page is 'index'");
+  });
+
+  await t.step("string function interpolation", async () => {
+    const { env, sf } = setupLuaEnv();
+    const result = await env.get("spacelua").get("interpolate").call(
+      sf,
+      "Journal/${string.upper('test')}",
+      new LuaTable(),
+    );
+    assertEquals(
+      result,
+      "Journal/TEST",
+      "String function is correctly evaluated",
+    );
+  });
+
+  await t.step("error handling - invalid Lua expression", async () => {
+    const { env, sf } = setupLuaEnv();
+    try {
+      await env.get("spacelua").get("interpolate").call(
+        sf,
+        "Journal/${invalid + expression}",
+        new LuaTable(),
+      );
+      throw new Error("Expected invalid expression to throw an error");
+    } catch (e: any) {
+      assertEquals(typeof e.message, "string", "Error message is a string");
+      assertEquals(e.message !== "", true, "Error message is not empty");
+    }
+  });
+
+  await t.step("SB_INDEX_PAGE with os.date", async () => {
+    const { env, sf } = setupLuaEnv();
+    const result = await env.get("spacelua").get("interpolate").call(
+      sf,
+      "Journal/${os.date('%Y-%m-%d')}",
+      new LuaTable(),
+    );
+    assertEquals(typeof result, "string");
+    const dateRegex = /^Journal\/\d{4}-\d{2}-\d{2}$/;
+    assertEquals(
+      dateRegex.test(result),
+      true,
+      "Date string matches format Journal/YYYY-MM-DD",
+    );
+  });
+});

--- a/cmd/server.test.ts
+++ b/cmd/server.test.ts
@@ -67,12 +67,20 @@ Deno.test("SB_INDEX_PAGE template interpolation", async (t) => {
       "Journal/${os.date('%Y-%m-%d')}",
       new LuaTable(),
     );
-    assertEquals(typeof result, "string");
-    const dateRegex = /^Journal\/\d{4}-\d{2}-\d{2}$/;
-    assertEquals(
-      dateRegex.test(result),
-      true,
-      "Date string matches format Journal/YYYY-MM-DD",
+    assertEquals(typeof result, "string", "Result is a string");
+    assertEquals(result.startsWith("Journal/"), true, "Result starts with Journal/");
+    assertEquals(result.length > "Journal/".length, true, "Result contains date");
+  });
+
+  await t.step("SB_INDEX_PAGE with multiple expressions", async () => {
+    const { env, sf } = setupLuaEnv();
+    const result = await env.get("spacelua").get("interpolate").call(
+      sf,
+      "Journal/${os.date('%Y')}/${os.date('%m')}/${os.date('%d')}",
+      new LuaTable(),
     );
+    assertEquals(typeof result, "string", "Result is a string");
+    assertEquals(result.startsWith("Journal/"), true, "Result starts with Journal/");
+    assertEquals(result.split("/").length >= 4, true, "Result contains multiple date parts");
   });
 });

--- a/cmd/server.ts
+++ b/cmd/server.ts
@@ -9,6 +9,8 @@ import { AssetBundle, type AssetJson } from "../lib/asset_bundle/bundle.ts";
 
 import { determineDatabaseBackend } from "../server/db_backend.ts";
 import { sleep } from "$lib/async.ts";
+import { LuaStackFrame } from "$common/space_lua/runtime.ts";
+import { luaBuildStandardEnv } from "$common/space_lua/stdlib.ts";
 
 export type AuthOptions = {
   authToken?: string;
@@ -37,7 +39,23 @@ export async function serveCommand(
 
   const readOnly = !!Deno.env.get("SB_READ_ONLY");
 
-  const indexPage = Deno.env.get("SB_INDEX_PAGE") || "index";
+  // Support template syntax in SB_INDEX_PAGE
+  let indexPage = Deno.env.get("SB_INDEX_PAGE") || "index";
+  if (indexPage.includes("${")) {
+    // Create a Lua environment with standard library to evaluate the template
+    const env = luaBuildStandardEnv();
+    const sf = new LuaStackFrame(env, null);
+    sf.threadLocal.set("_GLOBAL", env);
+    try {
+      indexPage = await env.get("spacelua").get("interpolate").call(
+        sf,
+        indexPage,
+      );
+    } catch (e) {
+      console.error("Error evaluating SB_INDEX_PAGE template:", e);
+      indexPage = "index";
+    }
+  }
 
   if (!folder) {
     // Didn't get a folder as an argument, check if we got it as an environment variable

--- a/cmd/server.ts
+++ b/cmd/server.ts
@@ -39,23 +39,8 @@ export async function serveCommand(
 
   const readOnly = !!Deno.env.get("SB_READ_ONLY");
 
-  // Support template syntax in SB_INDEX_PAGE
-  let indexPage = Deno.env.get("SB_INDEX_PAGE") || "index";
-  if (indexPage.includes("${")) {
-    // Create a Lua environment with standard library to evaluate the template
-    const env = luaBuildStandardEnv();
-    const sf = new LuaStackFrame(env, null);
-    sf.threadLocal.set("_GLOBAL", env);
-    try {
-      indexPage = await env.get("spacelua").get("interpolate").call(
-        sf,
-        indexPage,
-      );
-    } catch (e) {
-      console.error("Error evaluating SB_INDEX_PAGE template:", e);
-      indexPage = "index";
-    }
-  }
+  // Get the index page template without evaluating it
+  const indexPage = Deno.env.get("SB_INDEX_PAGE") || "index";
 
   if (!folder) {
     // Didn't get a folder as an argument, check if we got it as an environment variable


### PR DESCRIPTION
Example with Docker Compose (the `$$` escapes a single `$`):

```yaml
environment:
  - SB_INDEX_PAGE=Journal/$${os.date('%Y-%m-%d')}
```