### PR TITLE
feat: allow CONFIG.md in any directory

### DIFF
--- a/server/space_server.ts
+++ b/server/space_server.ts
@@ -81,7 +81,14 @@ export class SpaceServer {
 
   async ensureBasicPages() {
     await this.ensurePageWithContent(`${this.indexPage}.md`, INDEX_TEMPLATE);
-    await this.ensurePageWithContent("CONFIG.md", CONFIG_TEMPLATE);
+
+    const files = await this.spacePrimitives.fetchFileList();
+    const hasConfig = files.some(
+      (f) => f.name === "CONFIG.md" || f.name.endsWith("/CONFIG.md"),
+    );
+    if (!hasConfig) {
+      await this.ensurePageWithContent("CONFIG.md", CONFIG_TEMPLATE);
+    }
   }
 
   private async ensurePageWithContent(path: string, content: string) {


### PR DESCRIPTION
In this commit, the server checks for a `CONFIG.md` file in the entire file list, rather than only in the root directory.

Having this file in the root directory might be helpful for new users, as it provides a starter template at an easy to find location. However, if the file is moved to a custom location, the original template gets recreated after a server restart.

There's even a case to be made that this config file may not be necessary at all, since all `space-lua` code blocks are already evaluated.

Alternatively, this behaviour could be controlled via an environment variable, similar to how `SB_INDEX_PAGE` is handled, but I'm not sure what's preferred.