### PR TITLE
Fix `![[]]` not being indexed.

### DIFF
--- a/plugs/index/page_links.ts
+++ b/plugs/index/page_links.ts
@@ -110,13 +110,10 @@ export async function indexLinks({ name, tree }: IndexTreeEvent) {
     }
 
     // Also index [Markdown style]() links
-    if (n.type === "Link") {
-      const linkNode = findNodeOfType(n, "URL")!;
-      if (!linkNode) {
-        return false;
-      }
+    if (n.type === "Link" || n.type === "Image") {
+      // The [[Wiki links]] also have a wrapping Image node, but this just fails at the regex
       mdLinkRegex.lastIndex = 0;
-      const match = mdLinkRegex.exec(renderToText(linkNode.parent));
+      const match = mdLinkRegex.exec(renderToText(n));
       if (!match) {
         return false;
       }
@@ -129,7 +126,7 @@ export async function indexLinks({ name, tree }: IndexTreeEvent) {
       if (!isLocalURL(url)) {
         return false;
       }
-      const pos = linkNode.from!;
+      const pos = n.from!;
       url = resolveMarkdownLink(name, decodeURI(url));
 
       const link: any = {


### PR DESCRIPTION
We could also trigger on the `URL` type but this isn't quite as clear and I'm unsure if that node type isn't used somewhere else