### PR TITLE
Fix: add a missing triple-backtick to close env

### DIFF
--- a/website/API/space.md
+++ b/website/API/space.md
@@ -58,7 +58,7 @@ if space.pageExists("Hello") then
 else
     print("Page not found")
 end
-
+```
 
 # Document Operations
 


### PR DESCRIPTION
This fixes a typo that causes https://silverbullet.md/API/space to miss the "Document Operations" header and the `space.ListDocuments()` API in the TOC.