### PR TITLE
Increase contrast for `Filterlist` descriptions

### DIFF
--- a/web/styles/colors.scss
+++ b/web/styles/colors.scss
@@ -151,11 +151,6 @@
     color: var(--modal-help-color);
   }
 
-  .sb-selected-option {
-    background-color: var(--modal-selected-option-background-color);
-    color: var(--modal-selected-option-color);
-  }
-
   .sb-result-list {
     .sb-hint:not(.sb-hint-inactive) {
       color: var(--modal-hint-color);
@@ -169,6 +164,15 @@
 
     .sb-description {
       color: var(--modal-description-color);
+    }
+
+    .sb-selected-option {
+      background-color: var(--modal-selected-option-background-color);
+      color: var(--modal-selected-option-color);
+
+      .sb-description {
+        color: var(--modal-selected-option-description-color);
+      }
     }
   }
 }

--- a/web/styles/theme.scss
+++ b/web/styles/theme.scss
@@ -40,7 +40,8 @@ html {
   --modal-hint-color: #eee;
   --modal-hint-inactive-background-color: #e1e1e1;
   --modal-hint-inactive-color: #111;
-  --modal-description-color: #aaa;
+  --modal-description-color: #6b6b6b;
+  --modal-selected-option-description-color: #E6E6E6;
 
   --notifications-background-color: inherit;
   --notifications-border-color: rgb(41, 41, 41);
@@ -185,7 +186,8 @@ html[data-theme="dark"] {
   --modal-hint-color: #eee;
   --modal-hint-inactive-background-color: #353535;
   --modal-hint-inactive-color: #ccc;
-  --modal-description-color: #aaa;
+  --modal-description-color: #969696;
+  --modal-selected-option-description-color: #E6E6E6;
 
   --notifications-background-color: #333;
   --notifications-border-color: rgb(197, 197, 197);


### PR DESCRIPTION
This is motivated by [this issue](https://github.com/MrMugame/silversearch/issues/1). It changes the colors for modal descriptions a little bit to increase contrast.
Before:
<img width="704" height="349" alt="image" src="https://github.com/user-attachments/assets/83e18bb5-10d4-4bd4-83be-ac16eb73b66f" />

After:
<img width="703" height="351" alt="image" src="https://github.com/user-attachments/assets/70c22750-6118-4a10-b9a6-34761ac5c2d8" />

The changes for dark mode were only minor.