### PR TITLE
Fix widgets not re-rendering when page metadata loads

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -543,6 +543,9 @@ export class Client {
                     type: "update-current-page-meta",
                     meta: enrichedMeta,
                   });
+
+                  // Trigger editor re-render to update Lua widgets with the new metadata
+                  this.editorView.dispatch({});
                 }
               })
               .catch((e) => {
@@ -1150,6 +1153,9 @@ export class Client {
           type: "update-current-page-meta",
           meta: enrichedMeta,
         });
+
+        // Trigger editor re-render to update Lua widgets with the new metadata
+        this.editorView.dispatch({});
       } catch (e: any) {
         console.log(
           `There was an error trying to fetch enriched metadata: ${e.message}`,


### PR DESCRIPTION
Trigger editor re-render after page metadata is loaded to ensure widgets re-evaluate with the correct context. This fixes issue [#1729](https://github.com/silverbulletmd/silverbullet/issues/1729) where widgets would continue showing broken state on initial page load because `ctx.currentPage` would be `nil` until the metadata finished loading asynchronously.

The fix dispatches an empty transaction after updating the page metadata, which triggers all decorator state fields (including widgets) to re-render with the updated metadata.