### PR TITLE
Handle invalid-syntax errors for virtual files `tag:..` and `search:..`

### DIFF
--- a/server/disk_space_primitives_test.go
+++ b/server/disk_space_primitives_test.go
@@ -255,3 +255,20 @@ func TestSymlinksAndInfiniteLoops(t *testing.T) {
 	assert.NoError(t, err, "Should be able to read original file")
 	assert.Equal(t, []byte("new content"), content, "Original file should be updated through symlink")
 }
+
+// Test that virtual pages (like tag:Something) return ErrNotFound instead of possible filesystem errors
+func TestVirtualPages(t *testing.T) {
+	space, err := NewDiskSpacePrimitives(t.TempDir(), "")
+	assert.NoError(t, err, "Failed to create DiskSpacePrimitives")
+
+	// Virtual pages with colons should return ErrNotFound, not a filesystem error
+	_, err = space.GetFileMeta("tag:Todo.md")
+	assert.Equal(t, ErrNotFound, err, "Virtual page should return ErrNotFound")
+
+	_, err = space.GetFileMeta("search:this")
+	assert.Equal(t, ErrNotFound, err, "Virtual page should return ErrNotFound")
+
+	_, _, err = space.ReadFile("tag:Todo.md")
+	assert.Equal(t, ErrNotFound, err, "Reading virtual page should return ErrNotFound")
+
+}


### PR DESCRIPTION
## Change

On some filesystems, `os.Stat` for a file with a special character like `:` returns a "syntax error" rather than a "fileNotFound error". 

This happens for BuiltInPaths `tag:..` and `search:..` -> results in a 500 error returned to the frontend -> prevents the "Virtual Page" handler from being invoked -> breaks 'tag' and 'global search' functionality.

To resolve - this PR checks for this syntax error after the calls to `os.Stat`, and instead return the same "file not found" result as for `os.IsNotExist` error.

I decided that parsing the error message text was better than using `syscall.Errno`.

Closes #1700.

## Testing

I added new unit tests that exercise the new function `isSyntaxError`.

I built the solution on MacOS and Windows and tested that the error no longer occurs; tag and search functionality now works as expected under the special virtual filesytems as noted in the related issue.