### PR TITLE
document editor.getCurrentLine() function

### DIFF
--- a/website/API/editor.md
+++ b/website/API/editor.md
@@ -35,6 +35,15 @@ local text = editor.getText()
 print("Document length: " .. #text)
 ```
 
+### editor.getCurrentLine()
+Returns the current line range and text.
+
+Example:
+```lua
+local line = editor.getCurrentLine()
+print("from " .. line.from .. " to " .. line.to .. " text " .. line.text .. " text with cursor " .. line.textWithCursor)
+```
+
 ### editor.setText(text, isolateHistory)
 Updates the editor text while preserving cursor location.
 


### PR DESCRIPTION
Adds documentation for `editor.getCurrentLine()`. There are a few other missing parameters from the same change that added this function but I held off on making incomplete changes and was instead going to look at how to automate checking the API surface.