### PR TITLE
Added paragraphs to tag-page

### DIFF
--- a/Library/Std/Tag.md
+++ b/Library/Std/Tag.md
@@ -36,6 +36,15 @@ event.listen {
       text = text .. "## Items\n"
         .. template.each(taggedItems, templates.itemItem)
     end
+    local taggedParagraphs = query[[
+      from index.tag "paragraph"
+      order by ref
+      where table.includes(_.tags, tagName)
+    ]]
+    if #taggedParagraphs > 0 then
+      text = text .. "## Paragraphs\n"
+        .. template.each(taggedParagraphs, templates.itemItem)
+    end
     return {
       text = text,
       -- Read only page


### PR DESCRIPTION
Paragraphs were not included in the queries of the tag page.

Second attempt, as previous PR got closed by moving v2 to main.