### PR TITLE
Fix docker image helthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ VOLUME /space
 
 RUN apk add --no-cache git curl bash tini
 
-HEALTHCHECK CMD curl --fail http://localhost:3000$SB_URL_PREFIX/.ping || exit 1
+HEALTHCHECK CMD curl --fail http://localhost:$SB_PORT$SB_URL_PREFIX/.ping || exit 1
 
 # Expose port 3000
 # Port map this when running, e.g. with -p 3002:3000 (where 3002 is the host port)


### PR DESCRIPTION
With a compose.yaml:
```
  silver:
    image: zefhemel/silverbullet
    environment:
    - SB_PORT=8080
    - SB_HOSTNAME=0.0.0.0
    ports:
    - 8080
```
it will show the container unhealthy as it check on the port 3000.
The healthchek was already using the `SB_URL_PREFIX` but `SB_PORT` was missing