### PR TITLE
Update example Authelia resource regex to match literal dots

### DIFF
--- a/website/Authelia.md
+++ b/website/Authelia.md
@@ -16,9 +16,9 @@ access_control:
   rules:
     - domain: silverbullet.yourdomain.com
       resources:
-        - '/.client/manifest.json$'
-        - '/.client/[a-zA-Z0-9_-]+.png$'
-        - '/service_worker.js$'
+        - '/\.client/manifest\.json$'
+        - '/\.client/[a-zA-Z0-9_-]+\.png$'
+        - '/service_worker\.js$'
       policy: bypass
     - domain: yourdomain.com
       policy: two_factor


### PR DESCRIPTION
The current regular expressions for the example Authelia configuration don't escape the dot character, meaning they'd match requests for `/Xclient/manifestXjson` for instance.

This PR just escapes them so the expressions match literal dot characters, which I assume was the intention.