### PR TITLE
feat: configure vim in CONFIG

### DIFF
--- a/Library/Std/Config.md
+++ b/Library/Std/Config.md
@@ -142,4 +142,79 @@ config.define("actionButtons", {
   }
 })
 
+config.define("vim", {
+  description = "Vim mode configuration",
+  type = "object",
+  properties = {
+    unmap = {
+      description = "Keys to unmap",
+      type = "array",
+      items = {
+        oneOf = {
+          { type = "string" },
+          {
+            type = "object",
+            properties = {
+              key = { type = "string" },
+              mode = {
+                type = "string",
+                enum = {"normal", "insert", "visual"}
+              }
+            },
+            required = { "key" },
+            additionalProperties = false
+          }
+        }
+      }
+    },
+    map = {
+      description = "Custom mappings",
+      type = "array",
+      items = {
+        type = "object",
+        properties = {
+          map = { type = "string" },
+          to = { type = "string" },
+          mode = {
+            type = "string",
+            enum = {"normal", "insert", "visual"}
+          }
+        },
+        required = { "map", "to" },
+        additionalProperties = false
+      }
+    },
+    noremap = {
+      description = "Non-recursive custom mappings",
+      type = "array",
+      items = {
+        type = "object",
+        properties = {
+          map = { type = "string" },
+          to = { type = "string" },
+          mode = {
+            type = "string",
+            enum = {"normal", "insert", "visual"}
+          }
+        },
+        required = { "map", "to" },
+        additionalProperties = false
+      }
+    },
+    commands = {
+      description = "Custom Ex commands",
+      type = "array",
+      items = {
+        type = "object",
+        properties = {
+          command = { type = "string" },
+          ex = { type = "string" }
+        },
+        required = { "command", "ex" },
+        additionalProperties = false
+      }
+    },
+  },
+  additionalProperties = false
+})
 ```

--- a/plug-api/syscalls/editor.ts
+++ b/plug-api/syscalls/editor.ts
@@ -468,6 +468,13 @@ export function vimEx(exCommand: string): Promise<any> {
   return syscall("editor.vimEx", exCommand);
 }
 
+/**
+ * Execute a vim config using the CodeMirror Vim Mode API
+ */
+export function vimConfig(): Promise<any> {
+  return syscall("editor.vimConfig");
+}
+
 // Document editor specific syscalls
 
 /**

--- a/plugs/editor/editor.plug.yaml
+++ b/plugs/editor/editor.plug.yaml
@@ -305,6 +305,13 @@ functions:
       requireEditor: page
     events:
       - editor:modeswitch
+  loadVimConfig:
+    path: "./vim.ts:loadVimConfig"
+    command:
+      name: "Editor: Vim: Load Vim Config"
+      requireEditor: page
+    events:
+      - editor:modeswitch
 
   # Random stuff
   statsCommand:

--- a/plugs/editor/vim.ts
+++ b/plugs/editor/vim.ts
@@ -32,3 +32,18 @@ export async function loadVimRc() {
     // No VIMRC page found
   }
 }
+
+export async function loadVimConfig() {
+  const vimMode = await editor.getUiOption("vimMode");
+  if (!vimMode) {
+    console.log("Not in vim mode");
+    return;
+  }
+  try {
+    await editor.save();
+    await editor.reloadConfigAndCommands();
+    await editor.vimConfig();
+  } catch (e: any) {
+    await editor.flashNotification(e.message, "error");
+  }
+}

--- a/type/client.ts
+++ b/type/client.ts
@@ -46,3 +46,12 @@ export type SmartQuotesConfig = {
   double?: { left?: string; right?: string };
   single?: { left?: string; right?: string };
 };
+
+type vimMode = "normal" | "insert" | "visual";
+
+export type VimConfig = {
+  unmap?: (string | { key: string; mode?: vimMode })[];
+  map?: { map: string; to: string; mode?: vimMode }[];
+  noremap?: { map: string; to: string; mode?: vimMode }[];
+  commands?: { ex: string; command: string }[];
+};

--- a/website/Vim.md
+++ b/website/Vim.md
@@ -1,6 +1,66 @@
-SilverBullet has a basic Vim mode. You can toggle it using the 
+SilverBullet has a basic Vim mode. You can toggle it using the
 ${widgets.commandButton("Editor: Toggle Vim Mode")} command.
 
 In addition, it supports various ex commands that you can run as you would expect, for instance: `:imap jj <Esc>`.
 
-Also, you can use [[VIMRC]]
+These commands can be configured in a [[VIMRC]] file placed in the root directory.
+Alternatively, the [[CONFIG]] file can also be used to define and extend these commands. It supports the following:
+- **Key unmapping** - disable existing keybindings
+- **Custom mappings** - using `map` and `noremap`
+- **Ex command definitions** - map custom ex commands to built-in or custom SilverBullet commands
+
+Both the [[VIMRC]] and [[CONFIG]] files will run on boot and work alongside each other.
+
+To manually reload the `vim` section of your [[CONFIG]], use the
+${widgets.commandButton("Editor: Vim: Load Vim Config")} command.
+
+# Configuration
+Using Space Lua:
+
+```lua
+config.set {
+  vim = {
+    unmap = {
+      "<Space>",
+      {
+        key = "<C-c>",
+        mode = "insert",
+      },
+    },
+    map = {
+      {
+        map = "jj",
+        to = "<Esc>",
+        mode = "insert",
+      },
+    },
+    noremap = {
+      {
+        map = "<",
+        to = "<gv",
+        mode = "visual",
+      },
+      {
+        map = "<Space>ff",
+        to = ":findfile<CR>",
+        mode = "normal",
+      },
+      {
+        map = "<Space>rc",
+        to = ":runcommand<CR>",
+        mode = "normal",
+      },
+    },
+    commands = {
+      {
+        command = "Navigate: Page Picker",
+        ex = "findfile",
+      },
+      {
+        command = "Open Command Palette",
+        ex = "runcommand",
+      },
+    }
+  }
+}
+```


### PR DESCRIPTION
Alright, hear me out here.
I know what you are thinking; why do it via the CONFIG file when it can be done via VIMRC?

Well, the new Lua implementation is great, and I like customising SB with custom commands.
If I want to invoke these, I could use shortcuts, but then I'm limited to only some key bindings. I prefer custom vim keybindings.

To my knowledge, there is no way to map Vim keybindings to SilverBullet commands. (otherwise, this pull request is pointless)

So, this commit allows you to define a custom _ex_ command that invokes a SilverBullet command, which you can then map to a custom vim keybind.
Since the [CodeMirror Vim Mode API](https://codemirror.net/5/doc/manual.html#vimapi) also allows you to `map`, `unmap` and `noremap`, I've implemented these as well.

The CodeMirror API has some type inconsistencies, so it's not a 1 to 1 implementation; but the resulting functionality should be complete and consistent with expectations.

Consult the JSON schema and `Vim.md` on how to use it.

One thing that can be considered for the future, is to add a `Vim.mapclear` before running `loadVimRc` and `loadVimConfig`. If it is not cleared, old key bindings will stick around until a page reload. This can have unexpected behaviour when new bindings partially match old binding. 
You can't call mapclear in each function because it will leak and clear already mapped binding from the other function.
So in the future, these can maybe be combined into a single function/syscall. But I guess this is not high prio.