### PR TITLE
upd: task cycle state to remove task

### DIFF
--- a/plugs/tasks/task.ts
+++ b/plugs/tasks/task.ts
@@ -390,6 +390,16 @@ export async function taskCycleCommand() {
     return;
   }
 
+  // Check if this ListItem already contains a Task (cursor might be at beginning of line)
+  const existingTask = findNodeOfType(listItem, "Task");
+  if (existingTask) {
+    const taskState = findNodeOfType(existingTask, "TaskState");
+    if (taskState) {
+      await cycleTaskState(taskState, true);
+    }
+    return;
+  }
+
   convertListItemToTask(listItem);
 }
 

--- a/plugs/tasks/task.ts
+++ b/plugs/tasks/task.ts
@@ -179,11 +179,23 @@ export function previewTaskToggle(eventString: string) {
 
 async function convertListItemToTask(node: ParseTree) {
   const listMark = node.children![0];
+  const originalMark = renderToText(listMark);
+  
+  // Determine the task marker based on the original list type
+  let taskMarker: string;
+  if (originalMark.match(/^\d+\./)) {
+    // Numbered list: preserve the number
+    taskMarker = originalMark + " [ ]";
+  } else {
+    // Bullet list: use standard bullet
+    taskMarker = "* [ ]";
+  }
+  
   await editor.dispatch({
     changes: {
       from: listMark.from,
       to: listMark.to,
-      insert: "* [ ]",
+      insert: taskMarker,
     },
   });
 }


### PR DESCRIPTION
Hello, this PR updates the task cycle command (`Alt+t`) to support an additional state of “no task”, and allows toggling also if the cursor is at the beginning of a line.

Example:
```
- Some test

// Alt+t
- [ ] Some test

// Alt+t
- [x] Some test

// Alt+t
- Some test
```

```
1. Some test

// Alt+t
1. [ ] Some test

// Alt+t
1. [x] Some test

// Alt+t
1. Some test
```