### PR TITLE
draft fix #1772

### DIFF
--- a/client/plugos/plug_compile.ts
+++ b/client/plugos/plug_compile.ts
@@ -13,6 +13,24 @@ import { version } from "../../version.ts";
 const workerRuntimeUrl =
   `https://deno.land/x/silverbullet@${version}/client/plugos/worker_runtime.ts`;
 
+// Known SHA-256 checksums for worker_runtime.ts by version
+const WORKER_RUNTIME_CHECKSUMS: Record<string, string> = {
+  "2.3.0": "0237c0c2d689bb47fc7561f835d081d8cc582b047b5867bea6e8c0b073b4ed55",
+  "2.2.1": "0237c0c2d689bb47fc7561f835d081d8cc582b047b5867bea6e8c0b073b4ed55",
+  "2.2.0": "0237c0c2d689bb47fc7561f835d081d8cc582b047b5867bea6e8c0b073b4ed55",
+  "2.1.9": "0237c0c2d689bb47fc7561f835d081d8cc582b047b5867bea6e8c0b073b4ed55",
+  "2.1.8": "0237c0c2d689bb47fc7561f835d081d8cc582b047b5867bea6e8c0b073b4ed55",
+  "2.1.7": "0237c0c2d689bb47fc7561f835d081d8cc582b047b5867bea6e8c0b073b4ed55",
+  "2.1.6": "0237c0c2d689bb47fc7561f835d081d8cc582b047b5867bea6e8c0b073b4ed55",
+  "2.1.5": "0371f6d8f007222b397dfe72a5b8b2e02f38f3521b9317d695f3f0a46e2310e1",
+  "2.1.4": "0371f6d8f007222b397dfe72a5b8b2e02f38f3521b9317d695f3f0a46e2310e1",
+  "2.1.3": "0371f6d8f007222b397dfe72a5b8b2e02f38f3521b9317d695f3f0a46e2310e1",
+  "2.1.2": "0371f6d8f007222b397dfe72a5b8b2e02f38f3521b9317d695f3f0a46e2310e1",
+  "2.1.1": "0371f6d8f007222b397dfe72a5b8b2e02f38f3521b9317d695f3f0a46e2310e1",
+  "2.1.0": "0371f6d8f007222b397dfe72a5b8b2e02f38f3521b9317d695f3f0a46e2310e1",
+  "2.0.0": "7d04f7431bbfa41a04bcc7e6b98b9de0d919756c4c671c5785c99fff45f16402",
+};
+
 export type CompileOptions = {
   debug?: boolean;
   runtimeUrl?: string;
@@ -23,6 +41,62 @@ export type CompileOptions = {
   // Print info on bundle size
   info?: boolean;
 };
+
+async function verifyWorkerRuntimeChecksum(
+  runtimeUrl: string,
+  version: string,
+): Promise<void> {
+  // Only verify 2.x versions
+  if (!version.startsWith("2.")) {
+    return;
+  }
+
+  const expectedChecksum = WORKER_RUNTIME_CHECKSUMS[version];
+  if (!expectedChecksum) {
+    console.warn(
+      `Warning: No checksum available for worker_runtime.ts version ${version}. Skipping verification.`,
+    );
+    return;
+  }
+
+  try {
+    // Fetch the runtime file
+    const response = await fetch(runtimeUrl);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch worker_runtime.ts: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const runtimeContent = await response.text();
+
+    // Calculate SHA-256 hash
+    const encoder = new TextEncoder();
+    const data = encoder.encode(runtimeContent);
+    const hashBuffer = await globalThis.crypto.subtle.digest("SHA-256", data);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const actualChecksum = hashArray.map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    // Verify checksum matches
+    if (actualChecksum !== expectedChecksum) {
+      throw new Error(
+        `Worker runtime checksum mismatch for version ${version}!\n` +
+          `Expected: ${expectedChecksum}\n` +
+          `Actual:   ${actualChecksum}\n` +
+          `This may indicate the runtime has been tampered with or incorrectly published.`,
+      );
+    }
+
+    console.log(`✓ Worker runtime checksum verified for version ${version}`);
+  } catch (error) {
+    throw new Error(
+      `Worker runtime verification failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
 
 export async function compileManifest(
   manifestPath: string,
@@ -99,6 +173,10 @@ setupMessageListener(functionMapping, manifest, self.postMessage);
   const inFile = await Deno.makeTempFile({ suffix: ".js" });
   const outFile = `${destPath}/${manifest.name}.plug.js`;
   await Deno.writeTextFile(inFile, jsFile);
+
+  // Verify worker runtime checksum before bundling
+  const runtimeUrlToVerify = options.runtimeUrl || workerRuntimeUrl;
+  await verifyWorkerRuntimeChecksum(runtimeUrlToVerify, version);
 
   const result = await esbuild.build({
     entryPoints: [path.basename(inFile)],


### PR DESCRIPTION
draft fix https://github.com/silverbulletmd/silverbullet/issues/1772

adds checksum verification for worker runtime, but this is still useless as there is no guarantee that the verified content is actually used, this gap must be addressed. the actual download seems to happens with esbuild