### PR TITLE
Use UTC year, month, and date for strings lacking time components

### DIFF
--- a/plug-api/lib/json.ts
+++ b/plug-api/lib/json.ts
@@ -54,9 +54,9 @@ export function cleanStringDate(d: Date): string {
   if (
     d.getUTCHours() === 0 && d.getUTCMinutes() === 0 && d.getUTCSeconds() === 0
   ) {
-    return d.getFullYear() + "-" +
-      String(d.getMonth() + 1).padStart(2, "0") + "-" +
-      String(d.getDate()).padStart(2, "0");
+    return d.getUTCFullYear() + "-" +
+      String(d.getUTCMonth() + 1).padStart(2, "0") + "-" +
+      String(d.getUTCDate()).padStart(2, "0");
   } else {
     return d.toISOString();
   }


### PR DESCRIPTION
For negative time zone offsets, object attribute dates were returning the day before the desired result.

See https://community.silverbullet.md/t/date-manipulation-problems/2389