### PR TITLE
Follow up to #1526

### DIFF
--- a/web/document_editor.ts
+++ b/web/document_editor.ts
@@ -231,10 +231,6 @@ export class DocumentEditor {
     srcdoc: string,
   ): [HTMLIFrameElement, Promise<void>] {
     const iframe = document.createElement("iframe");
-    // This can be escaped, but we don't really care, it's only there to give a
-    // first barrier against accessing some apis like navigation
-    iframe.sandbox =
-      "allow-scripts allow-same-origin allow-downloads allow-forms allow-modals allow-presentation allow-orientation-lock";
     iframe.srcdoc = srcdoc;
 
     // Avoid possible loading artifcats


### PR DESCRIPTION
Removes the sandbox attribute from document editors. This has two advantages
- I ran into a situation where I needed popus. I thought it was reasonable to not allow specific stuff, but I think it's more annoying than useful
- Removes the warning in the console