### PR TITLE
Add openssh-client for SSH Git operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ VOLUME /space
 # Or simply mount an existing folder into the container:
 #   docker run -v /path/to/my/folder:/space -p3000:3000 -it ghcr.io/silverbulletmd/silverbullet
 
-RUN apk add --no-cache git curl bash tini
+RUN apk add --no-cache git curl bash tini openssh-client
 
 HEALTHCHECK CMD curl --fail http://localhost:3000$SB_URL_PREFIX/.ping || exit 1
 


### PR DESCRIPTION
**Add openssh-client for SSH Git operations**

```
RUN apk add --no-cache git curl bash tini openssh-client
```

**Fixes**: `git push` SSH failures (`error: cannot run ssh: No such file or directory`)

Enables SSH key authentication in `/space` mounted folders, avoiding Git tokens.

```
Before: fatal: unable to fork
After: git push origin main works with SSH keys
```

***

Would you like any tweaks to the wording?