### PR TITLE
Support mixing html and md widgets

### DIFF
--- a/web/cm_plugins/lua_widget.ts
+++ b/web/cm_plugins/lua_widget.ts
@@ -174,7 +174,7 @@ export class LuaWidget extends WidgetType {
         trimmedMarkdown,
       );
 
-      html = parseHtmlString(renderMarkdownToHtml(mdTree, {
+      const mdHtml = parseHtmlString(renderMarkdownToHtml(mdTree, {
         translateUrls: (url) => {
           if (isLocalPath(url)) {
             url = resolvePath(
@@ -187,6 +187,16 @@ export class LuaWidget extends WidgetType {
         },
         preserveAttributes: true,
       }, this.client.ui.viewState.allPages));
+
+      if (html) {
+        // If html is already defined from the html case, extend it by appending mdHtml
+        const container = document.createElement("div");
+        container.appendChild(typeof html === "string" ? parseHtmlString(html) : html);
+        container.appendChild(mdHtml);
+        html = container;
+      } else {
+        html = mdHtml;
+      }
     }
     if (html) {
       div.replaceChildren(this.wrapHtml(block, html, copyContent));


### PR DESCRIPTION
This addresses the issue of mixing html and md widgets, as reported in this community post: https://community.silverbullet.md/t/mixing-html-and-md-widgets/2652

I’m not deeply familiar with the codebase, so I approached this by testing a few different solutions and settled on the one with the smallest footprint. It resolves the issue effectively without introducing major changes.

That said, the widget code might benefit from a broader refactor, which could be tackled in a separate pull request by someone more familiar with the internals.
