### PR TITLE
More robust "offline" handling when using proxies

### DIFF
--- a/client/boot.ts
+++ b/client/boot.ts
@@ -2,6 +2,7 @@ import { race, safeRun, sleep } from "@silverbulletmd/silverbullet/lib/async";
 import {
   notAuthenticatedError,
   offlineError,
+  offlineStatusCodes,
 } from "@silverbulletmd/silverbullet/constants";
 import { initLogger } from "./lib/logger.ts";
 import { extractSpaceLuaFromPageText, loadConfig } from "./boot_config.ts";
@@ -270,8 +271,7 @@ async function cachedFetch(path: string): Promise<string> {
         "X-Sync-Mode": "1",
       },
     });
-    if (response.status === 503) {
-      // Offline
+    if (response.status in offlineStatusCodes) {
       const text = localStorage.getItem(cacheKey);
       if (text) {
         console.info("Falling back to cache for", path);

--- a/client/spaces/http_space_primitives.ts
+++ b/client/spaces/http_space_primitives.ts
@@ -7,6 +7,7 @@ import type { FileMeta } from "@silverbulletmd/silverbullet/type/index";
 import {
   notFoundError,
   offlineError,
+  offlineStatusCodes,
   pingTimeout,
   wrongSpacePathError,
 } from "@silverbulletmd/silverbullet/constants";
@@ -46,7 +47,7 @@ export class HttpSpacePrimitives implements SpacePrimitives {
       options.signal = AbortSignal.timeout(fetchTimeout);
       options.redirect = "manual";
       const result = await fetch(url, options);
-      if (result.status === 503) {
+      if (result.status in offlineStatusCodes) {
         throw offlineError;
       }
       const redirectHeader = result.headers.get("location");

--- a/plug-api/constants.ts
+++ b/plug-api/constants.ts
@@ -8,3 +8,21 @@ export const wrongSpacePathError: Error = new Error(
 );
 export const pingTimeout: number = 2000;
 export const pingInterval: number = 5000;
+
+/**
+ * HTTP status codes that should be treated as "offline" conditions.
+ *
+ * This is particularly useful for cases where a proxy (such as Cloudflare or other reverse proxies)
+ * indicates that the backend server is down, but there is still network connectivity between
+ * the user and the proxy. In these scenarios, we want to allow the user to continue working
+ * with their cached data rather than showing an error, even though technically there is network
+ * connectivity to the proxy.
+ *
+ * This enables SilverBullet to work in a true "offline-first" manner, falling back to cached
+ * content when the backend is unavailable through no fault of the user's network connection.
+ */
+export const offlineStatusCodes = {
+  502: "Bad Gateway", // Proxy server received invalid response from upstream server
+  503: "Service Unavailable", // Server is temporarily unable to handle the request
+  504: "Gateway Timeout", // Proxy server did not receive a timely response from upstream server
+} as const;


### PR DESCRIPTION
Identify more HTTP statuses as indicating "offline", specifically ones delivered by proxies such as cloudflare.