### PR TITLE
Fix documentation: rename net.proxyRequest to net.proxyFetch

### DIFF
--- a/website/API/http.md
+++ b/website/API/http.md
@@ -6,4 +6,4 @@ HTTP APIs
 > Deprecated: use [[API/net]] instead.
 
 ### http.request(url, options?)
-Deprecated, use [[API/net#net.proxyRequest(url, options?)]] instead.
+Deprecated, use [[API/net#net.proxyFetch(url, options?)]] instead.

--- a/website/API/net.md
+++ b/website/API/net.md
@@ -2,7 +2,7 @@
 
 Network-related APIs.
 
-### net.proxyRequest(url, options?)
+### net.proxyFetch(url, options?)
 Performs a HTTP call, proxied via the server (to avoid CORS issues, see [[HTTP API]]).
 
 Options:


### PR DESCRIPTION
## Summary
- Fixed documentation inconsistency where the net API function was documented as `net.proxyRequest` but implemented as `net.proxyFetch`
- Updated `website/API/net.md` to use the correct function name
- Updated `website/API/http.md` reference to point to the correct function name

## Test plan
- Review the documentation changes to ensure they match the actual implementation in `client/space_lua/stdlib/net.ts`
- Verify that the function is exported as `proxyFetch` (line 10 of net.ts)