### PR TITLE
Ensure command keybindings work reliably in any vim-mode

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -121,7 +121,7 @@ export class Client {
 
   // CodeMirror editor
   editorView!: EditorView;
-  keyHandlerCompartment?: Compartment;
+  commandKeyHandlerCompartment?: Compartment;
   indentUnitCompartment?: Compartment;
   undoHistoryCompartment?: Compartment;
 

--- a/client/client_system.ts
+++ b/client/client_system.ts
@@ -33,7 +33,7 @@ import { languageSyscalls } from "./plugos/syscalls/language.ts";
 import { codeWidgetSyscalls } from "./plugos/syscalls/code_widget.ts";
 import { clientCodeWidgetSyscalls } from "./plugos/syscalls/client_code_widget.ts";
 import { KVPrimitivesManifestCache } from "./plugos/manifest_cache.ts";
-import { createKeyBindings } from "./codemirror/editor_state.ts";
+import { createCommandKeyBindings } from "./codemirror/editor_state.ts";
 import type { DataStoreMQ } from "./data/mq.datastore.ts";
 import { jsonschemaSyscalls } from "./plugos/syscalls/jsonschema.ts";
 import { luaSyscalls } from "./plugos/syscalls/lua.ts";
@@ -125,8 +125,8 @@ export class ClientSystem {
         });
         // Replace the key mapping compartment (keybindings)
         this.client.editorView.dispatch({
-          effects: this.client.keyHandlerCompartment?.reconfigure(
-            createKeyBindings(this.client),
+          effects: this.client.commandKeyHandlerCompartment?.reconfigure(
+            createCommandKeyBindings(this.client),
           ),
         });
       },

--- a/client/components/mini_editor.tsx
+++ b/client/components/mini_editor.tsx
@@ -148,6 +148,9 @@ export function MiniEditor(
       doc: text,
       extensions: [
         EditorView.theme({}, { dark: darkMode }),
+        // Insert command bindings before vim-mode to ensure they're available
+        // in normal mode. See editor_state.ts for more details.
+        createCommandKeyBindings(globalThis.client),
         // Enable vim mode, or not
         [...vimMode ? [vim()] : []],
         [
@@ -182,7 +185,6 @@ export function MiniEditor(
           },
           ...standardKeymap,
           ...historyKeymap,
-          ...createCommandKeyBindings(globalThis.client),
         ]),
         EditorView.domEventHandlers({
           click: (e) => {


### PR DESCRIPTION
When the vim extension is enabled and in "normal" mode, some default bindings collide with Silverbullets commands (eg: `ctrl-p` - Share, `ctrl-o` - Open Document, `ctrl-e` - Export, `ctrl-g h` - Home). These vim bindings are not always functional (they may appear to do nothing depending on vims state). This gives the impression that Silverbullet is bugged and wont trigger commands. In "insert" mode, most bindings are passed through correctly with some exceptions (eg: `ctrl-o`).

By splitting the command keybindings into their own keymap extension and loading it before the vim extension, we can ensure Silverbullet commands always trigger.

This does mean some vim bindings are overshadowed, but if a binding triggers a Silverbullet command, its generally obvious that *something* happened and the user should be able to recognise why the vim binding failed and then rebind the command or vim mapping.

Closes https://github.com/silverbulletmd/silverbullet/issues/1323
