### PR TITLE
Order strings in queries using collation algorithm

### DIFF
--- a/Library/Std/Config.md
+++ b/Library/Std/Config.md
@@ -217,4 +217,25 @@ config.define("vim", {
   },
   additionalProperties = false
 })
+
+config.define("queryCollation", {
+  description = "Configure string ordering in queries",
+  type = "object",
+  properties = {
+    enabled = {
+      type = "boolean",
+      description = "Indicates whether string collation should be used instead of simple codepoint ordering"
+    },
+    locale = {
+      type = "string",
+      description = "Language tag to specify sorting rules (from BCP 47)"
+    },
+    options = {
+      type = "object",
+      description = "Additional options passed to Intl.Collator constructor"
+      -- See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#options
+    },
+  },
+  additionalProperties = false
+})
 ```

--- a/type/client.ts
+++ b/type/client.ts
@@ -55,3 +55,9 @@ export type VimConfig = {
   noremap?: { map: string; to: string; mode?: vimMode }[];
   commands?: { ex: string; command: string }[];
 };
+
+export type QueryCollationConfig = {
+  enabled?: boolean;
+  locale?: string;
+  options?: object;
+};

--- a/website/CONFIG.md
+++ b/website/CONFIG.md
@@ -43,6 +43,13 @@ config.set {
       key = "Ctrl-Shift-s",
       slashCommand = "stats"
     }
+  },
+  queryCollate = {
+    enabled = true,
+    locale = "en",
+    options = {
+      caseFirst = "upper"
+    }
   }
 }
 ```

--- a/website/Space Lua/Lua Integrated Query.md
+++ b/website/Space Lua/Lua Integrated Query.md
@@ -81,6 +81,8 @@ ${query[[
   limit 3
 ]]}
 
+Sorting of strings can be adjusted with `queryCollation` in [[^Library/Std/Config]]
+
 ## limit <expression>[, <expression>]
 The `limit` clause allows you to limit the number of results, optionally with an offset.
 


### PR DESCRIPTION
Configurable with queryCollation, default value maintains old behaviour. Added schema, example settings, and documentation to query page.

Close: #614
Close: #1316