### PR TITLE
Add optional priority attribute to PageCreatingContent

### DIFF
--- a/plug-api/types.ts
+++ b/plug-api/types.ts
@@ -203,6 +203,8 @@ export type PageCreatingEvent = {
 export type PageCreatingContent = {
   text: string;
   perm: "ro" | "rw";
+  // Default 0, higher is higher priority
+  priority?: number;
 };
 
 export type SlashCompletionOption = {


### PR DESCRIPTION
This PR introduces a way to override existing event listeners by adding an optional `priority` attribute to event callbacks. If multiple callbacks respond to the same event, the one with the highest priority is chosen.

I may have missed a more obvious or built-in solution, but this approach worked well in my case - and since the `priority` attribute is optional, it doesn't break any existing behavior.

Here's an example of how this can be used to override the default tag page:

```lua
event.listen {
  name = "editor:pageCreating",
  run = function(e)
    if not e.data.name:startsWith("tag:") then
      return
    end
    
    local text = "My custom tag-page\n"
    
    return {
      text = text,
      perm = "ro",
      priority = 1,
    }
  end
}
```

The main drawback is performance. Right now, all potential page variants are computed before selecting one, which isn’t ideal. It’s not an issue for me at the moment, but it could be optimized in the future.