### PR TITLE
Parse wiki links more freely

### DIFF
--- a/web/cm_plugins/wiki_link.ts
+++ b/web/cm_plugins/wiki_link.ts
@@ -12,6 +12,7 @@ import {
   parseRef,
 } from "@silverbulletmd/silverbullet/lib/page_ref";
 import type { ClickEvent } from "@silverbulletmd/silverbullet/type/client";
+import { wikiLinkRegex } from "../markdown_parser/constants.ts";
 
 /**
  * Plugin to hide path prefix when the cursor is not inside.
@@ -27,7 +28,8 @@ export function cleanWikiLinkPlugin(client: Client) {
           return;
         }
         const text = state.sliceDoc(from, to);
-        const match = /(!?\[\[)([^\]\|]+)(?:\|([^\]]+))?(\]\])/g.exec(text);
+        wikiLinkRegex.lastIndex = 0;
+        const match = wikiLinkRegex.exec(text);
 
         if (!match) return;
         const [_fullMatch, firstMark, url, alias, lastMark] = match;

--- a/web/markdown_parser/constants.ts
+++ b/web/markdown_parser/constants.ts
@@ -1,4 +1,4 @@
-export const wikiLinkRegex = /(!?\[\[)([^\]\|]+)(?:\|([^\]]+))?(\]\])/g; // [fullMatch, firstMark, url, alias, lastMark]
+export const wikiLinkRegex = /(!?\[\[)(.*?)(?:\|(.*?))?(\]\])/g; // [fullMatch, firstMark, url, alias, lastMark]
 export const mdLinkRegex = /!?\[(?<title>[^\]]*)\]\((?<url>.+)\)/g; // [fullMatch, alias, url]
 export const tagRegex =
   /#(?:(?:\d*[^\d\s!@#$%^&*(),.?":{}|<>\\][^\s!@#$%^&*(),.?":{}|<>\\]*)|(?:<[^>\n]+>))/;


### PR DESCRIPTION
Issues this fixes or where it takes a first step to fixing it:
- https://community.silverbullet.md/t/silverbullet-render-failed-when-ref-to-a-header-with-links-inside/858 (Fixed)
- #1462 (Fixed)
- https://community.silverbullet.md/t/is-there-a-markdown-api-function-to-convert-md-to-raw-text-only/2616 (Fixed)
- #867 (Regression, was fixed by #887, partially fixed now)

All those issues were related to wiki links not properly parsing, because they contained stuff like links in the alias or header. I fixed the issue by lazily parsing anything inside a wiki link. This now makes wiki links one of things with the highest priorities, which seems sensible in my opinion. This now also allows stuff like `[[|]]` to exist, which can be helpful when generating wikilinks from spacelua for example. (This is also pretty much how obsidian behaves).
The only thing this doesn't fix is a wikilink inside a wikilink (, because there is no nesting with markdown). Which is still the reason why I would root for something like the function implemented in #887 (which now doesn't exist anymore?) to be a syscall, so lua code can use it to sanitize anything it puts into a wikilink. Most notably the toc should be doing it. Such a function (and using it in the stdlib) would also fix #1460