### PR TITLE
Include sourcemaps in production builds

### DIFF
--- a/build_client.ts
+++ b/build_client.ts
@@ -70,7 +70,7 @@ async function buildCopyBundleAssets() {
     absWorkingDir: Deno.cwd(),
     bundle: true,
     treeShaking: true,
-    sourcemap: Deno.args[0] === "--production" ? undefined : "linked",
+    sourcemap: "linked",
     minify: true,
     jsxFactory: "h",
     // metafile: true,

--- a/client/plugos/plug_compile.ts
+++ b/client/plugos/plug_compile.ts
@@ -106,7 +106,7 @@ setupMessageListener(functionMapping, manifest, self.postMessage);
     format: "esm",
     globalName: "mod",
     platform: "browser",
-    sourcemap: options.debug ? "linked" : undefined,
+    sourcemap: "linked",
     minify: !options.debug,
     outfile: outFile,
     metafile: options.info,

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -4,6 +4,7 @@ An attempt at documenting the changes/new features introduced in each release.
 Whenever a commit is pushed to the `main` branch, within ~10 minutes, it will be released as a docker image with the `:v2` tag, and a binary in the [edge release](https://github.com/silverbulletmd/silverbullet/releases/tag/edge). If you want to live on the bleeding edge of SilverBullet goodness (or regression) this is where to do it.
 
 * **Removed** full-text search plug from the main distribution, this has now been moved to [a separate repo](https://github.com/silverbulletmd/basic-search) (installable via the library manager). This dramatically improves indexing speed. Honestly, use [Silversearch](https://github.com/MrMugame/silversearch) instead.
+* Production builds now include sourcemaps for easier debugging in browser DevTools. If you don't want to serve sourcemaps publicly, you can block `*.js.map` files at your reverse proxy level (see [[TLS#Blocking sourcemaps]]).
 
 ## 2.3.0
 This release (re)introduces [[Share]], formalizes [[Library]], and introduces in initial version of the [[Library Manager]], a type of package manager for SilverBullet. It also progresses on Lua 5.4 compatibility.

--- a/website/TLS.md
+++ b/website/TLS.md
@@ -76,3 +76,30 @@ Restart Caddy and access SilverBullet via `https://silverbullet.mydomain.com`. O
 
 ## Self-signed certificate
 It is possible to self sign certificates and use those. Search the Internet for instructions on how to do this, [here is website that describes the way it works and how to do it](https://www.ssldragon.com/blog/what-is-self-signed-certificate/).
+
+# Blocking sourcemaps
+
+SilverBullet production builds include sourcemaps (`.js.map` files) to help with debugging in browser DevTools. These files expose the original source code, which some users may prefer not to serve publicly.
+
+If you're using a reverse proxy, you can block access to sourcemaps:
+
+## Caddy
+Add a matcher and respond block to your Caddyfile:
+
+```
+silverbullet.mydomain.com {
+    @sourcemaps path *.js.map
+    respond @sourcemaps 404
+
+    reverse_proxy localhost:3000
+}
+```
+
+## Nginx
+```nginx
+location ~* \.js\.map$ {
+    return 404;
+}
+```
+
+This will return a 404 for any `.js.map` file requests while still allowing normal SilverBullet operation.


### PR DESCRIPTION
This makes it easier to debug issues, but also to understand SilverBullet internals while developing new features in Space Lua.

Fixes #1699.