### PR TITLE
Make read only more robust

### DIFF
--- a/web/editor_state.ts
+++ b/web/editor_state.ts
@@ -93,8 +93,10 @@ export function createEditorState(
           : [],
       ],
       [
-        ...(readOnly || client.ui.viewState.uiOptions.forcedROMode)
-          ? [EditorView.editable.of(false)]
+        ...(readOnly ||
+            client.ui.viewState.uiOptions.forcedROMode ||
+            client.clientConfig.readOnly)
+          ? [EditorView.editable.of(false), EditorState.readOnly.of(true)]
           : [],
       ],
 


### PR DESCRIPTION
Adds `EditorState.readOnly` so the page is *actually* read only and also makes the page read only if `client.clientConfig.readOnly` is set.