### PR TITLE
feat: Improve Lua go-to-definition with Ctrl-click support and user feedback

### DIFF
--- a/libraries/Library/Std/Editor/Lua.md
+++ b/libraries/Library/Std/Editor/Lua.md
@@ -138,15 +138,23 @@ local function inLuaContext(parentNodes)
   return false
 end
 
+local function notDefinedinLua()
+  return editor.flashNotification(
+    "Cannot navigate to definition; not defined in Lua."
+  )
+end
+
 event.listen {
   name = "page:click",
   run = function(e)
-    if not e.data.metaKey or e.data.ctrlKey then
+    -- Accept either Cmd-click (Mac) or Ctrl-click (Linux)
+    if not (e.data.metaKey or e.data.ctrlKey) then
       return
     end
     if not inLuaContext(e.data.parentNodes) then
-      return
+      return notDefinedinLua()
     end
+
     local pos = e.data.pos
     local text = editor.getText()
     -- Find start pos
@@ -188,6 +196,8 @@ event.listen {
         -- Has to be offset a bit
         pos=tonumber(refBits[2]) + ctx.from + #"```space-lua\n"
       })
+    else
+      return notDefinedinLua()
     end
   end
 }


### PR DESCRIPTION
## Summary
- Accept Ctrl-click (Linux) in addition to Cmd-click (Mac) for navigating to Lua function definitions
- Show flash notification when definition cannot be found (e.g., for built-in functions or non-Lua code)

## Test plan
- [ ] Test Cmd-click on a Space Lua function on macOS - should navigate to definition
- [ ] Test Ctrl-click on a Space Lua function on Linux - should navigate to definition
- [ ] Test Cmd/Ctrl-click on a built-in function (e.g., `string.match`) - should show "Cannot navigate to definition; not defined in Lua." notification
- [ ] Test Cmd/Ctrl-click outside of a Lua context - should show the notification