### PR TITLE
Cleanup code around dark mode

### DIFF
--- a/plugs/editor/editor.ts
+++ b/plugs/editor/editor.ts
@@ -9,8 +9,12 @@ export async function setEditorMode() {
   if (await clientStore.get("vimMode")) {
     await editor.setUiOption("vimMode", true);
   }
-  if (await clientStore.get("darkMode")) {
-    await editor.setUiOption("darkMode", true);
+  // Only set the darkmode value if it was deliberatly set in the clientstore,
+  // otherwise leave it so the client can choose depending on the system
+  // settings
+  const darkMode = await clientStore.get("darkMode");
+  if (darkMode != null) {
+    await editor.setUiOption("darkMode", darkMode);
   }
   const markdownSyntaxRendering = await clientStore.get(
     "markdownSyntaxRendering",

--- a/web/editor_ui.tsx
+++ b/web/editor_ui.tsx
@@ -103,28 +103,15 @@ export class MainUI {
     }, [viewState.uiOptions.vimMode]);
 
     useEffect(() => {
-      clientStoreSyscalls(client.ds)["clientStore.get"](
-        {},
-        "darkMode",
-      ).then((storedDarkModePreference: boolean | undefined) => {
-        let theme: "dark" | "light";
-        if (storedDarkModePreference === true) {
-          theme = "dark";
-        } else if (storedDarkModePreference === false) {
-          theme = "light";
-        } else {
-          theme = globalThis.matchMedia("(prefers-color-scheme: dark)").matches
-            ? "dark"
-            : "light";
-        }
+      const darkMode = viewState.uiOptions.darkMode === undefined
+        ? globalThis.matchMedia("(prefers-color-scheme: dark)").matches
+        : viewState.uiOptions.darkMode;
 
-        viewState.uiOptions.darkMode = theme === "dark";
-        document.documentElement.dataset.theme = theme;
+      document.documentElement.dataset.theme = darkMode ? "dark" : "light";
 
-        if (this.client.isDocumentEditor()) {
-          this.client.documentEditor.updateTheme();
-        }
-      });
+      if (this.client.isDocumentEditor()) {
+        this.client.documentEditor.updateTheme();
+      }
     }, [viewState.uiOptions.darkMode]);
 
     useEffect(() => {


### PR DESCRIPTION
I don't want to offend anybody, but the code in the `useEffect` here, was really not it. This should also fix a bug, where you couldn't force white mode if your system is set to dark mode.
And maybe we should also add something to the docs about the use of the `clientStore` here, because this caused confusion multiple times now.