### PR TITLE
Make any frontmatter <scheme>:// URI's clickable

### DIFF
--- a/client/markdown_parser/constants.ts
+++ b/client/markdown_parser/constants.ts
@@ -9,4 +9,5 @@ export const frontmatterQuotesRegex = /["'].*["']/g;
 export const frontmatterUrlRegex = /([a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s"']+)/g;
 export const frontmatterWikiLinkRegex =
   /(?<leadingTrivia>!?\[\[)(?<stringRef>.*?)(?:\|(?<alias>.*?))?(?<trailingTrivia>\]\])/g;
+export const frontmatterMailtoRegex = /(mailto:[^@\s]+@[^@\s"']+)/ig;
 export const pWikiLinkRegex = new RegExp("^" + wikiLinkRegex.source); // Modified regex used only in parser


### PR DESCRIPTION
Per https://www.rfc-editor.org/rfc/rfc3986#section-3.1, the scheme must follow the pattern:

    scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )

Closes #1818