### PR TITLE
Fix domain v1

### DIFF
--- a/common/PAGE_TEMPLATES.ts
+++ b/common/PAGE_TEMPLATES.ts
@@ -1,12 +1,12 @@
 export const SETTINGS_TEMPLATE = `#meta
 
-This page contains some configuration overrides for SilverBullet. A list of configs and their documentation [[!silverbullet.md/SETTINGS|can be found here]].
+This page contains some configuration overrides for SilverBullet. A list of configs and their documentation [[!v1.silverbullet.md/SETTINGS|can be found here]].
 
-To update the [[!silverbullet.md/Libraries|libraries]] specified below, run {[Libraries: Update]}
+To update the [[!v1.silverbullet.md/Libraries|libraries]] specified below, run {[Libraries: Update]}
 
 \`\`\`yaml
 libraries:
-- import: "[[!silverbullet.md/Library/Core/*]]"
+- import: "[[!v1.silverbullet.md/Library/Core/*]]"
 \`\`\`
 `;
 
@@ -15,5 +15,5 @@ export const INDEX_TEMPLATE =
 
 For your convenience we're embedding some on-boarding info below. Feel free to delete it once you're done reading it.
 
-![[!silverbullet.md/Getting Started]]
+![[!v1.silverbullet.md/Getting Started]]
 `;

--- a/plug-api/lib/resolve.test.ts
+++ b/plug-api/lib/resolve.test.ts
@@ -29,7 +29,7 @@ Deno.test("Test URL resolver", () => {
   );
   assertEquals(
     resolvePath("!v1.silverbullet.md", "/test/image.png", true),
-    "https://silverbullet.md/test/image.png",
+    "https://v1.silverbullet.md/test/image.png",
   );
 
   // Relative paths
@@ -49,17 +49,17 @@ Deno.test("Test URL resolver", () => {
   );
   assertEquals(
     resolvePath("!v1.silverbullet.md", "test/image.png", true),
-    "https://silverbullet.md/test/image.png",
+    "https://v1.silverbullet.md/test/image.png",
   );
   // Federated pages
   assertEquals(resolvePath("!bla/bla", "!bla/bla2"), "!bla/bla2");
   assertEquals(
     federatedPathToUrl("!v1.silverbullet.md"),
-    "https://silverbullet.md",
+    "https://v1.silverbullet.md",
   );
   assertEquals(
     federatedPathToUrl("!v1.silverbullet.md/index"),
-    "https://silverbullet.md/index",
+    "https://v1.silverbullet.md/index",
   );
 
   assertEquals(cleanPageRef("hello"), "hello");

--- a/plug-api/lib/resolve.test.ts
+++ b/plug-api/lib/resolve.test.ts
@@ -16,19 +16,19 @@ Deno.test("Test URL resolver", () => {
   assertEquals("bla@123", resolvePath("somewhere", "/bla@123"));
   assertEquals("test.jpg", resolvePath("folder/test", "/test.jpg"));
   assertEquals(
-    resolvePath("!silverbullet.md", "/some page"),
-    "!silverbullet.md/some page",
+    resolvePath("!v1.silverbullet.md", "/some page"),
+    "!v1.silverbullet.md/some page",
   );
   assertEquals(
-    resolvePath("!silverbullet.md/some/deep/path", "/some page"),
-    "!silverbullet.md/some page",
+    resolvePath("!v1.silverbullet.md/some/deep/path", "/some page"),
+    "!v1.silverbullet.md/some page",
   );
   assertEquals(
-    "!silverbullet.md/test.jpg",
-    resolvePath("!silverbullet.md/something/bla", "/test.jpg"),
+    "!v1.silverbullet.md/test.jpg",
+    resolvePath("!v1.silverbullet.md/something/bla", "/test.jpg"),
   );
   assertEquals(
-    resolvePath("!silverbullet.md", "/test/image.png", true),
+    resolvePath("!v1.silverbullet.md", "/test/image.png", true),
     "https://silverbullet.md/test/image.png",
   );
 
@@ -36,29 +36,29 @@ Deno.test("Test URL resolver", () => {
   assertEquals("test.jpg", resolvePath("test", "test.jpg"));
   assertEquals("folder/test.jpg", resolvePath("folder/test", "test.jpg"));
   assertEquals(
-    resolvePath("!silverbullet.md", "some page"),
-    "!silverbullet.md/some page",
+    resolvePath("!v1.silverbullet.md", "some page"),
+    "!v1.silverbullet.md/some page",
   );
   assertEquals(
-    "!silverbullet.md/something/test.jpg",
-    resolvePath("!silverbullet.md/something/bla", "test.jpg"),
+    "!v1.silverbullet.md/something/test.jpg",
+    resolvePath("!v1.silverbullet.md/something/bla", "test.jpg"),
   );
   assertEquals(
-    resolvePath("!silverbullet.md", "bla@123"),
-    "!silverbullet.md/bla@123",
+    resolvePath("!v1.silverbullet.md", "bla@123"),
+    "!v1.silverbullet.md/bla@123",
   );
   assertEquals(
-    resolvePath("!silverbullet.md", "test/image.png", true),
+    resolvePath("!v1.silverbullet.md", "test/image.png", true),
     "https://silverbullet.md/test/image.png",
   );
   // Federated pages
   assertEquals(resolvePath("!bla/bla", "!bla/bla2"), "!bla/bla2");
   assertEquals(
-    federatedPathToUrl("!silverbullet.md"),
+    federatedPathToUrl("!v1.silverbullet.md"),
     "https://silverbullet.md",
   );
   assertEquals(
-    federatedPathToUrl("!silverbullet.md/index"),
+    federatedPathToUrl("!v1.silverbullet.md/index"),
     "https://silverbullet.md/index",
   );
 
@@ -78,20 +78,20 @@ page render [[template/page]]
 page: "[[template/use-template]]"
 \`\`\`
 `);
-  rewritePageRefs(tree, "!silverbullet.md");
+  rewritePageRefs(tree, "!v1.silverbullet.md");
   let rewrittenText = renderToText(tree);
 
   assertEquals(
     rewrittenText,
     `
-This is a [[!silverbullet.md/local link]] and [[!silverbullet.md/local link|with alias]].
+This is a [[!v1.silverbullet.md/local link]] and [[!v1.silverbullet.md/local link|with alias]].
 
 \`\`\`query
-page render [[!silverbullet.md/template/page]]
+page render [[!v1.silverbullet.md/template/page]]
 \`\`\`
 
 \`\`\`template
-page: "[[!silverbullet.md/template/use-template]]"
+page: "[[!v1.silverbullet.md/template/use-template]]"
 \`\`\`
 `,
   );

--- a/plugs/federation/util.test.ts
+++ b/plugs/federation/util.test.ts
@@ -12,9 +12,9 @@ Deno.test("Test wildcardPathToRegex", () => {
 });
 
 Deno.test("Test federatedPathToLocalPath", () => {
-  assertEquals(federatedPathToLocalPath("!silverbullet.md"), "");
+  assertEquals(federatedPathToLocalPath("!v1.silverbullet.md"), "");
   assertEquals(
-    federatedPathToLocalPath("!silverbullet.md/Library/Core/test"),
+    federatedPathToLocalPath("!v1.silverbullet.md/Library/Core/test"),
     "Library/Core/test",
   );
 });

--- a/web/syscalls/fetch.ts
+++ b/web/syscalls/fetch.ts
@@ -49,7 +49,10 @@ export function sandboxFetchSyscalls(
       let body: any;
       if (resp.headers.get("Content-Type")?.startsWith("application/json")) {
         body = await resp.json();
-      } else if (resp.headers.get("Content-Type")?.startsWith("application/xml") || resp.headers.get("Content-Type")?.startsWith("text/")) {
+      } else if (
+        resp.headers.get("Content-Type")?.startsWith("application/xml") ||
+        resp.headers.get("Content-Type")?.startsWith("text/")
+      ) {
         body = await resp.text();
       } else {
         body = new Uint8Array(await resp.arrayBuffer());

--- a/website/Federation.md
+++ b/website/Federation.md
@@ -1,4 +1,4 @@
-Federation enables _browsing_ content from spaces _outside_ the user’s space, specified by quasi-URLs in the shape of `!domain.tld/path`. An example would be: [[!silverbullet.md/CHANGELOG]].
+Federation enables _browsing_ content from spaces _outside_ the user’s space, specified by quasi-URLs in the shape of `!domain.tld/path`. An example would be: [[!v1.silverbullet.md/CHANGELOG]].
 
 This enables a few things:
 

--- a/website/Libraries.md
+++ b/website/Libraries.md
@@ -14,22 +14,22 @@ When you set up a fresh space, the [[Library/Core]] is automatically configured:
 
 ```yaml
 libraries:
-- import: "[[!silverbullet.md/Library/Core/*]]"
+- import: "[[!v1.silverbullet.md/Library/Core/*]]"
 ```
 
 If you would like to _exclude_ specific pages, for instance [[Library/Core/Widget/Table of Contents]], you can do so using the library’s `exclude` attribute
 
 ```yaml
 libraries:
-- import: "[[!silverbullet.md/Library/Core/*]]"
+- import: "[[!v1.silverbullet.md/Library/Core/*]]"
   exclude:
-  - "[[!silverbullet.md/Library/Core/Widget/Table of Contents]]"
+  - "[[!v1.silverbullet.md/Library/Core/Widget/Table of Contents]]"
 ```
 
 In these paths, you can also use the `*` wildcard:
 
 ```yaml
-  - "[[!silverbullet.md/Library/Core/Widget/*]]"
+  - "[[!v1.silverbullet.md/Library/Core/Widget/*]]"
 ```
 
 This would exclude all widgets specified in the Core library.
@@ -40,7 +40,7 @@ To update all libraries from their original source (we recommend doing this regu
 Updating does the following for each library:
 
 1. It _deletes_ all pages under its local source prefix in your space. For instance for the Core library, this would be `Library/Core/*`. This means that you should **not make local changes** to these files, because they will be wiped out on every update.
-2. It downloads fresh copies from the `source` and puts them in the local source prefix (for `!silverbullet.md/Library/Core/*` this would be `Library/Core/`).
+2. It downloads fresh copies from the `source` and puts them in the local source prefix (for `!v1.silverbullet.md/Library/Core/*` this would be `Library/Core/`).
 3. It performs a {[System: Reload]} so all new commands and configurations are immediately available.
 
 # Where are libraries stored?

--- a/website/Library/Core.md
+++ b/website/Library/Core.md
@@ -11,7 +11,7 @@ Some examples:
 In your [[SETTINGS]] list the following under `libraries:`
 ```yaml
 libraries:
-- import: "[[!silverbullet.md/Library/Core/*]]"
+- import: "[[!v1.silverbullet.md/Library/Core/*]]"
 ```
 Then run the {[Libraries: Update]} command to install it.
 

--- a/website/Library/Core/Page/Space Overview.md
+++ b/website/Library/Core/Page/Space Overview.md
@@ -9,27 +9,27 @@ This page compiles some useful things about your space and may also be useful fo
 **Total tags:** {{count({tag select name})}}
 ```
 
-# Active [[!silverbullet.md/Space Script]]
+# Active [[!v1.silverbullet.md/Space Script]]
 ```template
 {{#each {space-script}}}
 * [[{{ref}}]]
 {{/each}}
 ```
 
-# Active [[!silverbullet.md/Space Lua]]
+# Active [[!v1.silverbullet.md/Space Lua]]
 ${template.each(query[[
   from index.tag "space-lua"
   select {name= ref}
 ]], templates.pageItem)}
 
-# Active [[!silverbullet.md/Space Style]]
+# Active [[!v1.silverbullet.md/Space Style]]
 ```template
 {{#each {space-style}}}
 * [[{{ref}}]]
 {{/each}}
 ```
 
-# Active [[!silverbullet.md/Space Config]]
+# Active [[!v1.silverbullet.md/Space Config]]
 You have space config defined on the following pages:
 ```template
 {{#each {space-config select replace(ref, /@.+/, "") as page}}}

--- a/website/Library/Core/Page/Template Index.md
+++ b/website/Library/Core/Page/Template Index.md
@@ -1,16 +1,16 @@
 #meta
 
-This page lists all templates currently available in your space. You can also navigate to them via the {[Navigate: Meta Picker]}. More information on templates can be found [[!silverbullet.md/Templates]]
+This page lists all templates currently available in your space. You can also navigate to them via the {[Navigate: Meta Picker]}. More information on templates can be found [[!v1.silverbullet.md/Templates]]
 
 # New Page
-These [[!silverbullet.md/Page Templates]] are available through the {[Page: From Template]} command:
+These [[!v1.silverbullet.md/Page Templates]] are available through the {[Page: From Template]} command:
 
 ```query
 template where hooks.newPage render [[Library/Core/Query/Template]]
 ```
 
 # Snippets
-These can be used as [[!silverbullet.md/Snippets]] via [[!silverbullet.md/Slash Commands]]:
+These can be used as [[!v1.silverbullet.md/Snippets]] via [[!v1.silverbullet.md/Slash Commands]]:
 
 ```template
 {{#each {
@@ -23,7 +23,7 @@ These can be used as [[!silverbullet.md/Snippets]] via [[!silverbullet.md/Slash 
 ```
 
 # Widgets
-Widgets can either be automatically attached to the top or bottom of pages (matching certain criteria) or used inline via [[!silverbullet.md/Live Templates]].
+Widgets can either be automatically attached to the top or bottom of pages (matching certain criteria) or used inline via [[!v1.silverbullet.md/Live Templates]].
 
 ## Top
 ```query
@@ -42,7 +42,7 @@ render [[Library/Core/Query/Template]]
 ```
 
 ## Inline
-Use with [[!silverbullet.md/Live Templates#Include]] to render useful things in your pages:
+Use with [[!v1.silverbullet.md/Live Templates#Include]] to render useful things in your pages:
 
 ```query
 template

--- a/website/Library/Journal.md
+++ b/website/Library/Journal.md
@@ -4,7 +4,7 @@ This [[Libraries|library]] contains some useful page templates for journalers. W
 In your [[SETTINGS]] list the following under `libraries:`
 ```yaml
 libraries:
-- import: "[[!silverbullet.md/Library/Journal/*]]"
+- import: "[[!v1.silverbullet.md/Library/Journal/*]]"
 ```
 Then run the {[Libraries: Update]} command to install it.
 

--- a/website/Live Template Widgets.md
+++ b/website/Live Template Widgets.md
@@ -20,7 +20,7 @@ The following widget template applies to all pages tagged with `person` (see the
     ---
     ## Incoming tasks
     ```template
-    page: "[[!silverbullet.md/Library/Core/Widget/Linked Tasks]]"
+    page: "[[!v1.silverbullet.md/Library/Core/Widget/Linked Tasks]]"
     ```
 
 More examples can be found [[Library/Core/Page/Template Index$widgets|here]].

--- a/website/SETTINGS.md
+++ b/website/SETTINGS.md
@@ -5,11 +5,11 @@ This page contains configuration of SilverBullet and its plugs. Some of these ch
 ```space-config
 libraries:
 # The "Core" library is recommended for all users
-- import: "[[!silverbullet.md/Library/Core/*]]"
+- import: "[[!v1.silverbullet.md/Library/Core/*]]"
   # You can exclude items from the import using exclude (also supports wildcards):
   #exclude:
-  # - "[[!silverbullet.md/Table of Contents]]"
-  # - "[[!silverbullet.md/Library/Core/Widget/*]]""
+  # - "[[!v1.silverbullet.md/Table of Contents]]"
+  # - "[[!v1.silverbullet.md/Library/Core/Widget/*]]""
 
 ## UI TWEAKS
 # Hide the sync button

--- a/website/Space Config.md
+++ b/website/Space Config.md
@@ -1,6 +1,6 @@
 While SilverBullet tries to set sensible defaults, you may want to tweak a few things here and there.
 
-This is where [[Space Config]] comes in. You can put fenced code blocks anywhere in your space (but the convention is to use [[^SETTINGS]]) with `space-config` as a language, and override the default configurations [[!silverbullet.md/SETTINGS|specified here]].
+This is where [[Space Config]] comes in. You can put fenced code blocks anywhere in your space (but the convention is to use [[^SETTINGS]]) with `space-config` as a language, and override the default configurations [[!v1.silverbullet.md/SETTINGS|specified here]].
 
 You can reload the configuration on demand using {[System: Reload]}, for some configurations a client (page) reload (Ctrl-r/Cmd-r in your browser) may be required.
 


### PR DESCRIPTION
Fixes #1381 

Change domain to v1.silverbullet.md
    
After the domain migration, some users[^1] who still use the old version complains about their installation being broken or incomplete.
    
This commit changes the domain to point to v1.silverbullet.md for v1 users

[^1]: Users for the Yunohost package [reporter on the Forum](https://community.silverbullet.md/t/silverbullet-packaged-for-yunohost-to-easily-self-host-it/313/14?u=fflorent) and [on Github](https://github.com/YunoHost-Apps/silverbullet_ynh/issues/33).