### PR TITLE
Fix page decoration prefix appearing in table of content's links

### DIFF
--- a/web/markdown/markdown_render.ts
+++ b/web/markdown/markdown_render.ts
@@ -551,7 +551,7 @@ export function renderMarkdownToHtml(
         if (t.attrs!["data-ref"]?.length) {
           const pageRef = parseRef(t.attrs!["data-ref"]!);
           const pageMeta = allPages.find((p) => pageRef.page === p.name);
-          if (pageMeta) {
+          if (pageMeta && !("pos" in pageRef)) {
             t.body = [(pageMeta.pageDecoration?.prefix ?? "") + t.body];
             if (pageMeta.pageDecoration?.cssClasses) {
               t.attrs!.class += " sb-decorated-object " +


### PR DESCRIPTION
Table of content's links contain page decoration prefixes when navigating between pages or when reloading the system (not on page refresh for some reasons, might be related to https://github.com/silverbulletmd/silverbullet/issues/1352).

This proposal avoids adding those prefixes when the link is having a `pos` in the file which indicates that it targets a heading. I think that it's an expected behavior as the heading could as well be prefixed with something (e.g., an emoji).

Note that it will as well change link's mention widget behavior.

closes https://github.com/silverbulletmd/silverbullet/issues/1043