### PR TITLE
Keybindings - Update disable key bindings documentation

### DIFF
--- a/libraries/Library/Std/APIs/Command.md
+++ b/libraries/Library/Std/APIs/Command.md
@@ -48,8 +48,8 @@ command.update {
 -- To disable key bindings of an existing command
 command.update {
   name = "Navigate: Document Picker",
-  key = nil,
-  mac = nil,
+  key = "",
+  mac = "",
 }
 ```
 


### PR DESCRIPTION
I've been looking at this issue because I also experienced the same. Seems we could try to handle this in command.update.. OR just have an empty string, "", be the preferred way to unset a keyboard shortcut. Nothing would need to change.... Except peoples implementation, changing their nil values to "".