### PR TITLE
Improvements for Modals

### DIFF
--- a/web/editor_ui.tsx
+++ b/web/editor_ui.tsx
@@ -397,15 +397,15 @@ export class MainUI {
           )}
         />
         <div id="sb-main">
-          {!!viewState.panels.lhs.mode && (
+          {(viewState.panels.lhs.mode !== undefined) && (
             <Panel config={viewState.panels.lhs} editor={client} />
           )}
           <div id="sb-editor" />
-          {!!viewState.panels.rhs.mode && (
+          {(viewState.panels.rhs.mode !== undefined) && (
             <Panel config={viewState.panels.rhs} editor={client} />
           )}
         </div>
-        {!!viewState.panels.modal.mode && (
+        {(viewState.panels.modal.mode !== undefined) && (
           <div
             className="sb-modal"
             style={{ inset: `${viewState.panels.modal.mode}px` }}
@@ -413,7 +413,7 @@ export class MainUI {
             <Panel config={viewState.panels.modal} editor={client} />
           </div>
         )}
-        {!!viewState.panels.bhs.mode && (
+        {(viewState.panels.bhs.mode !== undefined) && (
           <div className="sb-bhs">
             <Panel config={viewState.panels.bhs} editor={client} />
           </div>

--- a/web/styles/colors.scss
+++ b/web/styles/colors.scss
@@ -51,11 +51,6 @@
   background-color: var(--bhs-background-color);
 }
 
-.sb-modal {
-  border: 1px solid var(--modal-border-color);
-  background-color: var(--modal-background-color);
-}
-
 .sb-notifications {
   font-family: var(--editor-font);
 }

--- a/web/styles/main.scss
+++ b/web/styles/main.scss
@@ -114,6 +114,10 @@ body {
 
   .sb-panel {
     height: 100%;
+
+    iframe {
+      background-color: initial;
+    }
   }
 }
 


### PR DESCRIPTION
Modals had a background and border before, which made it hard to e.g. achieve rounded edges. I see no reason for this. If a modal should have a border/background the developer should add them themselves.
Also the check for rendering panels didn't allow for a `mode` of `0`, which was kind of weird imo. Took me a second to find that.