### PR TITLE
Https note for editor.copyToCliboard

### DIFF
--- a/website/API/editor.md
+++ b/website/API/editor.md
@@ -262,7 +262,7 @@ print("Uploaded: " .. file.name)
 ```
 
 ### editor.copyToClipboard(data)
-Copies data to the clipboard. 
+Copies data to the clipboard.
 
 > **note** Note
 > Requires HTTPS, see [[Install/Network and Internet]]


### PR DESCRIPTION
Added note about HTTPS requirement for clipboard function, ref https://github.com/silverbulletmd/silverbullet/issues/1650