### PR TITLE
Add command to toggle clean mode

### DIFF
--- a/plugs/editor/editor.plug.yaml
+++ b/plugs/editor/editor.plug.yaml
@@ -10,6 +10,10 @@ functions:
     path: "./editor.ts:toggleDarkMode"
     command:
       name: "Editor: Toggle Dark Mode"
+  toggleCleanMode:
+    path: "./editor.ts:toggleCleanMode"
+    command:
+      name: "Editor: Toggle Clean Mode"
   newWindow:
     path: editor.ts:newWindowCommand
     command:

--- a/plugs/editor/editor.ts
+++ b/plugs/editor/editor.ts
@@ -12,6 +12,9 @@ export async function setEditorMode() {
   if (await clientStore.get("darkMode")) {
     await editor.setUiOption("darkMode", true);
   }
+  if (await clientStore.get("cleanMode")) {
+    await editor.setUiOption("cleanMode", true);
+  }
 }
 
 export function openCommandPalette() {
@@ -38,6 +41,13 @@ export async function toggleDarkMode() {
   let darkMode = await editor.getUiOption("darkMode");
   darkMode = !darkMode;
   await clientStore.set("darkMode", darkMode);
+  await editor.reloadUI();
+}
+
+export async function toggleCleanMode() {
+  let cleanMode = await editor.getUiOption("cleanMode");
+  cleanMode = !cleanMode;
+  await clientStore.set("cleanMode", cleanMode);
   await editor.reloadUI();
 }
 

--- a/web/cm_plugins/clean.ts
+++ b/web/cm_plugins/clean.ts
@@ -17,7 +17,17 @@ import { hashtagPlugin } from "./hashtag.ts";
 import type { ClickEvent } from "@silverbulletmd/silverbullet/type/client";
 
 export function cleanModePlugins(client: Client) {
+  const pluginsNeededEvenWithoutCleanMode = [
+    luaDirectivePlugin(client),
+    cleanWikiLinkPlugin(client),
+  ];
+
+  if (!client.ui.viewState.uiOptions.cleanMode) {
+    return pluginsNeededEvenWithoutCleanMode;
+  }
+
   return [
+    ...pluginsNeededEvenWithoutCleanMode,
     linkPlugin(client),
     blockquotePlugin(),
     admonitionPlugin(),
@@ -42,9 +52,7 @@ export function cleanModePlugins(client: Client) {
     }),
     listBulletPlugin(),
     tablePlugin(client),
-    cleanWikiLinkPlugin(client),
     cleanEscapePlugin(),
-    luaDirectivePlugin(client),
     hashtagPlugin(),
   ] as Extension[];
 }

--- a/web/cm_plugins/inline_content.ts
+++ b/web/cm_plugins/inline_content.ts
@@ -208,6 +208,8 @@ function parseAlias(
 }
 
 export function inlineContentPlugin(client: Client) {
+  const cleanModeEnabled = client.ui.viewState.uiOptions.cleanMode;
+
   return decoratorStateField((state: EditorState) => {
     const widgets: Range<Decoration>[] = [];
     if (!shouldRenderWidgets(client)) {
@@ -253,7 +255,8 @@ export function inlineContentPlugin(client: Client) {
           alias = "";
         }
 
-        if (!isCursorInRange(state, [from, to])) {
+        const cursorIsInRange = isCursorInRange(state, [from, to]);
+        if (cleanModeEnabled && !cursorIsInRange) {
           widgets.push(invisibleDecoration.range(from, to));
         }
 

--- a/web/editor_ui.tsx
+++ b/web/editor_ui.tsx
@@ -128,6 +128,15 @@ export class MainUI {
     }, [viewState.uiOptions.darkMode]);
 
     useEffect(() => {
+      clientStoreSyscalls(client.ds)["clientStore.get"](
+        {},
+        "cleanMode",
+      ).then((storedCleanModePreference: boolean) => {
+        viewState.uiOptions.cleanMode = storedCleanModePreference;
+      });
+    });
+
+    useEffect(() => {
       // Need to dispatch a resize event so that the top_bar can pick it up
       globalThis.dispatchEvent(new Event("resize"));
     }, [viewState.panels]);

--- a/web/ui_types.ts
+++ b/web/ui_types.ts
@@ -39,6 +39,7 @@ export type AppViewState = {
   uiOptions: {
     vimMode: boolean;
     darkMode?: boolean;
+    cleanMode: boolean;
     forcedROMode: boolean;
     customStyles?: string;
   };
@@ -76,6 +77,7 @@ export const initialViewState: AppViewState = {
   uiOptions: {
     vimMode: false,
     darkMode: undefined,
+    cleanMode: true,
     forcedROMode: false,
   },
   isMobile: false,


### PR DESCRIPTION
This PR resolves #1500 by adding a built-in editor command to toggle 'clean mode', i.e. the feature that hides markdown syntax like `*`s when not focused by the cursor.

The goal of having clean mode disabled is to have *both* the markdown syntax and formatting simultaneously, except for places where that would be overly repetitive (e.g. tables), in which case the syntax is prioritized.

Implementation-wise, I largely mimicked the `Toggle Dark Mode` command for the toggling behavior, creating a `cleanMode` UI option, defaulting to true. When false, almost every instance of markdown syntax being hidden is disabled, as if everything on the page was alt-clicked or highlighted. The only exception is lua directives (`${...}`); their behavor is unchanged whether clean mode is enabled or not.

There are, I think, two questions left in my mind before I'd call this done:
1. *Should* lua directives be excluded from this? The other reasonable option, I think, is giving them the same behavior as images (and other inline content), rendering both the syntax and the result. I poked at that a bit, but it behaved oddly.
2. Should the color of syntax characters change with clean mode disabled? The current `--meta-color` in the dark theme is a rather angry red, giving the impression that there's some kind of error with syntax characters. It'd be nice if that was less the case with clean mode disabled, where syntax characters are an expected part of the page. This could be changed on a per-user/space basis with space styles, of course.