### PR TITLE
silverbullet: fix ToC rendering when item itself is a link.

### DIFF
--- a/libraries/Library/Std/Widgets/Widgets.md
+++ b/libraries/Library/Std/Widgets/Widgets.md
@@ -100,6 +100,8 @@ function widgets.toc(options)
         for child in topLevelChild.children do
           text = text .. string.trim(markdown.renderParseTree(child))
         end
+        -- Strip link syntax to avoid nested brackets in TOC
+        text = string.gsub(text, "%[%[(.-)%]%]", "%1")
 
         if text != "" then
           table.insert(headers, {


### PR DESCRIPTION
When item itself is a link, it seems to be rendered as `[[[[header_name]]]]`

Just stripping `[[ ]]` from the title before creating anchor link.


Before:
<img width="302" height="127" alt="Screenshot 2025-10-06 at 10 29 15 PM" src="https://github.com/user-attachments/assets/74b589cb-8752-4032-8c36-f80de9beb083" />

After:
<img width="304" height="124" alt="Screenshot 2025-10-06 at 10 27 54 PM" src="https://github.com/user-attachments/assets/335c7240-dd7d-4594-a943-222691518dfa" />


