### PR TITLE
Fix embed youtube 153 error by adding referrer-policy header

### DIFF
--- a/libraries/Library/Std/Widgets/Embed.md
+++ b/libraries/Library/Std/Widgets/Embed.md
@@ -51,7 +51,8 @@ function embed.youtube(specOrUrl)
   return widget.html(dom.iframe {
     src="https://www.youtube.com/embed/" .. videoId,
     style="width: " .. width .. "; height: " .. height,
-    class = "sb-video-embed"
+    class = "sb-video-embed",
+    referrerpolicy = "strict-origin-when-cross-origin"
   })
 end
 


### PR DESCRIPTION
The header fixes the issue, the change was on YouTube end. 

Collateral damage is that `no-referrer` header is no longer allowed it causes error 153. The change is acceptable, since `strict-origin-when-cross-origin` is now the default in [firefox](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy) and [chrome](https://developer.chrome.com/blog/referrer-policy-new-chrome-default) since 2020. 

However the tweak is not ideal for privacy because websites are now required to send the domain name (it sends the domain name only with `strict-origin-when-cross-origin`). Using yt's official `youtube-nocookie.com/embed` instead of `youtube.com/embed` works but it still exposes the domain name. I tested it. So that  `no-referrer` still doesn't work. Using youtube-nocookie could also raise concerns about fingerprinting. It seems that the best option is to use some external tool for privacy and cookie blocking with yt. And just send the `strict-origin-when-cross-origin` header.