### PR TITLE
feat: Add linkName attribute support for wiki link autocomplete

### DIFF
--- a/plugs/editor/complete.ts
+++ b/plugs/editor/complete.ts
@@ -96,20 +96,23 @@ export async function pageComplete(completeEvent: CompleteEvent) {
 
       if (isWikilink) {
         // A [[wikilink]]
-        if (pageMeta.displayName) {
-          const decoratedName = namePrefix + pageMeta.displayName;
+        const linkAlias = pageMeta.linkName || pageMeta.displayName;
+        if (linkAlias) {
+          const decoratedName = namePrefix + linkAlias;
           let boost = new Date(pageMeta.lastModified).getTime();
           if (pageMeta._isAspiring) {
             boost = -Infinity;
           }
           completions.push({
-            label: pageMeta.displayName,
+            label: linkAlias,
             displayLabel: decoratedName,
             boost,
             apply: pageMeta.tag === "template"
               ? pageMeta.name
-              : `${pageMeta.name}|${pageMeta.displayName}`,
-            detail: `displayName for: ${pageMeta.name}`,
+              : `${pageMeta.name}|${linkAlias}`,
+            detail: pageMeta.linkName
+              ? `linkName for: ${pageMeta.name}`
+              : `displayName for: ${pageMeta.name}`,
             type: "page",
             cssClass,
           });


### PR DESCRIPTION
## Summary

- Add support for `linkName` frontmatter attribute that controls the alias text inserted during wiki link autocomplete
- Precedence order: `linkName` > `displayName` > page name
- Allows users to have separate link text from display name

## Use Case

For a page named "Randy Mario Poffo" with frontmatter:
```yaml
---
linkName: Randy Savage
displayName: Macho Man
---
```

Selecting this page from autocomplete inserts: `[[Randy Mario Poffo|Randy Savage]]`

This separates the concept of "how this page appears in links" (`linkName`) from "how this page is displayed in the UI" (`displayName`).

## Changes

- Modified `plugs/editor/complete.ts` to check for `linkName` before falling back to `displayName`
- Updated detail text in autocomplete to indicate which attribute is being used

## Test plan

- [ ] Create a page with `linkName` in frontmatter
- [ ] Verify autocomplete inserts `[[pagename|linkName]]`
- [ ] Create a page with only `displayName` - verify existing behavior unchanged
- [ ] Create a page with both - verify `linkName` takes precedence