### PR TITLE
Fixing service worker and local storage conflicts when hosting multiple instances on same origin, different URL prefix but same space path

### DIFF
--- a/web/boot.ts
+++ b/web/boot.ts
@@ -1,7 +1,7 @@
 import { safeRun } from "$lib/async.ts";
 import { Client, type ClientConfig } from "./client.ts";
 
-const configCacheKey = "config";
+const configCacheKey = `silverbullet.${document.baseURI}.config`;
 
 safeRun(async () => {
   // First we attempt to fetch the config from the server
@@ -50,9 +50,15 @@ safeRun(async () => {
   }
   if (navigator.serviceWorker) {
     // Register service worker
+    const workerURL = new URL("service_worker.js", document.baseURI);
     navigator.serviceWorker
-      .register(new URL("service_worker.js", document.baseURI), {
+      .register(workerURL, {
         type: "module",
+        //limit the scope of the service worker to any potential URL prefix
+        scope: workerURL.pathname.substring(
+          0,
+          workerURL.pathname.lastIndexOf("/") + 1,
+        ),
       })
       .then((registration) => {
         console.log("Service worker registered...");

--- a/web/client.ts
+++ b/web/client.ts
@@ -145,7 +145,11 @@ export class Client {
   ) {
     // Generate a semi-unique prefix for the database so not to reuse databases for different space paths
     this.dbPrefix = "" +
-      simpleHash(clientConfig.spaceFolderPath);
+      simpleHash(
+        `${clientConfig.spaceFolderPath}:${
+          document.baseURI.replace(/\/*$/, "")
+        }`,
+      );
     this.onLoadRef = parseRefFromURI();
   }
 

--- a/web/service_worker.ts
+++ b/web/service_worker.ts
@@ -217,7 +217,8 @@ self.addEventListener("message", (event: any) => {
     }
     case "config": {
       const spaceFolderPath = event.data.config.spaceFolderPath;
-      const dbPrefix = "" + simpleHash(spaceFolderPath);
+      const dbPrefix = "" +
+        simpleHash(`${spaceFolderPath}:${baseURI.replace(/\/*$/, "")}`);
 
       // Setup space
       const kv = new IndexedDBKvPrimitives(dbPrefix);


### PR DESCRIPTION
(I was waiting on #1336 and the URL prefix PR to be resolved to tackle this since this depended on their outcome)

I've been using URL prefixes smoothly for many weeks now, except for this:

  When hosting _multiple_ Silverbullet instances on the same origin on different URL prefixes **BUT** with the same space folder/path - Docker container's path is always '/space' - conflicts and weird issues arise because the indexedDB name is derived only from the space path.

In this PR, to address the issue described above:
- Introduction of the URL prefix (if any) in deriving the database name
- Limiting the scope of the service worker to the URL prefix (if any) - otherwise multiple service workers can end up being active at once
- Tweaking the localStorage key a bit to include the URL prefix (and also adding the app name to play nicer with other potential applications on the same origin)


