### PR TITLE
Update registered syscall for event.listEvents

### DIFF
--- a/lib/plugos/syscalls/event.ts
+++ b/lib/plugos/syscalls/event.ts
@@ -6,7 +6,7 @@ export function eventSyscalls(eventHook: EventHookI): SysCallMapping {
     "event.dispatch": (_ctx, eventName: string, data: any) => {
       return eventHook.dispatchEvent(eventName, data);
     },
-    "event.list": () => {
+    "event.listEvents": () => {
       return eventHook.listEvents();
     },
   };

--- a/plug-api/syscalls/event.ts
+++ b/plug-api/syscalls/event.ts
@@ -43,5 +43,5 @@ export function dispatchEvent(
  * @returns an array of event names
  */
 export function listEvents(): Promise<string[]> {
-  return syscall("event.list");
+  return syscall("event.listEvents");
 }


### PR DESCRIPTION
The documentation, example, and other function names use `listEvents`, but `event.list` is being registered with the client.