### PR TITLE
fix: case insensitive admonitions by default

### DIFF
--- a/web/cm_plugins/admonition.ts
+++ b/web/cm_plugins/admonition.ts
@@ -37,7 +37,7 @@ function extractAdmonitionFields(rawText: string): AdmonitionFields | null {
 
   if (regexResults) {
     const preSpaces = regexResults[1] || "";
-    const admonitionType = regexResults[2];
+    const admonitionType = regexResults[2].toLowerCase();
     const postSyntax = regexResults[3];
     const postSpaces = regexResults[4] || "";
     const admonitionTitle: string = regexResults[5] || "";

--- a/web/styles/theme.scss
+++ b/web/styles/theme.scss
@@ -265,7 +265,7 @@ html[data-theme="dark"] {
   --editor-directive-background-color: #4c4c4c7d;
 }
 
-.sb-admonition[admonition="note"] {
+.sb-admonition[admonition="note" i] {
   .sb-admonition-type {
     &::before {
       width: var(--admonition-width) !important;
@@ -280,7 +280,7 @@ html[data-theme="dark"] {
   --admonition-color: #00b8d4;
 }
 
-.sb-admonition[admonition="warning"] {
+.sb-admonition[admonition="warning" i] {
   .sb-admonition-type {
     &::before {
       width: var(--admonition-width) !important;

--- a/website/Markdown/Admonitions.md
+++ b/website/Markdown/Admonitions.md
@@ -12,7 +12,7 @@ Custom admonitions can be added in a [[Space Style]] using the following format:
 
 ```space-style
 /* Replace the keyword with a word or phrase of your choice */
-.sb-admonition[admonition="keyword"] {
+.sb-admonition[admonition="keyword" i] {
   .sb-admonition-type * { display: none; }
   .sb-admonition-type::before { 
     width: var(--admonition-width) !important;


### PR DESCRIPTION
Fixes: #1402 

I don't really think it's a true valid issue since it can easily be overwritten using a custom `space-style` that is case-sensitive. But I can understand it can be a bit confusing since the docs point to a GitHub discussion that uses capitalization.

The CSS attribute is now explicitly set to be case-insensitive (this is also reflected in the updated docs), and the admonition attribute name has been standardized to lowercase to ensure the correct icon appears.

It's true that we lose case sensitivity here, but I don’t see a compelling reason for users to define multiple admonitions with the same name but different capitalizations.