### PR TITLE
Make `stripIndent` an option for `template.new`

### DIFF
--- a/Library/Std/Template.md
+++ b/Library/Std/Template.md
@@ -20,15 +20,17 @@ function template.each(tbl, fn)
 end
 
 -- Creates a new template function from a string template
-function template.new(templateStr)
+function template.new(templateStr, stripIndent)
   -- Preprocess: strip indentation
-  local lines = {}
-  local splitLines = string.split(templateStr, "\n")
-  for _, line in ipairs(splitLines) do
-    line = string.gsub(line, "^    ", "")
-    table.insert(lines, line)
+  if stripIndent == nil or strpIndent == true then
+    local lines = {}
+    local splitLines = string.split(templateStr, "\n")
+    for _, line in ipairs(splitLines) do
+      line = string.gsub(line, "^    ", "")
+      table.insert(lines, line)
+    end
+    templateStr = table.concat(lines, "\n")
   end
-  templateStr = table.concat(lines, "\n")
   return function(obj)
     return spacelua.interpolate(templateStr, obj)
   end
@@ -51,6 +53,6 @@ function template.fromPage(name, raw)
       return templateText
     end, fm.frontmatter
   end
-  return template.new(templateText), fm.frontmatter
+  return template.new(templateText, false), fm.frontmatter
 end
 ```

--- a/website/API/template.md
+++ b/website/API/template.md
@@ -1,7 +1,8 @@
 Template functions that use the [[API/template#template.new(template)]] function.
 
-## template.new(template)
+## template.new(template, stripIndent)
 Returns a template function that can be used to render a template. Conventionally, a template string is put between `[==[` and `]==]` as string delimiters.
+If `stripIndent` is set to true or omitted, the function will try to remove indentation at the start of the line. This can be useful for multiline strings.
 
 Example:
 


### PR DESCRIPTION
This fixes #1459

I feel like just adding the option to template new is the best and most sensible option, even if it makes a core api a little more complex.