### PR TITLE
Add request body size limits to prevent OOM

### DIFF
--- a/server/fs.go
+++ b/server/fs.go
@@ -93,6 +93,9 @@ func handleFsPut(w http.ResponseWriter, r *http.Request) {
 	path := DecodeURLParam(r, "*")
 	spaceConfig := spaceConfigFromContext(r.Context())
 
+	// Limit request body size to prevent OOM (50MB max)
+	r.Body = http.MaxBytesReader(w, r.Body, 50*1024*1024)
+
 	// Read request body
 	body, err := io.ReadAll(r.Body)
 	if err != nil {

--- a/server/logs_endpoint.go
+++ b/server/logs_endpoint.go
@@ -16,6 +16,9 @@ type LogEntry struct {
 }
 
 func handleLogsEndpoint(w http.ResponseWriter, r *http.Request) {
+	// Limit request body size to prevent OOM (1MB max for log messages)
+	r.Body = http.MaxBytesReader(w, r.Body, 1*1024*1024)
+
 	var messages []LogEntry
 
 	if err := render.DecodeJSON(r.Body, &messages); err != nil {

--- a/server/shell_endpoint.go
+++ b/server/shell_endpoint.go
@@ -20,6 +20,10 @@ func init() {
 // handleShellEndpoint handles POST requests to /.shell for executing shell commands
 func handleShellEndpoint(w http.ResponseWriter, r *http.Request) {
 	spaceConfig := spaceConfigFromContext(r.Context())
+
+	// Limit request body size to prevent OOM (1MB max for shell commands)
+	r.Body = http.MaxBytesReader(w, r.Body, 1*1024*1024)
+
 	// Parse the request body
 	var shellRequest ShellRequest
 	if err := json.NewDecoder(r.Body).Decode(&shellRequest); err != nil {


### PR DESCRIPTION
## Summary

Adds `http.MaxBytesReader` limits to prevent server crashes from large request bodies.

## Motivation

From SECURITY_TRIAGE_PERSONAL_USE.md - "Easy Win #1":
- **Why:** Prevents accidental crashes (upload huge file → server OOM)
- **UX Impact:** None (reasonable limits like 50MB)
- **Benefit:** Server won't crash if you accidentally try to PUT a 5GB video file

## Changes

### fs.go:97
- Added 50MB limit for file uploads via PUT

### shell_endpoint.go:25
- Added 1MB limit for shell command requests

### logs_endpoint.go:20  
- Added 1MB limit for client log messages

## Testing

- All existing tests pass (38.7% coverage maintained)
- Limits are high enough for normal usage but prevent OOM scenarios

## Context

This is part of a series of small, focused hardening fixes for personal use. Each PR is independent and can be cherry-picked individually.