### PR TITLE
Fix diff styles in code fence

### DIFF
--- a/client/styles/colors.scss
+++ b/client/styles/colors.scss
@@ -349,6 +349,16 @@ tbody tr:nth-of-type(even) {
   color: var(--editor-meta-color);
 }
 
+.sb-deleted {
+  color: var(--editor-code-deleted-color, #dc2626);
+  background-color: var(--editor-code-deleted-bg, rgba(254, 202, 202, 0.25));
+}
+
+.sb-inserted {
+  color: var(--editor-code-inserted-color, #16a34a);
+  background-color: var(--editor-code-inserted-bg, rgba(187, 247, 208, 0.25));
+}
+
 // Admonitions
 
 .sb-admonition {


### PR DESCRIPTION
when inserting a new code fence, `diff` as a language option showed up,
but I didn't see the expected red/green coloring.

Yes finally I was able to create my onwn `space-style` but it was quite frustrating,
as bash/yaml/golang all worked but diff