### PR TITLE
Improve hamburger menu behavior in mobile mode (Fixes #1519)

### DIFF
--- a/client/components/top_bar.tsx
+++ b/client/components/top_bar.tsx
@@ -136,6 +136,13 @@ export function TopBar({
                       e.stopPropagation();
                       actionButton.callback();
                     }}
+                    onBlur={() => {
+                      // Close the hamburger menu in mobile mode if the action button loses focus after callback
+                      if (mobileMenuStyle === "hamburger") {
+                        document.querySelector("#sb-top .sb-actions.hamburger")
+                          ?.classList.remove("open");
+                      }
+                    }}
                     title={actionButton.description}
                     className={actionButton.class}
                   >

--- a/client/editor_ui.tsx
+++ b/client/editor_ui.tsx
@@ -343,7 +343,9 @@ export class MainUI {
                 description: "Open Menu",
                 class: "expander",
                 callback: () => {
-                  /* nothing to do, menu opens on hover/mobile click */
+                  // Make the expander button open/close the menu via toggling the CSS class "open"
+                  document.querySelector("#sb-top .sb-actions.hamburger")
+                    ?.classList.toggle("open");
                 },
               }]
               : [],

--- a/client/styles/colors.scss
+++ b/client/styles/colors.scss
@@ -88,6 +88,11 @@
   color: var(--action-button-hover-color);
 }
 
+// Only color the expander button, when the hamburger menu is open
+.sb-actions:not(.open) button.expander:hover {
+  color: var(--action-button-color);
+}
+
 .sb-button,
 .sb-button-primary {
   --color: var(--button-color);

--- a/client/styles/top.scss
+++ b/client/styles/top.scss
@@ -151,7 +151,8 @@
       }
     }
 
-    &:hover {
+    // CSS class for toggling the hamburger menu, so it can be toggled via JS
+    &.open:hover {
       /* Expanded height limited to the viewport height minus some padding */
       max-height: calc(100vh - 24px);
       box-shadow: 0 2px 15px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
Hello,

currently the hamburger menu in mobile mode only closes, when clicking outside of the menu. I found it to be pretty unintuitve that the hamburger button is only able to open the menu, but not close it.

This PR makes the hamburger menu toggleable. It opens and closes when the hamburger button is pressed. It also closes when another action button is pressed and the button imposes a focus change. It keeps the behavior of the menu closing when clicking outside the menu. I've also tested it to only affect the hamburger menu and neither the bottom-bar style or the desktop version.

I know that it is a little bit hacky to use querySelector and I am sure that we could create something more elegant or configurable but this way only a very little addition of JS is needed and at least to me it is a serious improvement for the usage of the hamburger menu.

I have run make check, fmt and test and everything went fine. I'm happy to get this reviewed and maybe discuss for a better solution if this one doesn't fit.

Cheers