### PR TITLE
Add GitHub Actions Cache to reduce build times

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,3 +86,5 @@ jobs:
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
I read on https://community.silverbullet.md/t/docker-image-included-software/1931/24 that build times were a concern, so I thought it would be worth taking a look at this.

The docker build should be pretty quick locally due to the layers being cached between builds, I imagine that for most builds the only changes should be when Silverbullet code changes and that's on the final layers. So the issue must be on GitHub Actions.

I added GitHub Actions Cache to the build and got these numbers
- control build: 9m 22s
- build with cache, first run: 11m 22s
- build with cache, second run: 1m 12s

Note that on my tests I removed these steps:
- "Login to Docker Hub"
- "Log in to the ghcr Container registry"
- "Extract metadata (tags, labels) for Docker"

There seems to be different strategies to caching a docker build step but I'm not really knowledgeable about them tbh. Here's an article explaining different strategies to caching:
https://www.blacksmith.sh/blog/cache-is-king-a-guide-for-docker-layer-caching-in-github-actions

I hope this helps.