### PR TITLE
Redirect to auth page if ping returns 401

### DIFF
--- a/lib/spaces/http_space_primitives.ts
+++ b/lib/spaces/http_space_primitives.ts
@@ -90,7 +90,7 @@ export class HttpSpacePrimitives implements SpacePrimitives {
             "You are not authenticated, going to reload and hope that that kicks off authentication",
           );
           location.reload();
-          throw new Error("Not authenticated, got 401");
+          throw new Error("Not authenticated");
         }
       }
       return result;


### PR DESCRIPTION
Fix message thrown on 401/403 status in authenticatedFetch.

The client tests this string for an exact match in init() and if it's different assumes the server is offline rather than (as intended) doing a redirect to the auth page.
