### PR TITLE
Fix tag links in rendered markdown

### DIFF
--- a/client/cm_plugins/hashtag.ts
+++ b/client/cm_plugins/hashtag.ts
@@ -3,6 +3,7 @@ import { Decoration } from "@codemirror/view";
 import { decoratorStateField } from "./util.ts";
 import * as Constants from "../../plugs/index/constants.ts";
 import { extractHashtag } from "../../plug-api/lib/tags.ts";
+import { encodePageURI } from "@silverbulletmd/silverbullet/lib/ref";
 
 export function hashtagPlugin() {
   return decoratorStateField((state) => {
@@ -29,7 +30,7 @@ export function hashtagPlugin() {
             tagName: "a",
             class: "sb-hashtag",
             attributes: {
-              href: `/${Constants.tagPrefix}${tagName}`,
+              href: `/${encodePageURI(Constants.tagPrefix + tagName)}`,
               rel: "tag",
               "data-tag-name": tagName,
             },

--- a/client/cm_plugins/widget_util.ts
+++ b/client/cm_plugins/widget_util.ts
@@ -55,21 +55,6 @@ export function attachWidgetEventHandlers(
     });
   });
 
-  // Attach click handlers to hash tags
-  div.querySelectorAll("span.hashtag").forEach((el_) => {
-    const el = el_ as HTMLElement;
-    // Override default click behavior with a local navigate (faster)
-    el.addEventListener("click", (e) => {
-      if (e.ctrlKey || e.metaKey) {
-        // Don't do anything special for ctrl/meta clicks
-        return;
-      }
-      client.navigate(
-        parseToRef(`${tagPrefix}${extractHashtag(el.innerText)}@0`),
-      );
-    });
-  });
-
   div.querySelectorAll("button[data-onclick]").forEach((el_) => {
     const el = el_ as HTMLElement;
     const onclick = el.dataset.onclick!;

--- a/client/markdown_renderer/markdown_render.ts
+++ b/client/markdown_renderer/markdown_render.ts
@@ -7,7 +7,11 @@ import {
   renderToText,
   traverseTree,
 } from "@silverbulletmd/silverbullet/lib/tree";
-import { encodeRef, parseToRef } from "@silverbulletmd/silverbullet/lib/ref";
+import {
+  encodePageURI,
+  encodeRef,
+  parseToRef,
+} from "@silverbulletmd/silverbullet/lib/ref";
 import { Fragment, renderHtml, type Tag } from "./html_render.ts";
 import * as TagConstants from "../../plugs/index/constants.ts";
 import { extractHashtag } from "@silverbulletmd/silverbullet/lib/tags";
@@ -287,7 +291,7 @@ function render(
 
       const ref = parseToRef(link);
       if (ref) {
-        href = `/${encodeRef(ref)}`;
+        href = `/${encodePageURI(encodeRef(ref))}`;
       }
 
       return {
@@ -313,12 +317,14 @@ function render(
     }
     case "Hashtag": {
       const tagText: string = t.children![0].text!;
+      const link = TagConstants.tagPrefix + extractHashtag(tagText);
       return {
         name: "a",
         attrs: {
           class: "hashtag sb-hashtag",
           "data-tag-name": extractHashtag(tagText),
-          href: `/${TagConstants.tagPrefix}${extractHashtag(tagText)}`,
+          href: `/${encodePageURI(link)}`,
+          "data-ref": link,
         },
         body: tagText,
       };


### PR DESCRIPTION
The real fix here is that I added the `data-ref` property, so the click handler picks it up, but I also fixed the `href` for the cases I could find. They don't really matter, but I guess why not.