### PR TITLE
upd: Improved Mention UI

### DIFF
--- a/Library/Std/Widgets.md
+++ b/Library/Std/Widgets.md
@@ -63,7 +63,7 @@ function widgets.toc(options)
   local text = editor.getText()
   local pageName = editor.getCurrentPage()
   local parsedMarkdown = markdown.parseMarkdown(text)
-  
+
   -- Collect all headers
   local headers = {}
   for topLevelChild in parsedMarkdown.children do
@@ -129,7 +129,9 @@ event.listen {
 widgets = widgets or {}
 
 local mentionTemplate = template.new [==[
-* [[${_.ref}]]: “${_.snippet}”
+**[[${_.ref}]]**
+> ${_.snippet}
+
 ]==]
 
 function widgets.linkedMentions(pageName)

--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -521,8 +521,7 @@
   }
 
   .sb-lua-bottom-widget blockquote {
-    margin-left: 5px;
-    margin-right: 5px;
+    margin: 0 5px;
     padding: 12px;
     border: 1px solid var(--editor-widget-background-color);
     border-radius: 8px;

--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -511,6 +511,26 @@
     padding: 10px;
   }
 
+  .sb-lua-bottom-widget p strong {
+    display: block;
+    padding: 10px 12px;
+    background-color: var(--editor-widget-background-color);
+    border: 1px solid var(--editor-widget-background-color);
+    border-radius: 8px 8px 0 0;
+    font-weight: 600;
+  }
+
+  .sb-lua-bottom-widget blockquote {
+    margin-left: 5px;
+    margin-right: 5px;
+    padding: 12px;
+    border: 1px solid var(--editor-widget-background-color);
+    border-radius: 8px;
+    background-color: var(--editor-widget-background-color);
+    color: var(--editor-text-color);
+    border-top: 1px solid var(--editor-widget-background-color);
+  }
+
   .sb-markdown-top-widget:has(*) .content {
     max-height: 500px;
   }


### PR DESCRIPTION
Hello, this PR updates the styling of the mentions widget.

*Rationale:* Better separation of mentions and headings are easier to skim over.

**After**
<img width="819" alt="image" src="https://github.com/user-attachments/assets/41fdacdd-8d95-4e4d-aa5f-60e8c1d8ecb5" />

**Before**
<img width="785" alt="image" src="https://github.com/user-attachments/assets/0a5f879a-3054-4e78-bc48-83f6c9d17dc0" />