### PR TITLE
Add sorting to "Linked Tasks widget"

### DIFF
--- a/Library/Std/Widgets.md
+++ b/Library/Std/Widgets.md
@@ -166,6 +166,7 @@ function widgets.linkedTasks(pageName)
     from index.tag "task"
     where not _.done
       and string.find(_.name, "[[" .. pageName .. "]]", 1, true)
+    order by page
   ]]
   local md = ""
   if #tasks > 0 then


### PR DESCRIPTION
Added sorting for page name to the query of "Linked Tasks", just like it is with "Linked Mentions".