### PR TITLE
Allow non-zero shell exit codes

### DIFF
--- a/web/syscalls/shell.ts
+++ b/web/syscalls/shell.ts
@@ -45,9 +45,6 @@ export function shellSyscalls(
         },
       );
       const { code, stderr, stdout } = await (await resp).json();
-      if (code !== 0) {
-        throw new Error(stderr);
-      }
       return { code, stderr, stdout };
     },
     "shell.spawn": (


### PR DESCRIPTION
In the current implementation, an exception is thrown when a shell command exits with a non-zero code. While there may have been a good reason for this behavior, in my use case, non-zero exit codes are expected and should not result in an exception.

This pull request proposes removing the exception and returning the `code`, `stdout`, and `stderr` as-is. If there was a specific scenario this was meant to safeguard, I’m happy to adapt the pull request - but in that case, I’d need more context on what it’s protecting against.