### PR TITLE
Fix table constructor in editor.filterBox example

### DIFF
--- a/website/API/editor.md
+++ b/website/API/editor.md
@@ -264,8 +264,8 @@ Shows a filter box UI.
 Example:
 ```lua
 local result = editor.filterBox("Select:", {
-    { name: "Option 1", value: "1" },
-    { name: "Option 2", value: "2" }
+    { name="Option 1", value="1" },
+    { name="Option 2", value="2", description="More details about 2" }
 })
 ```
 


### PR DESCRIPTION
This fixes #1344

Also added description field from FilterOption, others didn't seem relevant.