### PR TITLE
Generate version from git describe at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ silverbullet
 deploy.json
 *.generated
 tmp_playground
+/version.ts

--- a/build_bundle.ts
+++ b/build_bundle.ts
@@ -1,6 +1,9 @@
 import { denoPlugins } from "@luca/esbuild-deno-loader";
 import * as esbuild from "esbuild";
 
+import { updateVersionFile } from "./update_version.ts";
+
+await updateVersionFile();
 await Deno.mkdir("dist", { recursive: true });
 await esbuild.build({
   entryPoints: {

--- a/build_plugs.ts
+++ b/build_plugs.ts
@@ -4,6 +4,9 @@ import { compileManifests } from "./cmd/compile.ts";
 import { builtinPlugNames } from "./plugs/builtin_plugs.ts";
 import { parseArgs } from "@std/cli/parse-args";
 import { fileURLToPath } from "node:url";
+import { updateVersionFile } from "./update_version.ts";
+
+await updateVersionFile();
 
 if (import.meta.main) {
   const args = parseArgs(Deno.args, {

--- a/build_web.ts
+++ b/build_web.ts
@@ -8,6 +8,9 @@ import { parseArgs } from "@std/cli/parse-args";
 import { patchDenoLibJS } from "./cmd/compile.ts";
 import { denoPlugins } from "@luca/esbuild-deno-loader";
 import * as esbuild from "esbuild";
+import { updateVersionFile } from "./update_version.ts";
+
+await updateVersionFile();
 
 export async function bundleAll(
   watch: boolean,

--- a/update_version.ts
+++ b/update_version.ts
@@ -10,7 +10,7 @@ export async function updateVersionFile() {
   process.close();
 
   const versionFilePath = "./version.ts";
-  const versionContent = `export const version = \"${commitHash}\";\n`;
+  const versionContent = `export const version = \"2.0-beta (${commitHash})\";\n`;
 
   await Deno.writeTextFile(versionFilePath, versionContent);
   console.log(`Updated version.ts with version information: ${commitHash}`);

--- a/update_version.ts
+++ b/update_version.ts
@@ -1,0 +1,17 @@
+export async function updateVersionFile() {
+  const process = Deno.run({
+    cmd: ["git", "describe", "--tags", "--long", "--dirty"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const output = await process.output();
+  const commitHash = new TextDecoder().decode(output).trim();
+  process.close();
+
+  const versionFilePath = "./version.ts";
+  const versionContent = `export const version = \"${commitHash}\";\n`;
+
+  await Deno.writeTextFile(versionFilePath, versionContent);
+  console.log(`Updated version.ts with version information: ${commitHash}`);
+}

--- a/update_version.ts
+++ b/update_version.ts
@@ -1,17 +1,16 @@
 export async function updateVersionFile() {
-  const process = Deno.run({
-    cmd: ["git", "describe", "--tags", "--long", "--dirty"],
+  const command = new Deno.Command("git", {
+    args: ["describe", "--tags", "--long", "--dirty"],
     stdout: "piped",
     stderr: "piped",
   });
 
-  const output = await process.output();
-  const commitHash = new TextDecoder().decode(output).trim();
-  process.close();
+  const { stdout } = await command.output();
+  const commitVersion = new TextDecoder().decode(stdout).trim();
 
   const versionFilePath = "./version.ts";
-  const versionContent = `export const version = \"2.0-beta (${commitHash})\";\n`;
+  const versionContent = `export const version = "2.0-beta (${commitVersion})";\n`;
 
   await Deno.writeTextFile(versionFilePath, versionContent);
-  console.log(`Updated version.ts with version information: ${commitHash}`);
+  console.log(`Updated version.ts with version information: ${commitVersion}`);
 }

--- a/version.ts
+++ b/version.ts
@@ -1,1 +1,0 @@
-export const version = "2.0-beta";


### PR DESCRIPTION
Generate version from git describe at build time using:

```bash
git describe --tags --long --dirty
```

This makes it easy to identify the exact version a particular instance is running.

Calling `${system.getVersion()}` now returns a string like `"2.0-beta (0.10.4-209-gcdbee2fa)"`.