### PR TITLE
Add resize-content viewport setting

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <meta
-            content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
+            content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content"
             name="viewport"
     />
     <base href="{{HOST_URL_PREFIX}}/"/>


### PR DESCRIPTION
In some situations on mobile devices the top and bottom toolbars may get scrolled off from the screen. This e.g. happens when the virtual keyboard is open and you scroll down a longer page to the bottom, you can see how the top bar is scrolled too. The same happens to the bottom mobile toolbar when scrolling up. Key issue here is that the viewport does not get resized when additional UI elements like the keyboard are opened. When viewing it in a debugger it becomes clear that the viewport size reaches below the virtual keyboard, to make up for this the browser starts to scroll the whole viewport as soon as nothing else can be moved in the scroll direction. As the toolbars are at the edges of the viewport they get scrolled of. This behaviour can be controlled by the [interactive-widget](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Viewport_meta_element#the_effect_of_interactive_ui_widgets) viewport setting. This fix sets it to `resize-content` which instructs the browser to resize the viewport when the virtual keyboard opens and thus the toolbars on the edges stay within the window.

**Preview**:

<img width="300" height="2244" alt="Before viewport setting" src="https://github.com/user-attachments/assets/fd1812b5-b4b5-4d2f-b28c-406d089cd512" />

<img width="300" height="2244" alt="After viewport setting" src="https://github.com/user-attachments/assets/86d1b6ef-4c01-468b-9da8-b3ad490b70df" />
