### PR TITLE
Allow multiple panel widgets

### DIFF
--- a/web/cm_plugins/lua_widget.ts
+++ b/web/cm_plugins/lua_widget.ts
@@ -211,9 +211,7 @@ export class LuaWidget extends WidgetType {
       );
       // Because of the rejiggering of the DOM, we need to do a no-op cursor move to make sure it's positioned correctly
       this.client.editorView.dispatch({
-        selection: {
-          anchor: this.client.editorView.state.selection.main.anchor,
-        },
+        selection: this.client.editorView.state.selection,
       });
     });
   }

--- a/web/cm_plugins/lua_widget.ts
+++ b/web/cm_plugins/lua_widget.ts
@@ -209,12 +209,6 @@ export class LuaWidget extends WidgetType {
           copyContent: copyContent,
         },
       );
-      // Because of the rejiggering of the DOM, we need to do a no-op cursor move to make sure it's positioned correctly
-      this.client.editorView.dispatch({
-        selection: {
-          anchor: this.client.editorView.state.selection.main.anchor,
-        },
-      });
     });
   }
 

--- a/web/cm_plugins/lua_widget.ts
+++ b/web/cm_plugins/lua_widget.ts
@@ -209,6 +209,12 @@ export class LuaWidget extends WidgetType {
           copyContent: copyContent,
         },
       );
+      // Because of the rejiggering of the DOM, we need to do a no-op cursor move to make sure it's positioned correctly
+      this.client.editorView.dispatch({
+        selection: {
+          anchor: this.client.editorView.state.selection.main.anchor,
+        },
+      });
     });
   }
 

--- a/web/cm_plugins/top_bottom_panels.ts
+++ b/web/cm_plugins/top_bottom_panels.ts
@@ -1,8 +1,106 @@
 import type { EditorState } from "@codemirror/state";
-import { Decoration } from "@codemirror/view";
+import { Decoration, WidgetType } from "@codemirror/view";
 import type { Client } from "../client.ts";
 import { decoratorStateField } from "./util.ts";
 import { LuaWidget, type LuaWidgetContent } from "./lua_widget.ts";
+
+class ArrayWidget extends WidgetType {
+  constructor(
+    readonly client: Client,
+    readonly cacheKey: string,
+    readonly callback: (
+      pageName: string,
+    ) => Promise<LuaWidgetContent[] | null>,
+    readonly childClass: string,
+  ) {
+    super();
+  }
+
+  override get estimatedHeight(): number {
+    const cacheItem = this.client.getWidgetCache(this.cacheKey);
+    return cacheItem ? cacheItem.height : -1;
+  }
+
+  toDOM(): HTMLElement {
+    const div = document.createElement("div");
+    div.className = "sb-widget-array";
+
+    // This doesn't do that much, but it also doesn't really hurt
+    const cacheItem = this.client.getWidgetCache(this.cacheKey);
+    if (cacheItem) {
+      div.innerHTML = cacheItem.html;
+    }
+
+    // Async kick-off of content renderer
+    this.renderContent(div).catch(console.error);
+    return div;
+  }
+
+  async renderContent(
+    div: HTMLElement,
+  ) {
+    const content = await this.callback(this.client.currentPage);
+    if (!content) return;
+
+    const renderedWidgets: HTMLElement[] = [];
+
+    for (const [i, widgetContent] of content.entries()) {
+      // Filter out any "empty" widgets. Leaving the content empty, but
+      // returning a valid widgets, seems to be a common pattern
+      if (
+        !widgetContent ||
+        widgetContent === "" ||
+        (widgetContent instanceof Object &&
+          !widgetContent.markdown &&
+          !widgetContent.html)
+      ) continue;
+
+      const widget = new LuaWidget(
+        this.client,
+        `${this.cacheKey}:${i}`,
+        "",
+        () => Promise.resolve(widgetContent),
+        false,
+        false,
+      );
+
+      // Throw away the wrapper, as it only causes trouble and we are rewrapping
+      // anyways
+      const html = widget.toDOM().querySelector<HTMLDivElement>(":scope > div");
+      if (!html) {
+        // This should never really happen, just in case
+        console.log("There was an error rendering one of the panel widgets");
+        continue;
+      }
+
+      html.classList.add(this.childClass);
+
+      renderedWidgets.push(html);
+    }
+
+    if (renderedWidgets.length === 0) {
+      div.style.display = "none";
+      return;
+    }
+
+    div.replaceChildren(...renderedWidgets);
+
+    // Wait for the clientHeight to settle
+    setTimeout(() => {
+      this.client.setWidgetCache(this.cacheKey, {
+        height: div.clientHeight,
+        block: true,
+        html: div.innerHTML,
+      });
+    });
+  }
+
+  override eq(other: WidgetType): boolean {
+    // This class isn't really used for stuff that's updated. If that's
+    // needed in the future, one could e.g. add a `bodyText` property again
+    return other instanceof ArrayWidget && other.cacheKey === this.cacheKey;
+  }
+}
 
 export function postScriptPrefacePlugin(
   editor: Client,
@@ -14,86 +112,38 @@ export function postScriptPrefacePlugin(
     }
     const widgets: any[] = [];
 
-    // Event driven hooks
     widgets.push(
       Decoration.widget({
-        widget: new LuaWidget(
+        widget: new ArrayWidget(
           editor,
           `top:lua:${editor.currentPage}`,
-          "top",
-          async () => {
-            const widgetResults = await client.dispatchAppEvent(
+          async () =>
+            await client.dispatchAppEvent(
               "hooks:renderTopWidgets",
-            );
-            const accumulatedWidget: LuaWidgetContent = {
-              _isWidget: true,
-              html: "",
-              markdown: "",
-              display: "block",
-              cssClasses: ["sb-lua-top-widget"],
-            };
-            for (const widget of widgetResults) {
-              if (widget.html) {
-                accumulatedWidget.html += widget.html;
-              }
-              if (widget.markdown) {
-                accumulatedWidget.markdown += widget.markdown + "\n";
-              }
-            }
-            if (accumulatedWidget.markdown || accumulatedWidget.html) {
-              return accumulatedWidget;
-            } else {
-              return null;
-            }
-          },
-          false,
-          false,
+            ),
+          "sb-lua-top-widget",
         ),
         side: -1,
         block: true,
       }).range(0),
     );
 
-    // Bottom widgets
-
     widgets.push(
       Decoration.widget({
-        widget: new LuaWidget(
+        widget: new ArrayWidget(
           editor,
           `bottom:lua:${editor.currentPage}`,
-          "bottom",
-          async () => {
-            const widgetResults = await client.dispatchAppEvent(
+          async () =>
+            await client.dispatchAppEvent(
               "hooks:renderBottomWidgets",
-            );
-            const accumulatedWidget: LuaWidgetContent = {
-              _isWidget: true,
-              html: "",
-              markdown: "",
-              display: "block",
-              cssClasses: ["sb-lua-bottom-widget"],
-            };
-            for (const widget of widgetResults) {
-              if (widget.html) {
-                accumulatedWidget.html += widget.html;
-              }
-              if (widget.markdown) {
-                accumulatedWidget.markdown += widget.markdown + "\n";
-              }
-            }
-            if (accumulatedWidget.markdown || accumulatedWidget.html) {
-              return accumulatedWidget;
-            } else {
-              return null;
-            }
-          },
-          false,
-          false,
+            ),
+          "sb-lua-bottom-widget",
         ),
         side: 1,
         block: true,
       }).range(state.doc.length),
     );
+
     return Decoration.set(widgets);
   });
 }

--- a/web/cm_plugins/top_bottom_panels.ts
+++ b/web/cm_plugins/top_bottom_panels.ts
@@ -3,8 +3,11 @@ import { Decoration, WidgetType } from "@codemirror/view";
 import type { Client } from "../client.ts";
 import { decoratorStateField } from "./util.ts";
 import { LuaWidget, type LuaWidgetContent } from "./lua_widget.ts";
+import { activeWidgets } from "./code_widget.ts";
 
 class ArrayWidget extends WidgetType {
+  public dom?: HTMLElement;
+
   constructor(
     readonly client: Client,
     readonly cacheKey: string,
@@ -22,6 +25,8 @@ class ArrayWidget extends WidgetType {
   }
 
   toDOM(): HTMLElement {
+    activeWidgets.add(this);
+
     const div = document.createElement("div");
     div.className = "sb-widget-array";
 
@@ -33,6 +38,7 @@ class ArrayWidget extends WidgetType {
 
     // Async kick-off of content renderer
     this.renderContent(div).catch(console.error);
+    this.dom = div;
     return div;
   }
 

--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -491,12 +491,19 @@
 
   .sb-lua-top-widget,
   .sb-lua-bottom-widget {
-    margin: 0 0 10px 0;
     border: 1px solid var(--editor-widget-background-color);
     border-radius: 5px;
     white-space: normal;
     position: relative;
     min-height: 48px;
+  }
+
+  .sb-lua-top-widget {
+    margin: 0 0 10px 0;
+  }
+
+  .sb-lua-bottom-widget {
+    margin: 10px 0 0 0;
   }
 
   .sb-lua-top-widget h1,

--- a/web/styles/editor.scss
+++ b/web/styles/editor.scss
@@ -341,6 +341,11 @@
     margin: -1em 0;
   }
 
+  .sb-widget-array {
+    display: flex;
+    flex-direction: column;
+  }
+
   a.sb-wiki-link-page-missing,
   .sb-wiki-link-page-missing > .sb-wiki-link-page {
     border-radius: 5px;


### PR DESCRIPTION
This basically is my answer to #1474, it implements an `ArrayWidget` which just takes a callback for an array of widget content and renders the individual widgets. This class is used to render multiple top and or bottom widgets. Arguably this could be considered hacky, but the implementation really isn't that bad and decently small. The only real thing to consider is that it taps into the widgetCache and activeWidgets set, which was previously only used by lua widgets, but this shouldn't matter.
Another thing is, to return event results in order (the order the event handlers are traversed), this change shouldn't break anything for users (otherwise they are dependent on a race condition), but allows the user to use the typically lua priority to order the top or bottom widgets.
~~I also removed a dispatch in 88cc33ad57f2f664cdb597e2c7f7ec35816810fc, where I'm not exactly sure what it was for. It caused me issues, but removing it doesn't really change anything as far as I noticed. Maybe you can shed some light on that. If it's actually necessary I'm going to look into fixing my issues.~~
And I added a top margin to the bottom widget so it doesn't hug the text.

<img width="771" height="257" alt="image" src="https://github.com/user-attachments/assets/047ffa09-cbe5-4815-97b1-0772c28e1080" />
