### PR TITLE
upd: page picker hierarchy

### DIFF
--- a/web/components/page_navigator.tsx
+++ b/web/components/page_navigator.tsx
@@ -128,7 +128,7 @@ export function PageNavigator({
           // Use the displayName or last bit of the path as the name
           name: pageMeta.displayName || pageMeta.name.split("/").pop()!,
           // And use the full path as the description
-          description: pageMeta.name.replaceAll("/", " > "),
+          description: pageMeta.name.replaceAll("/", " / "),
           hint: pageMeta.tags![0],
           orderId: orderId,
           cssClass,
@@ -143,7 +143,7 @@ export function PageNavigator({
         options.push({
           type: "page",
           meta: pageMeta,
-          name: pageMeta.name.replaceAll("/", " > "),
+          name: pageMeta.name.replaceAll("/", " / "),
           description,
           orderId: orderId,
           cssClass,


### PR DESCRIPTION
Hi, this is a very minor, visual only change for 'nested' pages to see the hierarchy more easily. Could keep the /, but I think the spaces help the eye.

**Before**
<img width="716" alt="image" src="https://github.com/user-attachments/assets/8b702a08-d413-4ccb-ac3d-bb13cdbcfad2" />

**After**
<img width="719" alt="image" src="https://github.com/user-attachments/assets/59ee7c8c-4e60-46d1-a76e-27d30bfc2319" />
