### PR TITLE
Fix issue #1588: Multiline Linked Mentions

### DIFF
--- a/plugs/index/snippet_extractor.ts
+++ b/plugs/index/snippet_extractor.ts
@@ -11,7 +11,7 @@ export function extractSnippetAroundIndex(
 
   // Find which line contains the index
   const textBeforeIndex = text.slice(0,index);
-  const linesBeforeIndex = textBeforeIndex.matchAll(new RegExp("/\n/","g")).toArray();
+  const linesBeforeIndex = textBeforeIndex.matchAll(new RegExp("\n","g")).toArray();
   targetLineIndex = linesBeforeIndex.length;
 
   if (targetLineIndex === -1) {


### PR DESCRIPTION
[This issue](https://github.com/silverbulletmd/silverbullet/issues/1588) is due to that newline characters not being included in the multiline snippet. 

Simplified snippet logic and **temporarily** removed multiline snippets. Please see below.


This is what I have been using locally to make the Linked Mentions look more familiar as a user coming from Logseq.

I will readd multiline logic to this PR depending on what you think.

I feel that for most mentions, adding context lines arbitrarily makes the snippet visually noisy in most cases.

I have the following possibly unwelcome ideas to improve this. I am willing to add them to this PR or separate PRs if you are interested.

Style the context lines with a slightly darker text color or something similar to make the line with the link stand out more. Could hide the context lines behind some sort of caret. 

Include the preceding outline parent (see below) while skipping any lines in between and maybe adding an elipsis to indicate the skipped lines.

```
- Parent
  - Child
  - Child with [[link]]
  - Child
```

Include some succeeding outline children for cases where the link is used as a title for those outline children like below

```
- [[link]]
  - Child
  - Child
  - Child
```