### PR TITLE
Make the link to the site point to main one

### DIFF
--- a/server/cmd/space_template/index.md
+++ b/server/cmd/space_template/index.md
@@ -31,4 +31,4 @@ There’s a whole world out there to explore, but let’s not get ahead of ourse
 Then we’ll talk.
 
 # What next?
-You can find more information on SilverBullet’s feature set on its [official website](https://v2.silverbullet.md/). Also, be sure to join the [SilverBullet community](https://community.silverbullet.md/) to interact with fellow SilverBullet explorers.
+You can find more information on SilverBullet’s feature set on its [official website](https://silverbullet.md/). Also, be sure to join the [SilverBullet community](https://community.silverbullet.md/) to interact with fellow SilverBullet explorers.


### PR DESCRIPTION
It used to point to `v2.silverbullet.md`, but not that all development is on v2 this is no longer needed? Keeping `v2` means landing on a page where no dynamic element gets rendered.

In other words, both https://v2.silverbullet.md/ and https://silverbullet.md/ have similar content as a markdown file, but only the latter renders the output of queries, templates, etc.

I did an `rg v2` to find other places where this could be changed, but none seemed relevant.