### PR TITLE
Update widget header to not overflow container

### DIFF
--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -480,10 +480,11 @@
     position: relative;
     min-height: 48px;
   }
+
   .sb-lua-top-widget h1,
   .sb-lua-bottom-widget h1 {
-    margin: -15px -15px 0 -15px !important;
-    padding: 15px 15px 10px 15px !important;
+    margin: -10px -10px 10px -10px !important;
+    padding: 15px 10px !important;
     background-color: var(--editor-widget-background-color);
     font-size: 1.2em;
   }


### PR DESCRIPTION
- Increase the left, right, and top margins from -15px to -10px to match the container's padding.
- Add a 10px margin below the header to create consistent margin around the contents.
- Reduce horizontal padding to 10px.
- Increase bottom padding to 15px to match the top.