### PR TITLE
Add optional argument to template.each for empty collection output

### DIFF
--- a/Library/Std/Pages/Maintenance.md
+++ b/Library/Std/Pages/Maintenance.md
@@ -10,7 +10,7 @@ ${template.each(query[[
   limit 20
 ]], template.new[==[
     * [[${ref}]]: broken link to [[${name}]]
-]==])}
+]==], "No aspiring pages, all good!")}
 
 # Conflicting copies
 These are pages that have conflicting copies (as a result of sync). Have a look at them as well as their original (non-conflicting) versions and decide which one to keep.
@@ -19,4 +19,4 @@ ${template.each(query[[
   from index.tag "page" where name:find("%.conflicted%.")
 ]], template.new[==[
     * [[${name:gsub("%.conflicted%..+$", "")}]]: conflict copy [[${name}]]
-]==])}
+]==], "No conflicting pages!")}

--- a/Library/Std/Template.md
+++ b/Library/Std/Template.md
@@ -10,13 +10,20 @@ template = template or {}
 templates = {}
 
 -- Iterates over a table/array and applies a function to each element,
--- concatenating the results
-function template.each(tbl, fn)
+-- concatenating the results. The last, optional argument is output for empty table
+function template.each(tbl, fn, empty)
+  local empty = empty or ""
+  
   local result = {}
   for _, item in ipairs(tbl) do
       table.insert(result, fn(item))
   end
-  return table.concat(result)
+
+  if #result == 0 then
+    return empty
+  else
+    return table.concat(result)
+  end
 end
 
 -- Creates a new template function from a string template

--- a/website/API/template.md
+++ b/website/API/template.md
@@ -13,8 +13,8 @@ examples.sayHello = template.new[==[Hello ${name}!]==]
 
 And its use: ${examples.sayHello {name="Pete"}}
 
-## template.each(collection, template)
-Iterates over a collection and renders a template for each item.
+## template.each(collection, template, empty="")
+Iterates over a collection and renders a template for each item. Optionally specify output for an empty collection.
 
 Example:
 


### PR DESCRIPTION
When omitted, the function outputs empty string for empty table as before. The feature was motivated by the Maintenance page in v1 that showed messages instead of just empty blocks (ported over).

I tried to get this working without touching the stdlib, but since I can't define variables in `${ }` blocks I didn't manage to do it.