### PR TITLE
Improve links in frontmatter

### DIFF
--- a/client/markdown_parser/constants.ts
+++ b/client/markdown_parser/constants.ts
@@ -5,7 +5,8 @@ export const tagRegex =
   /#(?:(?:\d*[^\d\s!@#$%^&*(),.?":{}|<>\\][^\s!@#$%^&*(),.?":{}|<>\\]*)|(?:<[^>\n]+>))/;
 export const nakedUrlRegex =
   /(^https?:\/\/([-a-zA-Z0-9@:%_\+~#=]|(?:[.](?!(\s|$)))){1,256})(([-a-zA-Z0-9(@:%_\+~#?&=\/]|(?:[.,:;)](?!(\s|$))))*)/;
-export const frontmatterUrlRegex = /"(https?:\/\/[^\s"']+)"/g;
+export const frontmatterQuotesRegex = /["'].*["']/g;
+export const frontmatterUrlRegex = /(https?:\/\/[^\s"']+)/g;
 export const frontmatterWikiLinkRegex =
-  /"(?<leadingTrivia>!?\[\[)(?<stringRef>.*?)(?:\|(?<alias>.*?))?(?<trailingTrivia>\]\])"/g;
+  /(?<leadingTrivia>!?\[\[)(?<stringRef>.*?)(?:\|(?<alias>.*?))?(?<trailingTrivia>\]\])/g;
 export const pWikiLinkRegex = new RegExp("^" + wikiLinkRegex.source); // Modified regex used only in parser


### PR DESCRIPTION
Without this, only a single quoted link would be rendered properly inside frontmatter, i.e:
```yaml
a: "[[link]]"
b: "https://silverbullet.md"
c: "[[link]] asdas"          # wouldn't work
d: "[[link]] [[das]]"        # wouldn't work - would render a link to: link]] [[das
e: '[[link]]'                # wouldn't work
```

With this change, the following works as expected:
```yaml
a: "[[aaaa]]"
b: "[[aaa]a]]"
c: "[[aaaa]] sadasd"
d: "[[aaaa]] [[bbbb]]"
e: "[[aaaa]] @ [[bbbb]]"
f: [[bbbb]]                  # this will NOT be rendered as a link as it's a valid yaml array (in array)
g: "https://silverbullet.md"
h: "https://silverbullet.md https://github.com"
i: "asd ads https://silverbullet.md"
j: '[[asdas]]'
```

Note that the links are rendered only when the cursor is outside the whole frontmatter block.
I am not sure what is preferred - before this patch wiki links would be rendered when the cursor was outside the whole block, but regular urls would be rendered when the cursor was outside the url itself, so it was kind of inconsistent.

I am also attaching a few screenshots.

Before this change:
<img width="771" height="310" alt="2025-11-27-183218" src="https://github.com/user-attachments/assets/1ca0e919-113c-49f9-a1d4-a9bb067272a4" />

With this change, with the cursor outside of the frontmatter block:
<img width="774" height="314" alt="2025-11-27-182942" src="https://github.com/user-attachments/assets/a0cf0e4d-6c16-4a6c-81fc-797456932b1e" />

With this change, with the cursor inside the frontmatter block:
<img width="778" height="312" alt="2025-11-27-182955" src="https://github.com/user-attachments/assets/8cfb09b4-8d88-4690-a58d-a54732ec8355" />

Thougts?