### PR TITLE
Fixed editable page title in readonly-mode

### DIFF
--- a/web/components/basic_modals.tsx
+++ b/web/components/basic_modals.tsx
@@ -47,6 +47,7 @@ export function Prompt({
           onChange={(text) => {
             setText(text);
           }}
+          editable={true}
         />
         <div className="sb-prompt-buttons">
           <Button

--- a/web/components/filter.tsx
+++ b/web/components/filter.tsx
@@ -211,6 +211,7 @@ export function FilterList({
 
             return true;
           }}
+          editable={true}
         />
       </div>
       <div

--- a/web/components/mini_editor.tsx
+++ b/web/components/mini_editor.tsx
@@ -43,6 +43,7 @@ export function MiniEditor(
     onChange,
     focus,
     completer,
+    editable,
   }: {
     text: string;
     placeholderText?: string;
@@ -53,6 +54,7 @@ export function MiniEditor(
     completer?: (
       context: CompletionContext,
     ) => Promise<CompletionResult | null>;
+    editable: boolean;
   } & MiniEditorEvents,
 ) {
   const editorDiv = useRef<HTMLDivElement>(null);
@@ -156,6 +158,11 @@ export function MiniEditor(
         EditorView.theme({}, { dark: darkMode }),
         // Enable vim mode, or not
         [...vimMode ? [vim()] : []],
+        [
+          ...editable
+            ? []
+            : [EditorView.editable.of(false), EditorState.readOnly.of(true)],
+        ],
 
         autocompletion({
           override: completer ? [completer] : [],

--- a/web/components/top_bar.tsx
+++ b/web/components/top_bar.tsx
@@ -91,6 +91,8 @@ export function TopBar({
                 onEnter={(newName) => {
                   onRename(newName);
                 }}
+                editable={!client.ui.viewState.uiOptions.forcedROMode &&
+                  !client.clientConfig.readOnly}
               />
             </span>
             {notifications.length > 0 && (


### PR DESCRIPTION
It was possible to edit the page name on the official homepage.  

<img width="619" alt="image" src="https://github.com/user-attachments/assets/fc9a8294-6219-40c3-9e1e-637bfb6d9b8d" />


I fixed it by adding a new attribute to the MiniEditor

