### PR TITLE
Fix plug names

### DIFF
--- a/cmd/test/runtime.test.ts
+++ b/cmd/test/runtime.test.ts
@@ -1,10 +1,10 @@
-import { createSandbox } from "../../lib/plugos/sandboxes/deno_worker_sandbox.ts";
 import type { SysCallMapping } from "../../lib/plugos/system.ts";
 import { System } from "../../lib/plugos/system.ts";
 import { assertEquals } from "@std/assert";
 import { compileManifest } from "../compile.ts";
 import * as esbuild from "esbuild";
 import { fileURLToPath } from "node:url";
+import { WorkerSandbox } from "../../lib/plugos/sandboxes/worker_sandbox.ts";
 
 Deno.test("Run a deno sandbox", {
   sanitizeResources: false,
@@ -40,9 +40,9 @@ Deno.test("Run a deno sandbox", {
     },
   );
 
-  const plug = await system.load(
+  const plug = await system.loadPlug(
+    (plug) => new WorkerSandbox(plug, new URL(`file://${workerPath}`)),
     "test",
-    createSandbox(new URL(`file://${workerPath}`)),
   );
 
   assertEquals({

--- a/lib/plugos/plug.ts
+++ b/lib/plugos/plug.ts
@@ -9,43 +9,50 @@ export class Plug<HookT> {
   public grantedPermissions: string[] = [];
   public sandbox: Sandbox<HookT>;
 
-  // Resolves once the plug's manifest is available
-  ready: Promise<void>;
-
-  // Only available after ready resolves
-  public manifest?: Manifest<HookT>;
+  public manifest!: Manifest<HookT>;
   public assets?: AssetBundle;
 
   constructor(
-    private system: System<HookT>,
-    readonly name: string,
-    private hash: number,
-    private sandboxFactory: SandboxFactory<HookT>,
+    readonly system: System<HookT>,
+    sandboxFactory: SandboxFactory<HookT>,
   ) {
     this.runtimeEnv = system.env;
+    this.sandbox = sandboxFactory(this);
+  }
 
-    this.sandbox = this.sandboxFactory(this);
-    // Retrieve the manifest asynchonously, which may either come from a cache or be loaded from the worker
-    this.ready = system.options.manifestCache!.getManifest(this, this.hash)
-      .then(
-        (manifest) => {
-          this.manifest = manifest;
-          // TODO: These need to be explicitly granted, not just taken
-          this.grantedPermissions = manifest.requiredPermissions || [];
-        },
-      );
+  static async createLazyily<HookT>(
+    system: System<HookT>,
+    cacheKey: string,
+    cacheHash: number,
+    sandboxFactory: SandboxFactory<HookT>,
+  ): Promise<Plug<HookT>> {
+    const plug = new Plug(
+      system,
+      sandboxFactory,
+    );
+
+    // Retrieve the manifest, which may either come from a cache or be loaded from the worker
+    plug.manifest = await system.options.manifestCache!.getManifest(
+      plug,
+      cacheKey,
+      cacheHash,
+    );
+
+    // TODO: These need to be explicitly granted, not just taken
+    plug.grantedPermissions = plug.manifest.requiredPermissions || [];
+
+    return plug;
   }
 
   // Invoke a syscall
   syscall(name: string, args: any[]): Promise<any> {
-    return this.system.syscall({ plug: this.name }, name, args);
+    return this.system.syscall({ plug: this.manifest.name }, name, args);
   }
 
   /**
    * Checks if a function can be invoked (it may be restricted on its execution environment)
    */
-  async canInvoke(name: string) {
-    await this.ready;
+  canInvoke(name: string) {
     const funDef = this.manifest!.functions[name];
     if (!funDef) {
       throw new Error(`Function ${name} not found in manifest`);
@@ -55,9 +62,6 @@ export class Plug<HookT> {
 
   // Invoke a function
   async invoke(name: string, args: any[]): Promise<any> {
-    // Ensure the worker is fully up and running
-    await this.ready;
-
     // Before we access the manifest
     const funDef = this.manifest!.functions[name];
     if (!funDef) {
@@ -89,7 +93,7 @@ export class Plug<HookT> {
   }
 
   stop() {
-    console.log("Stopping sandbox for", this.name);
+    console.log("Stopping sandbox for", this.manifest.name);
     this.sandbox.stop();
   }
 }

--- a/lib/plugos/sandboxes/web_worker_sandbox.ts
+++ b/lib/plugos/sandboxes/web_worker_sandbox.ts
@@ -1,7 +1,17 @@
 import { WorkerSandbox } from "./worker_sandbox.ts";
 import type { Plug } from "../plug.ts";
 import type { SandboxFactory } from "./sandbox.ts";
+import { fsEndpoint } from "../../spaces/constants.ts";
 
-export function createSandbox<HookT>(workerUrl: URL): SandboxFactory<HookT> {
-  return (plug: Plug<HookT>) => new WorkerSandbox(plug, workerUrl);
+export function createWorkerSandboxFromLocalPath<HookT>(
+  name: string,
+): SandboxFactory<HookT> {
+  return (plug: Plug<HookT>) =>
+    new WorkerSandbox(
+      plug,
+      new URL(
+        name,
+        document.baseURI.slice(0, -1) + fsEndpoint + "/", // We're NOT striping trailing '/', this used to be `location.origin`
+      ),
+    );
 }

--- a/lib/plugos/sandboxes/worker_sandbox.ts
+++ b/lib/plugos/sandboxes/worker_sandbox.ts
@@ -29,7 +29,7 @@ export class WorkerSandbox<HookT> implements Sandbox<HookT> {
    * Should only invoked lazily (either by invoke, or by a ManifestCache to load the manifest)
    */
   init(): Promise<void> {
-    console.log("Booting up worker for", this.plug.name);
+    console.log("Booting up worker from", this.workerUrl.pathname);
     if (this.worker) {
       // Race condition
       console.warn("Double init of sandbox, ignoring");
@@ -48,7 +48,7 @@ export class WorkerSandbox<HookT> implements Sandbox<HookT> {
           if (ev.data.type === "manifest") {
             this.manifest = ev.data.manifest;
             // Set manifest in the plug
-            this.plug.manifest = this.manifest;
+            this.plug.manifest = this.manifest!;
 
             // Set assets in the plug
             this.plug.assets = new AssetBundle(

--- a/plugs/builtin_plugs.ts
+++ b/plugs/builtin_plugs.ts
@@ -10,3 +10,7 @@ export const builtinPlugNames = [
   "search",
   "image-viewer",
 ];
+
+export const builtinPlugPaths = builtinPlugNames.map((name) =>
+  `_plug/${name}.plug.js`
+);

--- a/plugs/plug-manager/plugmanager.ts
+++ b/plugs/plug-manager/plugmanager.ts
@@ -4,7 +4,8 @@ import {
   space,
   system,
 } from "@silverbulletmd/silverbullet/syscalls";
-import { builtinPlugNames } from "../builtin_plugs.ts";
+import { builtinPlugPaths } from "../builtin_plugs.ts";
+import type { ResolvedPlug } from "@silverbulletmd/silverbullet/type/event";
 
 export async function updatePlugsCommand() {
   // Save the current file (could be a config page)
@@ -40,86 +41,101 @@ export async function updatePlugsCommand() {
     });
 
     console.log("Found Plug URIs:", plugList);
-    const allCustomPlugNames: string[] = [];
+    const allCustomPlugPaths: string[] = [];
     for (const plugUri of plugList) {
       const [protocol, ...rest] = plugUri.split(":");
-
-      let plugName: string;
-      if (protocol == "ghr") {
-        // For GitHub Release, the plug is expected to be named same as repository
-        plugName = rest[0].split("/")[1]; // skip repo owner
-        // Strip "silverbullet-foo" into "foo" (multiple plugs follow this convention)
-        if (plugName.startsWith("silverbullet-")) {
-          plugName = plugName.slice("silverbullet-".length);
-        }
-      } else {
-        // Other URIs are expected to contain the file .plug.js at the end
-        const plugNameMatch = /\/([^\/]+)\.plug\.js$/.exec(plugUri);
-        if (!plugNameMatch) {
-          console.error(
-            "Could not extract plug name from ",
-            plugUri,
-            "ignoring...",
-          );
-          continue;
-        }
-
-        plugName = plugNameMatch[1];
-      }
-
-      // Validate the extracted name
-      if (builtinPlugNames.includes(plugName)) {
-        throw new Error(
-          `Plug name '${plugName}' is conflicting with a built-in plug`,
-        );
-      }
-      if (allCustomPlugNames.includes(plugName)) {
-        throw new Error(
-          `Plug name '${plugName}' defined by more than one URI`,
-        );
-      }
 
       const manifests = await events.dispatchEvent(
         `get-plug:${protocol}`,
         rest.join(":"),
       );
+
       if (manifests.length === 0) {
-        console.error("Could not resolve plug", plugUri);
+        console.error("Could not resolve plug uri", plugUri);
+      } else if (manifests.length > 1) {
+        console.error(
+          `Got multiple results for plug uri ${plugUri}. Proceeding with the first result`,
+        );
       }
-      // console.log("Got manifests", plugUri, protocol, manifests);
-      const workerCode = manifests[0] as string;
-      allCustomPlugNames.push(plugName);
-      console.log("Writing", `_plug/${plugName}.plug.js`);
-      await space.writeDocument(
-        `_plug/${plugName}.plug.js`,
-        new TextEncoder().encode(workerCode),
-      );
+
+      const manifest = manifests[0] as unknown;
+
+      let code: string;
+      if (typeof manifest === "string") {
+        // "Legacy" syntax
+        code = manifest;
+      } else if (
+        manifest &&
+        typeof manifest === "object" &&
+        "code" in manifest &&
+        typeof manifest.code === "string"
+      ) {
+        code = manifest.code;
+      } else {
+        console.error(
+          "Invalid return from `get-plug` event. Please return value of type `{ code: string, name?: string } | string`",
+        );
+
+        continue;
+      }
+
+      let name: string;
+      if (
+        typeof manifest !== "object" ||
+        !("name" in manifest) ||
+        typeof manifest.name !== "string"
+      ) {
+        // Try taking a good guess at a name if it isn't provided
+        const match = /\/([^\/]+)\.plug\.js$/.exec(plugUri);
+        if (!match) {
+          console.error(
+            `No plug name provided and could not extract name from ${plugUri} ignoring...`,
+          );
+
+          continue;
+        }
+
+        name = match[1];
+      } else {
+        name = manifest.name;
+      }
+
+      const path = `_plug/${name}.plug.js`;
+
+      // Validate the extracted path
+      if (builtinPlugPaths.includes(path)) {
+        throw new Error(
+          `Plug '${path}' is conflicting with a built-in plug`,
+        );
+      }
+      if (allCustomPlugPaths.includes(path)) {
+        throw new Error(
+          `Plug '${path}' defined by more than one URI`,
+        );
+      }
+
+      allCustomPlugPaths.push(path);
+
+      console.log("Writing", path);
+      await space.writeDocument(path, new TextEncoder().encode(code));
     }
 
-    console.log("This part is done");
-
-    const allPlugNames = [...builtinPlugNames, ...allCustomPlugNames];
+    const allPlugPaths = [...builtinPlugPaths, ...allCustomPlugPaths];
     // And delete extra ones
     for (const { name: existingPlug } of await space.listPlugs()) {
-      const plugName = existingPlug.substring(
-        "_plug/".length,
-        existingPlug.length - ".plug.js".length,
-      );
-      if (!allPlugNames.includes(plugName)) {
+      if (!allPlugPaths.includes(existingPlug)) {
         console.log("Deleting", existingPlug);
         await space.deleteDocument(existingPlug);
       }
     }
-    await editor.flashNotification(
-      "All done!",
-    );
+    await editor.flashNotification("All done!");
     system.reloadPlugs();
   } catch (e: any) {
     editor.flashNotification("Error updating plugs: " + e.message, "error");
   }
 }
 
-export async function getPlugHTTPS(url: string): Promise<string> {
+export async function getPlugHTTPS(url: string): Promise<ResolvedPlug> {
   const fullUrl = `https:${url}`;
   console.log("Now fetching plug code from", fullUrl);
   const req = await fetch(fullUrl);
@@ -129,7 +145,7 @@ export async function getPlugHTTPS(url: string): Promise<string> {
   return req.text();
 }
 
-export function getPlugGithub(identifier: string): Promise<string> {
+export function getPlugGithub(identifier: string): Promise<ResolvedPlug> {
   const [owner, repo, path] = identifier.split("/");
   let [repoClean, branch] = repo.split("@");
   if (!branch) {
@@ -142,7 +158,7 @@ export function getPlugGithub(identifier: string): Promise<string> {
 
 export async function getPlugGithubRelease(
   identifier: string,
-): Promise<string> {
+): Promise<ResolvedPlug> {
   let [owner, repo, version] = identifier.split("/");
   let releaseInfo: any = {};
   let req: Response;
@@ -166,16 +182,12 @@ export async function getPlugGithubRelease(
   version = releaseInfo.tag_name;
 
   let assetName: string | undefined;
-  const shortName = repo.startsWith("silverbullet-")
+  // Support plug like foo.plug.js are in repo silverbullet-foo
+  const name = repo.startsWith("silverbullet-")
     ? repo.slice("silverbullet-".length)
-    : undefined;
+    : repo;
   for (const asset of releaseInfo.assets ?? []) {
     if (asset.name === `${repo}.plug.js`) {
-      assetName = asset.name;
-      break;
-    }
-    // Support plug like foo.plug.js are in repo silverbullet-foo
-    if (shortName && asset.name === `${shortName}.plug.js`) {
       assetName = asset.name;
       break;
     }
@@ -183,12 +195,16 @@ export async function getPlugGithubRelease(
   if (!assetName) {
     throw new Error(
       `Could not find "${repo}.plug.js"` +
-        (shortName ? ` or "${shortName}.plug.js"` : "") +
+        (name !== repo ? ` or "${name}.plug.js"` : "") +
         ` in release ${version}`,
     );
   }
 
   const finalUrl =
     `//github.com/${owner}/${repo}/releases/download/${version}/${assetName}`;
-  return getPlugHTTPS(finalUrl);
+  const code = await getPlugHTTPS(finalUrl);
+  return {
+    code: typeof code === "string" ? code : code.code,
+    name,
+  };
 }

--- a/type/event.ts
+++ b/type/event.ts
@@ -18,3 +18,8 @@ export type PageCreatingContent = {
 export type EventSubscription = EventSubscriptionDef & {
   run: (...args: any[]) => Promise<any>;
 };
+
+export type ResolvedPlug = {
+  code: string;
+  name?: string; // This will only dictate the filename
+} | string;

--- a/web/client_system.ts
+++ b/web/client_system.ts
@@ -53,7 +53,7 @@ import {
   luaValueToJS,
 } from "../lib/space_lua/runtime.ts";
 import { buildThreadLocalEnv, handleLuaError } from "./space_lua_api.ts";
-import { builtinPlugNames } from "../plugs/builtin_plugs.ts";
+import { builtinPlugPaths } from "../plugs/builtin_plugs.ts";
 
 const indexVersionKey = ["$indexVersion"];
 const indexQueuedKey = ["$indexQueued"];
@@ -260,9 +260,6 @@ export class ClientSystem {
     let allPlugs = await space.listPlugs();
     if (this.client.bootConfig.disablePlugs) {
       // Only keep builtin plugs
-      const builtinPlugPaths = builtinPlugNames.map((name) =>
-        `_plug/${name}.plug.js`
-      );
       allPlugs = allPlugs.filter(({ name }) => builtinPlugPaths.includes(name));
 
       console.warn("Not loading custom plugs as `disablePlugs` has been set");

--- a/web/hooks/event.ts
+++ b/web/hooks/event.ts
@@ -76,14 +76,14 @@ export class EventHook implements EventHookI {
               event === eventName || eventNameToRegex(event).test(eventName)
             ) {
               // Only dispatch functions that can run in this environment
-              if (await plug.canInvoke(name)) {
+              if (plug.canInvoke(name)) {
                 // Queue the promise
                 promises.push((async () => {
                   try {
                     return await plug.invoke(name, args);
                   } catch (e: any) {
                     console.error(
-                      `Error dispatching event ${eventName} to ${plug.name}.${name}: ${e.message}`,
+                      `Error dispatching event ${eventName} to ${plug.manifest.name}.${name}: ${e.message}`,
                     );
                     throw e;
                   }
@@ -140,7 +140,7 @@ export class EventHook implements EventHookI {
     this.system = system;
     this.system.on({
       plugLoaded: async (plug) => {
-        await this.dispatchEvent("plug:load", plug.name);
+        await this.dispatchEvent("plug:load", plug.manifest.name);
       },
     });
   }


### PR DESCRIPTION
The plug name and plug path were very intertwined in the code. This could cause problems, if the file path and plug name didn't align. The plug manager also modified the plug path for some plugs, which could be even more confusing.
I cleaned up some code around it, although there is so much code here that could just be dropped. Environments for plugs can be completely dropped for example (if there are not plans to reimplement this). The one place there name and path are still connected is for builtin plugs, because sometimes we need to know the name and sometimes the path. I just generated the paths from the names.
I also rewrote some stuff in the plug manager. It can now take a `{ code: string, name: string }` from the event and will use that name for the filename. This is used for the `ghr` case.
The only problem now is that plugs can overwrite other plugs, maybe this was possible before unsure. I added some protection against overwriting builtiin plugs.