### PR TITLE
feat: keyboard shortcuts in action buttons

### DIFF
--- a/web/components/tooltip.tsx
+++ b/web/components/tooltip.tsx
@@ -1,0 +1,247 @@
+import type { ComponentChildren } from "preact";
+import { useRef, useState, useEffect } from "preact/hooks";
+import type { Command } from "../../type/command.ts";
+
+export interface TooltipProps {
+  text: string;
+  shortcut?: string;
+  macShortcut?: string;
+  commandName?: string;
+  commands?: Map<string, Command>;
+  position?: 'top' | 'bottom' | 'left' | 'right' | 'auto';
+  delay?: number;
+  disabled?: boolean;
+  className?: string;
+  children: ComponentChildren;
+}
+
+export function Tooltip({
+  text,
+  shortcut,
+  macShortcut,
+  commandName,
+  commands,
+  position = 'auto',
+  delay = 500,
+  disabled = false,
+  className = '',
+  children,
+}: TooltipProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [tooltipPosition, setTooltipPosition] = useState(position);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const timeoutRef = useRef<number>();
+
+  let dynamicShortcut = shortcut;
+  let dynamicMacShortcut = macShortcut;
+
+  if (commandName && commands && !shortcut && !macShortcut) {
+    const command = commands.get(commandName);
+    if (command) {
+      dynamicShortcut = command.key;
+      dynamicMacShortcut = command.mac;
+    }
+  }
+
+  const formattedShortcut = formatShortcut(dynamicShortcut, dynamicMacShortcut);
+
+  const showTooltip = () => {
+    if (disabled || (!text && !formattedShortcut)) return;
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = globalThis.setTimeout(() => {
+      setIsVisible(true);
+      updatePosition();
+    }, delay);
+  };
+
+  const hideTooltip = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  const updatePosition = () => {
+    if (!triggerRef.current || !tooltipRef.current) return;
+
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const tooltipRect = tooltipRef.current.getBoundingClientRect();
+    const viewportWidth = globalThis.innerWidth;
+    const viewportHeight = globalThis.innerHeight;
+
+    let finalPosition = position;
+
+    if (position === 'auto') {
+      // 'Smart' positioning based on available space
+      const spaceTop = triggerRect.top;
+      const spaceBottom = viewportHeight - triggerRect.bottom;
+      const spaceLeft = triggerRect.left;
+      const spaceRight = viewportWidth - triggerRect.right;
+
+      if (spaceTop > tooltipRect.height + 10) {
+        finalPosition = 'top';
+      } else if (spaceBottom > tooltipRect.height + 10) {
+        finalPosition = 'bottom';
+      } else if (spaceRight > tooltipRect.width + 10) {
+        finalPosition = 'right';
+      } else if (spaceLeft > tooltipRect.width + 10) {
+        finalPosition = 'left';
+      } else {
+        finalPosition = 'bottom';
+      }
+    }
+
+    setTooltipPosition(finalPosition);
+  };
+
+  const handleFocus = () => {
+    showTooltip();
+  };
+
+  const handleBlur = () => {
+    hideTooltip();
+  };
+
+  // Touch support for mobile
+  const handleTouchStart = (e: TouchEvent) => {
+    e.preventDefault();
+    if (isVisible) {
+      hideTooltip();
+    } else {
+      showTooltip();
+    }
+  };
+
+  useEffect(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+
+    // Add event listeners for touch devices
+    const isTouchDevice = 'ontouchstart' in globalThis;
+    if (isTouchDevice) {
+      trigger.addEventListener('touchstart', handleTouchStart);
+    }
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      if (isTouchDevice && trigger) {
+        trigger.removeEventListener('touchstart', handleTouchStart);
+      }
+    };
+  }, []);
+
+  // Close tooltip when clicking outside on touch devices
+  useEffect(() => {
+    if (!isVisible) return;
+
+    const handleClickOutside = (e: MouseEvent | TouchEvent) => {
+      if (
+        triggerRef.current &&
+        !triggerRef.current.contains(e.target as Node) &&
+        tooltipRef.current &&
+        !tooltipRef.current.contains(e.target as Node)
+      ) {
+        hideTooltip();
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [isVisible]);
+
+  if (disabled || (!text && !formattedShortcut)) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="sb-tooltip-wrapper">
+      <div
+        ref={triggerRef}
+        className="sb-tooltip-trigger"
+        onMouseEnter={showTooltip}
+        onMouseLeave={hideTooltip}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+      >
+        {children}
+      </div>
+      {isVisible && (
+        <div
+          ref={tooltipRef}
+          className={`sb-tooltip ${tooltipPosition} ${className} visible`}
+          role="tooltip"
+          aria-hidden={!isVisible}
+        >
+          <div className="tooltip-content">
+            {text && <span className="tooltip-text">{text}</span>}
+            {formattedShortcut && (
+              <span className="tooltip-shortcut">{formattedShortcut}</span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatShortcut(key?: string, mac?: string): string | undefined {
+  if (!key && !mac) return undefined;
+
+  const isMac = isMacLike();
+  const shortcut = isMac && mac ? mac : key;
+
+  if (!shortcut) return undefined;
+
+  let formatted = shortcut;
+
+  if (isMac) {
+    // Mac-specific symbol replacements
+    formatted = formatted
+      .replace(/Cmd/g, '⌘')
+      .replace(/Ctrl/g, '⌃')
+      .replace(/Alt/g, '⌥')
+      .replace(/Shift/g, '⇧')
+      .replace(/Option/g, '⌥');
+  } else {
+    // Windows/Linux formatting – could use Mac symbols as well…
+    formatted = formatted
+      .replace(/Cmd/g, 'Ctrl')
+      .replace(/Ctrl/g, 'Ctrl')
+      .replace(/Alt/g, 'Alt')
+      .replace(/Shift/g, 'Shift');
+  }
+
+  // Common special key replacements
+  formatted = formatted
+    .replace(/Enter/g, '⏎')
+    .replace(/Space/g, '␣')
+    .replace(/ArrowUp/g, '↑')
+    .replace(/ArrowDown/g, '↓')
+    .replace(/ArrowLeft/g, '←')
+    .replace(/ArrowRight/g, '→')
+    .replace(/Escape/g, 'Esc')
+    .replace(/Backspace/g, '⌫')
+    .replace(/Delete/g, '⌦')
+    .replace(/Tab/g, '⇥');
+
+  // Replace +/- with spaces for cleaner display
+  formatted = formatted.replace(/\+/g, ' ').replace(/\-/g, ' ');
+
+  return formatted;
+}
+
+function isMacLike(): boolean {
+  return /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
+}

--- a/web/components/top_bar.tsx
+++ b/web/components/top_bar.tsx
@@ -3,10 +3,12 @@ import type {
   CompletionResult,
 } from "@codemirror/autocomplete";
 import type { ComponentChildren, FunctionalComponent } from "preact";
-import type { Notification } from "@silverbulletmd/silverbullet/type/client";
+import type { Notification } from "../../type/client.ts";
 import type { FeatherProps } from "preact-feather/types";
 import type { IconBaseProps } from "react-icons/types";
+import type { Command } from "../../type/command.ts";
 import { MiniEditor } from "./mini_editor.tsx";
+import { Tooltip } from "./tooltip.tsx";
 
 export type ActionButton = {
   icon: FunctionalComponent<FeatherProps | IconBaseProps>;
@@ -15,6 +17,9 @@ export type ActionButton = {
   callback: () => void;
   href?: string;
   mobile?: boolean;
+  shortcut?: string;
+  macShortcut?: string;
+  commandName?: string;
 };
 
 export function TopBar({
@@ -25,6 +30,7 @@ export function TopBar({
   notifications,
   onRename,
   actionButtons,
+  commands,
   darkMode,
   vimMode,
   progressPercentage,
@@ -50,6 +56,7 @@ export function TopBar({
   onClick: () => void;
   completer: (context: CompletionContext) => Promise<CompletionResult | null>;
   actionButtons: ActionButton[];
+  commands?: Map<string, Command>;
   lhs?: ComponentChildren;
   rhs?: ComponentChildren;
   pageNamePrefix?: string;
@@ -125,29 +132,37 @@ export function TopBar({
               className={"sb-actions " +
                 (mobileMenuStyle ? mobileMenuStyle : "")}
             >
-              {actionButtons.map((actionButton) => {
+              {actionButtons.map((actionButton, index) => {
                 const button = (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      actionButton.callback();
-                    }}
-                    title={actionButton.description}
-                    className={actionButton.class}
+                  <Tooltip
+                    text={actionButton.description}
+                    shortcut={actionButton.shortcut}
+                    macShortcut={actionButton.macShortcut}
+                    commandName={actionButton.commandName}
+                    commands={commands}
+                    position="bottom"
                   >
-                    <actionButton.icon size={18} />
-                  </button>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        actionButton.callback();
+                      }}
+                      className={actionButton.class}
+                    >
+                      <actionButton.icon size={18} />
+                    </button>
+                  </Tooltip>
                 );
 
                 return actionButton.href
                   ? (
-                    <a href={actionButton.href} key={actionButton.href}>
+                    <a href={actionButton.href} key={actionButton.href || index}>
                       {button}
                     </a>
                   )
-                  : button;
+                  : <div key={index}>{button}</div>;
               })}
             </div>
           </div>

--- a/web/editor_ui.tsx
+++ b/web/editor_ui.tsx
@@ -290,6 +290,7 @@ export class MainUI {
           progressPercentage={viewState.progressPercentage}
           progressType={viewState.progressType}
           completer={client.miniEditorComplete.bind(client)}
+          commands={client.getCommandsByContext(viewState)}
           onClick={() => {
             if (!client.isDocumentEditor()) {
               client.editorView.scrollDOM.scrollTop = 0;
@@ -359,6 +360,9 @@ export class MainUI {
                 if (!featherIcon) {
                   featherIcon = featherIcons.HelpCircle;
                 }
+                // Get command name from button configuration if explicitly provided
+                const commandName: string | undefined = (button as any).commandName;
+
                 return {
                   icon: mdiIcon ? mdiIcon : featherIcon,
                   description: button.description || "",
@@ -369,6 +373,7 @@ export class MainUI {
                     );
                   }),
                   href: "",
+                  commandName,
                 };
               }),
           ]}

--- a/web/styles/main.scss
+++ b/web/styles/main.scss
@@ -3,6 +3,7 @@
 @use "theme";
 @use "colors";
 @use "top";
+@use "tooltip";
 
 @font-face {
   font-family: "iA-Mono";

--- a/web/styles/theme.scss
+++ b/web/styles/theme.scss
@@ -42,6 +42,14 @@ html {
   --modal-hint-inactive-color: #111;
   --modal-description-color: #aaa;
 
+  --tooltip-background: var(--modal-background-color);
+  --tooltip-color: var(--modal-color);
+  --tooltip-border: var(--modal-border-color);
+  --tooltip-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  --tooltip-shortcut-bg: var(--button-background-color);
+  --tooltip-shortcut-color: var(--subtle-color);
+  --tooltip-shortcut-border: var(--subtle-background-color);
+
   --notifications-background-color: inherit;
   --notifications-border-color: rgb(41, 41, 41);
   --notification-info-background-color: rgb(187, 221, 247);

--- a/web/styles/tooltip.scss
+++ b/web/styles/tooltip.scss
@@ -1,0 +1,157 @@
+.sb-tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.sb-tooltip-trigger {
+  display: inline-block;
+  width: 100%;
+}
+
+.sb-tooltip {
+  position: absolute;
+  z-index: 9999;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+
+  &.visible {
+    opacity: 1;
+  }
+
+  .tooltip-content {
+    background: var(--tooltip-background);
+    color: var(--tooltip-color);
+    border: 1px solid var(--tooltip-border);
+    border-radius: 4px;
+    padding: 6px 8px;
+    font-size: 12px;
+    font-family: var(--ui-font);
+    line-height: 1.4;
+    white-space: nowrap;
+    box-shadow: var(--tooltip-shadow);
+    max-width: 300px;
+
+    .tooltip-text {
+      display: inline-block;
+    }
+
+    .tooltip-shortcut {
+      display: inline-block;
+      margin-left: 8px;
+      opacity: 0.8;
+      font-family: 'iA-Mono', monospace;
+      background: var(--tooltip-shortcut-bg);
+      color: var(--tooltip-shortcut-color);
+      padding: 2px 4px;
+      border-radius: 2px;
+      font-size: 11px;
+      border: 1px solid var(--tooltip-shortcut-border);
+    }
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    border: 5px solid transparent;
+  }
+
+  &.top {
+    transform: translateX(-50%);
+
+    .tooltip-content {
+      margin-bottom: 5px;
+    }
+
+    &::after {
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border-top-color: var(--tooltip-border);
+    }
+  }
+
+  &.bottom {
+    transform: translateX(-50%);
+
+    .tooltip-content {
+      margin-top: 5px;
+    }
+
+    &::after {
+      bottom: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border-bottom-color: var(--tooltip-border);
+    }
+  }
+
+  &.left {
+    transform: translateY(-50%);
+
+    .tooltip-content {
+      margin-right: 5px;
+    }
+
+    &::after {
+      top: 50%;
+      left: 100%;
+      transform: translateY(-50%);
+      border-left-color: var(--tooltip-border);
+    }
+  }
+
+  &.right {
+    transform: translateY(-50%);
+
+    .tooltip-content {
+      margin-left: 5px;
+    }
+
+    &::after {
+      top: 50%;
+      right: 100%;
+      transform: translateY(-50%);
+      border-right-color: var(--tooltip-border);
+    }
+  }
+}
+
+// Position tooltip relative to its trigger
+.sb-tooltip-wrapper {
+  .sb-tooltip.top {
+    bottom: 100%;
+    left: 50%;
+  }
+
+  .sb-tooltip.bottom {
+    top: 100%;
+    left: 50%;
+  }
+
+  .sb-tooltip.left {
+    right: 100%;
+    top: 50%;
+  }
+
+  .sb-tooltip.right {
+    left: 100%;
+    top: 50%;
+  }
+}
+
+@media (max-width: 768px) {
+  .sb-tooltip .tooltip-content {
+    font-size: 13px;
+    padding: 8px 10px;
+    max-width: 250px;
+
+    .tooltip-shortcut {
+      font-size: 12px;
+      padding: 3px 5px;
+    }
+  }
+}
+


### PR DESCRIPTION
Hi, this PR provides the capability to show dynamic keyboard shortcuts in action button tooltips. It does so by implementing a tooltip component (rather than using the browser's native plain tooltips) and using the `commandName` prop to determine the command to dynamically derive the shortcut from. Provides user-controllable CSS variables (applied my theme in the example screenshot).

Open to feedback and ideas – might have overengineered this one…

I tried parsing 'run' to get the command rather than a separate prop, but as I don't know where the user defined their command (could be any markdown file) and only get the minified JS it didn't work out. 

**Before**
<img width="162" alt="image" src="https://github.com/user-attachments/assets/96d47bb4-d569-4475-909e-9bb8321c12b9" />

**After**
<img width="193" alt="image" src="https://github.com/user-attachments/assets/892c165a-89e9-48dd-93a8-c9a2bc63097d" />

**Example Config**
```yaml
navigateHome:
    path: "./navigate.ts:navigateCommand"
    command:
      name: "Navigate: Home"
      key: "Alt-h"
      page: ""
```
```lua
config.set {
  actionButtons = {
    {
      icon = "home",
      description = "Go to index page",
      commandName = "Navigate: Home",  -- Shows "Alt h" in tooltip
      run = function()
        editor.invokeCommand("Navigate: Home")
      end
    }
  }
}
```