### PR TITLE
feat: collapsible mention section

### DIFF
--- a/Library/Std/Widgets.md
+++ b/Library/Std/Widgets.md
@@ -140,9 +140,16 @@ function widgets.linkedMentions(pageName)
     order by page
   ]]
   if #linkedMentions > 0 then
+    local htmlMentionTemplate = template.new [==[
+<li><a href="${_.ref}">${_.ref}</a>: "${_.snippet}"</li>
+]==]
+    
     return widget.new {
-      markdown = "# Linked Mentions\n"
-        .. template.each(linkedMentions, mentionTemplate)
+      html = "<div class=\"collapsible-linked-mentions collapsed\">" ..
+             "<h1 onclick=\"sbWidgets.toggleLinkedMentions(this)\" role=\"button\" aria-expanded=\"false\" tabindex=\"0\" onkeydown=\"if(event.key==='Enter'||event.key===' ') sbWidgets.toggleLinkedMentions(this)\">▶ Linked Mentions (" .. #linkedMentions .. ")</h1>" ..
+             "<div class=\"linked-mentions-content\" role=\"region\" aria-label=\"Linked mentions list\"><ul>" ..
+             template.each(linkedMentions, htmlMentionTemplate) ..
+             "</ul></div></div>"
     }
   end
 end

--- a/web/boot.ts
+++ b/web/boot.ts
@@ -113,6 +113,31 @@ safeRun(async () => {
   );
   // @ts-ignore: on purpose
   globalThis.client = client;
+
+  // Toggle function for collapsible linked mentions
+  // @ts-ignore: on purpose
+  globalThis.sbWidgets = globalThis.sbWidgets || {};
+  // @ts-ignore: on purpose
+  globalThis.sbWidgets.toggleLinkedMentions = function(header: HTMLElement) {
+    try {
+      const widget = header.closest('.collapsible-linked-mentions') as HTMLElement;
+      if (!widget) return;
+      
+      const isCollapsed = widget.classList.contains('collapsed');
+      if (isCollapsed) {
+        widget.classList.remove('collapsed');
+        header.textContent = header.textContent?.replace('▶', '▼') || '';
+        header.setAttribute('aria-expanded', 'true');
+      } else {
+        widget.classList.add('collapsed');
+        header.textContent = header.textContent?.replace('▼', '▶') || '';
+        header.setAttribute('aria-expanded', 'false');
+      }
+    } catch (error) {
+      console.error('Error toggling linked mentions:', error);
+    }
+  };
+
   await client.init();
 });
 

--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -489,6 +489,52 @@
     font-size: 1.2em;
   }
 
+  // Collapsible Linked Mentions
+  .collapsible-linked-mentions {
+    margin: 10px 0;
+    border: 1px solid var(--editor-widget-background-color);
+    border-radius: 5px;
+    background: var(--editor-background-color);
+
+    h1 {
+      cursor: pointer;
+      -webkit-user-select: none;
+      user-select: none;
+      margin: 0 !important;
+      padding: 15px !important;
+      background-color: var(--editor-widget-background-color);
+      font-weight: bold;
+      font-size: 1.2em;
+      border-radius: 5px 5px 0 0;
+    }
+
+    h1:hover {
+      background-color: var(--editor-selection-background-color);
+    }
+
+    .linked-mentions-content {
+      padding: 15px;
+      border-top: 1px solid var(--editor-widget-background-color);
+    }
+
+    &.collapsed .linked-mentions-content {
+      display: none;
+    }
+
+    &.collapsed h1 {
+      border-radius: 5px;
+    }
+
+    ul {
+      margin: 0;
+      padding-left: 20px;
+    }
+
+    li {
+      margin: 5px 0;
+    }
+  }
+
   .sb-markdown-top-widget h1,
   .sb-markdown-bottom-widget h1 {
     margin: 0 0 5px 0;


### PR DESCRIPTION
Hello, this makes the mention section collapsible by click (it is collapsed by default, could be changed). It also shows the total mentions (could be removed).

Note there is no change to the loading behavior (posssible async loading etc.). I didn't investigate this because I never really had long loading times :) 

_Rationale:_ If you have many mentions, it unnecessarily bloats the page.

<img width="795" alt="image" src="https://github.com/user-attachments/assets/1debaf1d-4e1b-4230-9f49-13510a5b7e1f" />
