### PR TITLE
Fix index page naming during server initialization

### DIFF
--- a/server/space_server.ts
+++ b/server/space_server.ts
@@ -80,7 +80,7 @@ export class SpaceServer {
   }
 
   async ensureBasicPages() {
-    await this.ensurePageWithContent("index.md", INDEX_TEMPLATE);
+    await this.ensurePageWithContent(`${this.indexPage}.md`, INDEX_TEMPLATE);
     await this.ensurePageWithContent("CONFIG.md", CONFIG_TEMPLATE);
   }
 


### PR DESCRIPTION
This pull request ensures that the correct name for the index page is used during server initialization. This is relevant only when the default name is overridden using the `SB_INDEX_PAGE` environment variable. In such cases, we should create `<SB_INDEX_PAGE>.md` instead of `index.md`, using the default template content.