### PR TITLE
fix: add null checks to prevent 'cannot read children' crash

### DIFF
--- a/client/markdown_renderer/inline.ts
+++ b/client/markdown_renderer/inline.ts
@@ -122,8 +122,9 @@ export async function expandMarkdown(
     } else if (n.type === "Task" && options.rewriteTasks !== false) {
       // Add a task reference to this based on the current page name if there's not one already
       const existingLink = findNodeOfType(n, "WikiLink");
-      if (!existingLink) {
-        n.children!.splice(1, 0, {
+      // Only rewrite if we have children, parent, and parent position
+      if (!existingLink && n.children && n.parent?.from !== undefined) {
+        n.children.splice(1, 0, {
           "text": " ",
         }, {
           "type": "WikiLink",
@@ -134,7 +135,7 @@ export async function expandMarkdown(
             },
             {
               "type": "WikiLinkPage",
-              "children": [{ "text": `${pageName}@${n.parent!.from!}` }],
+              "children": [{ "text": `${pageName}@${n.parent.from}` }],
             },
             {
               "type": "WikiLinkMark",

--- a/client/markdown_renderer/markdown_render.ts
+++ b/client/markdown_renderer/markdown_render.ts
@@ -47,9 +47,9 @@ function preprocess(t: ParseTree) {
   addParentPointers(t);
   traverseTree(t, (node) => {
     if (!node.type) {
-      if (node.text?.startsWith("\n")) {
-        const prevNodeIdx = node.parent!.children!.indexOf(node) - 1;
-        const prevNodeType = node.parent!.children![prevNodeIdx]?.type;
+      if (node.text?.startsWith("\n") && node.parent?.children) {
+        const prevNodeIdx = node.parent.children.indexOf(node) - 1;
+        const prevNodeType = node.parent.children[prevNodeIdx]?.type;
         if (
           prevNodeType?.includes("Heading") || prevNodeType?.includes("Table")
         ) {
@@ -60,6 +60,7 @@ function preprocess(t: ParseTree) {
     return false;
   });
 }
+
 
 function posPreservingRender(
   t: ParseTree,

--- a/plugs/index/item.ts
+++ b/plugs/index/item.ts
@@ -108,12 +108,14 @@ export function extractItemFromNode(
 
   // Is this a task?
   const taskNode = itemNode.children!.find((n) => n.type === "Task");
-  if (taskNode) {
+  if (taskNode && taskNode.children) {
     item.tag = "task";
-    item.state = taskNode.children![0].children![1].text!;
+    // Safely extract task state with fallback - structure is TaskState > [ > state > ]
+    const taskStateNode = taskNode.children[0];
+    item.state = taskStateNode?.children?.[1]?.text ?? " ";
     item.done = completeStates.includes(item.state);
     // Fake a paragraph node for text rendering later
-    nameNode = { type: "Paragraph", children: taskNode.children!.slice(1) };
+    nameNode = { type: "Paragraph", children: taskNode.children.slice(1) };
   }
 
   // Now let's extract tags and attributes


### PR DESCRIPTION
## Problem
When rendering Lua widget output containing tasks inside markdown tables, SilverBullet crashes with:
```
TypeError: Cannot read properties of undefined (reading 'children')
```

The error occurs in the `preprocess()` function in `markdown_render.ts` where `node.parent.children` is accessed without first checking if `node.parent` exists.

## Cause
This was likely introduced during the inline content refactor (commit fb3dd51b). When certain markdown nodes are processed in isolation (e.g., within table cells or widget outputs), they may not have a parent pointer set.

## Solution
Added defensive null checks:
- **markdown_render.ts**: Guard `node.parent?.children` before accessing in `preprocess()`
- **inline.ts**: Guard `n.children` and `n.parent?.from` in task rewriting
- **item.ts**: Use optional chaining for task state extraction

## Testing
Tested locally with a Lua widget that renders tasks inside a markdown table. The crash no longer occurs and tasks render correctly.