### PR TITLE
fix: expose markdownToHtml

### DIFF
--- a/plug-api/syscalls/markdown.ts
+++ b/plug-api/syscalls/markdown.ts
@@ -22,3 +22,12 @@ export function renderParseTree(tree: ParseTree): Promise<string> {
 export function expandMarkdown(tree: ParseTree): Promise<ParseTree> {
   return syscall("markdown.expandMarkdown", tree);
 }
+
+/**
+ * Renders markdown text to HTML.
+ * @param markdownText the markdown text to render
+ * @returns HTML representation of the markdown
+ */
+export function markdownToHtml(markdownText: string): Promise<string> {
+  return syscall("markdown.markdownToHtml", markdownText);
+}

--- a/web/syscalls/markdown.ts
+++ b/web/syscalls/markdown.ts
@@ -26,10 +26,13 @@ export function markdownSyscalls(client: Client): SysCallMapping {
         LuaStackFrame.lostFrame,
       );
     },
-    "markdown.markdownToHtml": (_ctx, markdownText: string): string => {
-      // Parse the markdown text to ParseTree first, then render to HTML
-      const tree = parse(extendedMarkdownLanguage, markdownText);
-      return renderMarkdownToHtml(tree);
+    "markdown.markdownToHtml": (
+      _ctx,
+      text: string,
+      options: MarkdownRenderOptions = {},
+    ) => {
+      const mdTree = parse(extendedMarkdownLanguage, text);
+      return renderMarkdownToHtml(mdTree, options);
     },
   };
 }

--- a/web/syscalls/markdown.ts
+++ b/web/syscalls/markdown.ts
@@ -26,13 +26,10 @@ export function markdownSyscalls(client: Client): SysCallMapping {
         LuaStackFrame.lostFrame,
       );
     },
-    "markdown.markdownToHtml": (
-      _ctx,
-      text: string,
-      options: MarkdownRenderOptions = {},
-    ) => {
-      const mdTree = parse(extendedMarkdownLanguage, text);
-      return renderMarkdownToHtml(mdTree, options);
+    "markdown.markdownToHtml": (_ctx, markdownText: string): string => {
+      // Parse the markdown text to ParseTree first, then render to HTML
+      const tree = parse(extendedMarkdownLanguage, markdownText);
+      return renderMarkdownToHtml(tree);
     },
   };
 }


### PR DESCRIPTION
Hello, `markdownToHtml()` exists in Lua but is not exposed as a syscall for TypeScript plugins (stumbled over it [here](https://silverbullet.md/Library/Std/Export)).

This PR:
  1. Adds `markdown.markdownToHtml` syscall in `web/syscalls/markdown.ts` which converts a markdown string to HTML
  2. Adds the corresponding TypeScript API function in `plug-api/syscalls/markdown.ts`

  This ensures API parity between Lua and TypeScript environments, allowing plugins to render markdown
  content to HTML as documented.
  
  Do let me know if it is not expected to be exposed!