### PR TITLE
Fix Lua arithmetic model (parser level only)

### DIFF
--- a/client/space_lua/arithmetic_test.lua
+++ b/client/space_lua/arithmetic_test.lua
@@ -1,0 +1,91 @@
+local function assert_eq(actual, expected, msg)
+  if actual ~= expected then
+    error('assert_eq failed: ' .. msg)
+  end
+end
+
+-- Integer-only (0 and -0 as integers)
+-- Expectation: -0 is integer 0, so 1/-0 == +Inf, -1/-0 == +Inf
+assert_eq(  1/ 0 ==  1/ 0,  true,  'int:  1/ 0 ==  1/ 0')
+assert_eq(  1/ 0 == -1/ 0,  false, 'int:  1/ 0 == -1/ 0')
+assert_eq(  1/ 0 ==  1/-0,  true,  'int:  1/ 0 ==  1/-0')
+assert_eq(  1/ 0 == -1/-0,  false, 'int:  1/ 0 == -1/-0')
+
+assert_eq( -1/ 0 ==  1/ 0,  false, 'int: -1/ 0 ==  1/ 0')
+assert_eq( -1/ 0 == -1/ 0,  true,  'int: -1/ 0 == -1/ 0')
+assert_eq( -1/ 0 ==  1/-0,  false, 'int: -1/ 0 ==  1/-0')
+assert_eq( -1/ 0 == -1/-0,  true,  'int: -1/ 0 == -1/-0')
+
+assert_eq(  1/-0 ==  1/ 0,  true,  'int:  1/-0 ==  1/ 0')
+assert_eq(  1/-0 == -1/ 0,  false, 'int:  1/-0 == -1/ 0')
+assert_eq(  1/-0 ==  1/-0,  true,  'int:  1/-0 ==  1/-0')
+assert_eq(  1/-0 == -1/-0,  false, 'int:  1/-0 == -1/-0')
+
+assert_eq( -1/-0 ==  1/ 0,  false, 'int: -1/-0 ==  1/ 0')
+assert_eq( -1/-0 == -1/ 0,  true,  'int: -1/-0 == -1/0 ')
+assert_eq( -1/-0 ==  1/-0,  false, 'int: -1/-0 ==  1/-0')
+assert_eq( -1/-0 == -1/-0,  true,  'int: -1/-0 == -1/-0')
+
+-- Float-only (0.0 and -0.0 as floats)
+-- Expectation: -0.0 is float negative zero, so 1/-0.0 == -Inf, -1/-0.0 == +Inf
+assert_eq(  1/ 0.0 ==  1/ 0.0,  true,  'float:  1/ 0.0 ==  1/ 0.0')
+assert_eq(  1/ 0.0 == -1/ 0.0,  false, 'float:  1/ 0.0 == -1/ 0.0')
+assert_eq(  1/ 0.0 ==  1/-0.0,  false, 'float:  1/ 0.0 ==  1/-0.0')
+assert_eq(  1/ 0.0 == -1/-0.0,  true,  'float:  1/ 0.0 == -1/-0.0')
+
+assert_eq( -1/ 0.0 ==  1/ 0.0,  false, 'float: -1/ 0.0 ==  1/ 0.0')
+assert_eq( -1/ 0.0 == -1/ 0.0,  true,  'float: -1/ 0.0 == -1/ 0.0')
+assert_eq( -1/ 0.0 ==  1/-0.0,  true,  'float: -1/ 0.0 ==  1/-0.0')
+assert_eq( -1/ 0.0 == -1/-0.0,  false, 'float: -1/ 0.0 == -1/-0.0')
+
+assert_eq(  1/-0.0 ==  1/ 0.0,  false, 'float:  1/-0.0 ==  1/ 0.0')
+assert_eq(  1/-0.0 == -1/ 0.0,  true,  'float:  1/-0.0 == -1/ 0.0')
+assert_eq(  1/-0.0 ==  1/-0.0,  true,  'float:  1/-0.0 ==  1/-0.0')
+assert_eq(  1/-0.0 == -1/-0.0,  false, 'float:  1/-0.0 == -1/-0.0')
+
+assert_eq( -1/-0.0 ==  1/ 0.0,  true,  'float: -1/-0.0 ==  1/ 0.0')
+assert_eq( -1/-0.0 == -1/ 0.0,  false, 'float: -1/-0.0 == -1/ 0.0')
+assert_eq( -1/-0.0 ==  1/-0.0,  false, 'float: -1/-0.0 ==  1/-0.0')
+assert_eq( -1/-0.0 == -1/-0.0,  true,  'float: -1/-0.0 == -1/-0.0')
+
+-- Integer-Float (left int 0/-0; right float 0.0/-0.0)
+assert_eq(  1/ 0 ==  1/ 0.0,  true,  'int-float:  1/0 ==  1/ 0.0')
+assert_eq(  1/ 0 == -1/ 0.0,  false, 'int-float:  1/0 == -1/ 0.0')
+assert_eq(  1/ 0 ==  1/-0.0,  false, 'int-float:  1/0 ==  1/-0.0')
+assert_eq(  1/ 0 == -1/-0.0,  true,  'int-float:  1/0 == -1/-0.0')
+
+assert_eq( -1/ 0 ==  1/ 0.0,  false, 'int-float: -1/0 ==  1/ 0.0')
+assert_eq( -1/ 0 == -1/ 0.0,  true,  'int-float: -1/0 == -1/ 0.0')
+assert_eq( -1/ 0 ==  1/-0.0,  true,  'int-float: -1/0 ==  1/-0.0')
+assert_eq( -1/ 0 == -1/-0.0,  false, 'int-float: -1/0 == -1/-0.0')
+
+assert_eq(  1/-0 ==  1/ 0.0,  true,  'int-float:  1/-0 ==  1/ 0.0')
+assert_eq(  1/-0 == -1/ 0.0,  false, 'int-float:  1/-0 == -1/ 0.0')
+assert_eq(  1/-0 ==  1/-0.0,  false, 'int-float:  1/-0 ==  1/-0.0')
+assert_eq(  1/-0 == -1/-0.0,  true,  'int-float:  1/-0 == -1/-0.0')
+
+assert_eq( -1/-0 ==  1/ 0.0,  false, 'int-float: -1/-0 ==  1/ 0.0')
+assert_eq( -1/-0 == -1/ 0.0,  true,  'int-float: -1/-0 == -1/ 0.0')
+assert_eq( -1/-0 ==  1/-0.0,  true,  'int-float: -1/-0 ==  1/-0.0')
+assert_eq( -1/-0 == -1/-0.0,  false, 'int-float: -1/-0 == -1/-0.0')
+
+-- Float-Integer (left float 0.0/-0.0; right int 0/-0)
+assert_eq(  1/ 0.0 ==  1/ 0,  true,  'float-int:  1/0.0 ==  1/ 0')
+assert_eq(  1/ 0.0 == -1/ 0,  false, 'float-int:  1/0.0 == -1/ 0')
+assert_eq(  1/ 0.0 ==  1/-0,  true,  'float-int:  1/0.0 ==  1/-0')
+assert_eq(  1/ 0.0 == -1/-0,  false, 'float-int:  1/0.0 == -1/-0')
+
+assert_eq( -1/ 0.0 ==  1/ 0,  false, 'float-int: -1/0.0 ==  1/ 0')
+assert_eq( -1/ 0.0 == -1/ 0,  true,  'float-int: -1/0.0 == -1/ 0')
+assert_eq( -1/ 0.0 ==  1/-0,  false, 'float-int: -1/0.0 ==  1/-0')
+assert_eq( -1/ 0.0 == -1/-0,  true,  'float-int: -1/0.0 == -1/-0')
+
+assert_eq(  1/-0.0 ==  1/ 0,  false, 'float-int:  1/-0.0 ==  1/ 0')
+assert_eq(  1/-0.0 == -1/ 0,  true,  'float-int:  1/-0.0 == -1/ 0')
+assert_eq(  1/-0.0 ==  1/-0,  false, 'float-int:  1/-0.0 ==  1/-0')
+assert_eq(  1/-0.0 == -1/-0,  true,  'float-int:  1/-0.0 == -1/-0')
+
+assert_eq( -1/-0.0 ==  1/ 0,  true,  'float-int: -1/-0.0 ==  1/ 0')
+assert_eq( -1/-0.0 == -1/ 0,  false, 'float-int: -1/-0.0 == -1/ 0')
+assert_eq( -1/-0.0 ==  1/-0,  true,  'float-int: -1/-0.0 ==  1/-0')
+assert_eq( -1/-0.0 == -1/-0,  false, 'float-int: -1/-0.0 == -1/-0')

--- a/client/space_lua/ast.ts
+++ b/client/space_lua/ast.ts
@@ -2,6 +2,8 @@ type ASTContext = {
   ctx: ASTCtx;
 };
 
+export type NumericType = "int" | "float";
+
 export type ASTCtx = {
   from?: number;
   to?: number;
@@ -165,6 +167,7 @@ export type LuaBooleanLiteral = {
 export type LuaNumberLiteral = {
   type: "Number";
   value: number;
+  numericType: NumericType;
 } & ASTContext;
 
 export type LuaStringLiteral = {

--- a/client/space_lua/eval.ts
+++ b/client/space_lua/eval.ts
@@ -154,6 +154,11 @@ export function evalExpression(
           return value.then((value) => {
             switch (e.operator) {
               case "-":
+                if (e.argument.type === "Number" && e.argument.numericType === "int") {
+                  if (e.argument.value === 0) {
+                    return 0;
+                  }
+                }
                 return -luaCoerceToNumber(singleResult(value));
               case "+":
                 return +singleResult(value);
@@ -172,6 +177,11 @@ export function evalExpression(
         } else {
           switch (e.operator) {
             case "-":
+              if (e.argument.type === "Number" && e.argument.numericType === "int") {
+                if (e.argument.value === 0) {
+                  return 0;
+                }
+              }
               return -luaCoerceToNumber(singleResult(value));
             case "+":
               return +singleResult(value);

--- a/client/space_lua/lua.test.ts
+++ b/client/space_lua/lua.test.ts
@@ -9,6 +9,10 @@ Deno.test("[Lua] Core language", async () => {
   await runLuaTest("./language_core_test.lua");
 });
 
+Deno.test("[Lua] Core language", async () => {
+  await runLuaTest("./arithmetic_test.lua");
+});
+
 Deno.test("[Lua] Table tests", async () => {
   await runLuaTest("./stdlib/table_test.lua");
 });

--- a/client/space_lua/parse.ts
+++ b/client/space_lua/parse.ts
@@ -404,6 +404,7 @@ function parseExpression(t: ParseTree, ctx: ASTCtx): LuaExpression {
         type: "Number",
         // Use the integer parser fox 0x literals
         value: text.includes("x") ? parseInt(text) : parseFloat(text),
+        numericType: /[\.eEpP]/.test(text) ? "float" : "int",
         ctx: context(t, ctx),
       };
     }


### PR DESCRIPTION
This patch fixes the Lua arithmetic model at parser level only. Runtime level fixtures are left for future work.

MOTIVATION

Space Lua treats all numbers as IEEE-754 doubles (JS semantics), so it preserves negative zero. Lua uses integers and floats. The literal "-0" in Lua is parsed as unary minus applied to the integer literal "0", which yields the integer "0" (no sign). This difference flips the sign of the divisor in "1/-0" and "-1/-0". Although it could be fixed without touching the parser by changing only unary minus evaluation, this commit goes a little further and provides integer vs float differenciating at the parser level as well and uses it to fix the unary minus evaluation.

Extensive tests are added to test this exact change works and the Space Lua arithmetic model is aligned with Lua. Note that things like `-(expr)` in general may still produce results inconsistent with Lua. This cannot be fixed at parser level and must be fixed at runtime level which will need far more complex change to the Space Lua interpreter code. Therefor these cases we omitted from the tests.