### PR TITLE
silverbullet: fix circular recent page deletion

### DIFF
--- a/plugs/editor/page.ts
+++ b/plugs/editor/page.ts
@@ -10,9 +10,12 @@ export async function deletePage() {
   }
   // Query for last
   const recentlyOpenedPages = await editor.getRecentlyOpenedPages();
-  // Find the the first page that is not the current page
+  const allPages = await space.listPages();
+  const existingPageNames = new Set(allPages.map(p => p.name));
+
+  // Find the first recently opened page that still exists and is not the current page
   const firstRecentlyOpenedPage = recentlyOpenedPages.find(
-    (page) => page.name !== pageName,
+    (page) => page.name !== pageName && existingPageNames.has(page.name)
   );
   await space.deletePage(pageName);
   console.log("Navigating to previous page");


### PR DESCRIPTION
Consider the scenario:
1. visit page 'foo'
2. visit page 'bar'
3. delete page 'bar' (and navigate to foo based on editor.getRecentlyOpenedPages)
4. delete page 'foo' (and navigate back to now empty 'bar', which is confusing)

This happens because deletion is not propagated to recentlyOpenPages.

In this fix we get the most recently opened page which still exists. Alternative way to fix it would be to push the deletion to the recentlyOpenPages.