### PR TITLE
feat: expandable mentions

### DIFF
--- a/Library/Std/Widgets.md
+++ b/Library/Std/Widgets.md
@@ -63,7 +63,7 @@ function widgets.toc(options)
   local text = editor.getText()
   local pageName = editor.getCurrentPage()
   local parsedMarkdown = markdown.parseMarkdown(text)
-  
+
   -- Collect all headers
   local headers = {}
   for topLevelChild in parsedMarkdown.children do
@@ -128,10 +128,6 @@ event.listen {
 -- priority: 10
 widgets = widgets or {}
 
-local mentionTemplate = template.new [==[
-* [[${_.ref}]]: “${_.snippet}”
-]==]
-
 function widgets.linkedMentions(pageName)
   pageName = pageName or editor.getCurrentPage()
   local linkedMentions = query[[
@@ -140,9 +136,22 @@ function widgets.linkedMentions(pageName)
     order by page
   ]]
   if #linkedMentions > 0 then
+    local html = "<h1>Linked Mentions</h1><ul>"
+    for _, mention in ipairs(linkedMentions) do
+      local hasMoreBtn = ""
+      if mention.hasMore then
+        hasMoreBtn = " <button class=\"sb-more-btn\" onclick=\"toggleSnippet(this)\">[more]</button>"
+      end
+      html = html .. "<li><a href=\"" .. mention.ref .. "\">" .. mention.ref .. "</a>: " ..
+        "<span class=\"sb-snippet\" data-snippet=\"" .. (mention.snippet or "") .. 
+        "\" data-full-snippet=\"" .. (mention.fullSnippet or "") .. 
+        "\" data-has-more=\"" .. (mention.hasMore and "true" or "false") .. "\">" ..
+        (mention.snippet or "") .. "</span>" .. hasMoreBtn .. "</li>"
+    end
+    html = html .. "</ul>"
+    
     return widget.new {
-      markdown = "# Linked Mentions\n"
-        .. template.each(linkedMentions, mentionTemplate)
+      html = html
     }
   end
 end

--- a/plugs/index/page_links.ts
+++ b/plugs/index/page_links.ts
@@ -82,10 +82,13 @@ export async function indexLinks({ name, tree }: IndexTreeEvent) {
       const url = resolvePath(name, "/" + wikiLinkPage.children![0].text!);
       const pos = wikiLinkPage.from!;
 
+      const snippetData = extractSnippetAroundIndex(pageText, pos, 300, 3, true);
       const link: any = {
         ref: `${name}@${pos}`,
         tag: "link",
-        snippet: extractSnippetAroundIndex(pageText, pos),
+        snippet: snippetData.snippet,
+        fullSnippet: snippetData.fullSnippet,
+        hasMore: snippetData.hasMore,
         pos,
         page: name,
         asTemplate: false,
@@ -125,10 +128,13 @@ export async function indexLinks({ name, tree }: IndexTreeEvent) {
       const pos = linkNode.from!;
       url = resolvePath(name, decodeURI(url));
 
+      const snippetData = extractSnippetAroundIndex(pageText, pos, 300, 3, true);
       const link: any = {
         ref: `${name}@${pos}`,
         tag: "link",
-        snippet: extractSnippetAroundIndex(pageText, pos),
+        snippet: snippetData.snippet,
+        fullSnippet: snippetData.fullSnippet,
+        hasMore: snippetData.hasMore,
         pos,
         page: name,
         asTemplate: false,
@@ -165,11 +171,14 @@ export async function indexLinks({ name, tree }: IndexTreeEvent) {
         for (const match of wikiLinkMatches) {
           const [_fullMatch, firstMark, url, alias, _lastMark] = match;
           const pos = codeText.from! + match.index! + firstMark.length;
+          const snippetData = extractSnippetAroundIndex(pageText, pos, 300, 3, true);
           const link: any = {
             ref: `${name}@${pos}`,
             tag: "link",
             page: name,
-            snippet: extractSnippetAroundIndex(pageText, pos),
+            snippet: snippetData.snippet,
+            fullSnippet: snippetData.fullSnippet,
+            hasMore: snippetData.hasMore,
             pos: pos,
             asTemplate: true,
           };
@@ -190,11 +199,14 @@ export async function indexLinks({ name, tree }: IndexTreeEvent) {
         for (const match of mdLinkMatches) {
           const [_fullMatch, alias, url] = match;
           const pos = codeText.from! + match.index! + 1;
+          const snippetData = extractSnippetAroundIndex(pageText, pos, 300, 3, true);
           const link: any = {
             ref: `${name}@${pos}`,
             tag: "link",
             page: name,
-            snippet: extractSnippetAroundIndex(pageText, pos),
+            snippet: snippetData.snippet,
+            fullSnippet: snippetData.fullSnippet,
+            hasMore: snippetData.hasMore,
             pos: pos,
             asTemplate: true,
           };
@@ -226,11 +238,14 @@ export async function indexLinks({ name, tree }: IndexTreeEvent) {
         if (match && match[0] === trimmed) {
           const [_fullMatch, firstMark, url, alias, _lastMark] = match;
           const pos = textNode.from! + match.index! + firstMark.length;
+          const snippetData = extractSnippetAroundIndex(pageText, pos, 300, 3, true);
           const link: any = {
             ref: `${name}@${pos}`,
             tag: "link",
             page: name,
-            snippet: extractSnippetAroundIndex(pageText, pos),
+            snippet: snippetData.snippet,
+            fullSnippet: snippetData.fullSnippet,
+            hasMore: snippetData.hasMore,
             pos: pos,
             asTemplate: false,
           };

--- a/plugs/index/snippet_extractor.test.ts
+++ b/plugs/index/snippet_extractor.test.ts
@@ -7,7 +7,7 @@ Deno.test("SnippetExtractor", () => {
     `;
   assertEquals(
     extractSnippetAroundIndex(testText, testText.indexOf("[[Diplomas]]")),
-    "This is all about [[Diplomas]], and stuff like that.",
+    "# Ongoing things This is all about [[Diplomas]], and stuff like that. More stuff.",
   );
 
   const testText2 =
@@ -15,6 +15,44 @@ Deno.test("SnippetExtractor", () => {
   `;
   assertEquals(
     extractSnippetAroundIndex(testText2, testText2.indexOf("[[Diplomas]]")),
-    "...much much much much much much much longer sentence [[Diplomas]], that just keeps and keeps and keeps and...",
+    "A much much much much much much much much much much much longer sentence [[Diplomas]], that just keeps and keeps and keeps and keeps and keeps going.",
   );
+
+  // Multi-line behavior
+  const testText3 = `Line 1
+Line 2 with [[Reference]]
+Line 3
+Line 4
+Line 5`;
+  assertEquals(
+    extractSnippetAroundIndex(testText3, testText3.indexOf("[[Reference]]")),
+    "Line 1 Line 2 with [[Reference]] Line 3",
+  );
+
+  // Long line with reference - ensure reference stays visible and centered
+  const longText = "Type the name of a non-existent page to create it.".repeat(
+    10,
+  );
+  const testText4 =
+    `Click on the page picker (book icon) icon at the top right, or hit \`Cmd-k\` (Mac) or \`Ctrl-k\` (Linux and Windows) to open the **page picker**.
+  * ${longText} Don't worry about folders existing, [[SilverBullet]] will automatically create them if they don't.
+  * Another line here`;
+  const result = extractSnippetAroundIndex(
+    testText4,
+    testText4.indexOf("[[SilverBullet]]"),
+  );
+
+  // Reference should always be visible in the result
+  assertEquals(result.includes("[[SilverBullet]]"), true);
+  // ... should also contain some context around it
+  assertEquals(result.includes("create them"), true);
+  // ... should not start with the very beginning of the long repeated text
+  assertEquals(result.startsWith("..."), true);
+
+  // Edge case: index beyond text bounds (triggers fallback)
+  const testText5 = "Hello\nWorld\nTest";
+  const beyondBoundsIndex = testText5.length + 10;
+  const fallbackResult = extractSnippetAroundIndex(testText5, beyondBoundsIndex);
+  // Fallback should return something, not break
+  assertEquals(typeof fallbackResult, "string");
 });

--- a/plugs/index/snippet_extractor.ts
+++ b/plugs/index/snippet_extractor.ts
@@ -1,6 +1,155 @@
 export function extractSnippetAroundIndex(
   text: string,
   index: number,
+  maxSnippetLength: number = 300,
+  maxLines: number = 3,
+): string {
+  if (index < 0 || index >= text.length) {
+    return "";
+  }
+  const lines = text.split("\n");
+  let currentPos = 0;
+  let targetLineIndex = -1;
+
+  // Find which line contains the index
+  for (let i = 0; i < lines.length; i++) {
+    const lineLength = lines[i].length + (i < lines.length - 1 ? 1 : 0); // +1 for newline except last line
+    if (index >= currentPos && index < currentPos + lineLength) {
+      targetLineIndex = i;
+      break;
+    }
+    currentPos += lineLength;
+  }
+
+  if (targetLineIndex === -1) {
+    // Fallback to original sentence-based logic if line detection fails
+    return extractSnippetAroundIndexLegacy(
+      text,
+      index,
+      Math.min(maxSnippetLength, 100),
+    );
+  }
+
+  // Calculate range of lines to include (up to maxLines, centered around target)
+  const linesToInclude = Math.min(maxLines, lines.length);
+  const linesAbove = Math.floor((linesToInclude - 1) / 2);
+  const linesBelow = linesToInclude - 1 - linesAbove;
+
+  const startLine = Math.max(0, targetLineIndex - linesAbove);
+  const endLine = Math.min(lines.length - 1, targetLineIndex + linesBelow);
+
+  const selectedLines = lines.slice(startLine, endLine + 1);
+
+  // Stop at markdown list boundaries to avoid including separate bullet points
+  const processedLines: string[] = [];
+  let foundTargetLine = false;
+
+  for (let i = 0; i < selectedLines.length; i++) {
+    const line = selectedLines[i];
+    const isCurrentTargetLine = (startLine + i) === targetLineIndex;
+
+    if (isCurrentTargetLine) {
+      foundTargetLine = true;
+      processedLines.push(line);
+    } else if (!foundTargetLine) {
+      // Before target line - include it
+      processedLines.push(line);
+    } else {
+      // After target line - check if it's a new bullet point or list item
+      const trimmedLine = line.trim();
+      if (trimmedLine.match(/^[*+-]\s/) || trimmedLine.match(/^\d+\.\s/)) {
+        // New bullt point or numbered list item
+        break;
+      }
+      processedLines.push(line);
+    }
+  }
+
+  let snippet = processedLines.join(" ").replace(/\s+/g, " ").trim();
+
+  // If snippet is still too long, truncate while centering around the reference
+  if (snippet.length > maxSnippetLength) {
+    // Calculate the position of the index within the multi-line snippet
+    let snippetStartPos = 0;
+    for (let i = 0; i < startLine; i++) {
+      snippetStartPos += lines[i].length + (i < lines.length - 1 ? 1 : 0); // +1 for newline except last line
+    }
+    const indexInSnippet = index - snippetStartPos;
+
+    // Center the truncation around the reference
+    const halfLength = Math.floor(maxSnippetLength / 2);
+    const ellipsisLength = 3;
+
+    // Calculate ideal start and end positions centered on the reference
+    let idealStart = Math.max(0, indexInSnippet - halfLength);
+    let idealEnd = Math.min(snippet.length, indexInSnippet + halfLength);
+
+    // Adjust if at beginning/end, use available space
+    if (idealStart === 0) {
+      idealEnd = Math.min(snippet.length, maxSnippetLength - ellipsisLength);
+    } else if (idealEnd === snippet.length) {
+      idealStart = Math.max(
+        0,
+        snippet.length - maxSnippetLength + ellipsisLength,
+      );
+    }
+
+    // Find word boundaries for cleaner truncation
+    let truncateStart = idealStart;
+    let truncateEnd = idealEnd;
+
+    // Adjust start to word boundary if not at the beginning
+    if (truncateStart > 0) {
+      const nearbySpace = snippet.lastIndexOf(" ", truncateStart + 20);
+      if (nearbySpace !== -1 && nearbySpace >= truncateStart - 20) {
+        truncateStart = nearbySpace + 1;
+      }
+    }
+
+    // Adjust end to word boundary if not at the end
+    if (truncateEnd < snippet.length) {
+      const nearbySpace = snippet.indexOf(" ", truncateEnd - 20);
+      if (nearbySpace !== -1 && nearbySpace <= truncateEnd + 20) {
+        truncateEnd = nearbySpace;
+      }
+    }
+
+    // Don't exceed maxSnippetLength with ellipsis
+    const needsStartEllipsis = truncateStart > 0;
+    const needsEndEllipsis = truncateEnd < snippet.length;
+    const availableLength = maxSnippetLength -
+      (needsStartEllipsis ? ellipsisLength : 0) -
+      (needsEndEllipsis ? ellipsisLength : 0);
+
+    if (truncateEnd - truncateStart > availableLength) {
+      // If still too long, prioritize keeping the reference centered
+      const excess = (truncateEnd - truncateStart) - availableLength;
+      const reduceStart = Math.floor(excess / 2);
+      const reduceEnd = excess - reduceStart;
+
+      truncateStart += reduceStart;
+      truncateEnd -= reduceEnd;
+    }
+
+    let truncated = snippet.substring(truncateStart, truncateEnd).trim();
+
+    if (needsStartEllipsis) {
+      truncated = "..." + truncated;
+    }
+    if (needsEndEllipsis) {
+      truncated = truncated + "...";
+    }
+
+    snippet = truncated;
+  }
+
+  return snippet;
+}
+
+// Legacy function for fallback compatibility
+function extractSnippetAroundIndexLegacy(
+  text: string,
+  index: number,
   maxSnippetLength: number = 100,
 ): string {
   // Use Intl.Segmenter to segment the text into sentences

--- a/web/boot.ts
+++ b/web/boot.ts
@@ -113,6 +113,30 @@ safeRun(async () => {
   );
   // @ts-ignore: on purpose
   globalThis.client = client;
+
+  // Expandable snippets for linked mentions
+  // @ts-ignore: on purpose
+  globalThis.toggleSnippet = function(button: HTMLButtonElement) {
+    const snippetSpan = button.previousElementSibling as HTMLElement;
+    if (!snippetSpan || !snippetSpan.classList.contains('sb-snippet')) {
+      console.error('Invalid snippet span found');
+      return;
+    }
+
+    const fullSnippet = snippetSpan.dataset.fullSnippet;
+    const shortSnippet = snippetSpan.dataset.snippet;
+
+    if (button.textContent === '[more]') {
+      // Expand to show full snippet
+      snippetSpan.textContent = fullSnippet || shortSnippet || '';
+      button.textContent = '[less]';
+    } else {
+      // Collapse to show short snippet
+      snippetSpan.textContent = shortSnippet || '';
+      button.textContent = '[more]';
+    }
+  };
+
   await client.init();
 });
 

--- a/web/components/panel_html.ts
+++ b/web/components/panel_html.ts
@@ -104,6 +104,29 @@ function loadJsByUrl(url,integrity=null) {
     document.documentElement.firstChild.appendChild(script);
   });
 }
+
+// Expandable snippets functionality
+function toggleSnippet(button) {
+  const snippetSpan = button.previousElementSibling;
+  if (!snippetSpan || !snippetSpan.classList.contains('sb-snippet')) {
+    console.error('Invalid snippet span found');
+    return;
+  }
+
+  const fullSnippet = snippetSpan.dataset.fullSnippet;
+  const shortSnippet = snippetSpan.dataset.snippet;
+  
+  if (button.textContent === '[more]') {
+    // Expand to show full snippet
+    snippetSpan.textContent = fullSnippet || shortSnippet || '';
+    button.textContent = '[less]';
+  } else {
+    // Collapse to show short snippet
+    snippetSpan.textContent = shortSnippet || '';
+    button.textContent = '[more]';
+  }
+}
+
 </script>
 </head>
 <body>

--- a/web/styles/main.scss
+++ b/web/styles/main.scss
@@ -155,3 +155,23 @@ body {
 .sb-markdown-toolbar:hover {
   opacity: 1;
 }
+
+// Expandable snippets for linked mentions
+.sb-snippet {
+  transition: all 0.2s ease;
+}
+
+.sb-more-btn {
+  background: none;
+  border: none;
+  color: #007acc;
+  cursor: pointer;
+  font-size: 0.9em;
+  text-decoration: underline;
+  padding: 0;
+  margin-left: 4px;
+}
+
+.sb-more-btn:hover {
+  color: #005a9e;
+}


### PR DESCRIPTION
Hello, this is in reference to https://github.com/silverbulletmd/silverbullet/pull/1430 and allows expanding/collapsing the mention. Could be an alternative or addition.

_Note:_ Uses both HTML rendering (for buttons) and Markdown rendering (for formatted text).

**Collapsed**
<img width="774" alt="image" src="https://github.com/user-attachments/assets/05dd86a7-b2ff-4af6-969b-4bbc6d7c1f8b" />

**Expanded**
<img width="785" alt="image" src="https://github.com/user-attachments/assets/7b6de858-19e2-4f56-ab43-cd78db33084b" />
