### PR TITLE
Alter editor.prompt handling of empty strings

### DIFF
--- a/client/plugos/syscalls/editor.ts
+++ b/client/plugos/syscalls/editor.ts
@@ -484,8 +484,24 @@ export function editorSyscalls(client: Client): SysCallMapping {
       _ctx,
       message: string,
       defaultValue = "",
+      options: { acceptEmpty?: boolean, trim?: boolean } = { acceptEmpty: false, trim: true }
     ): Promise<string | undefined> => {
-      return client.prompt(message, defaultValue);
+      const { acceptEmpty: acceptEmpty, trim: trim } = options;
+      // prompt() can return the input string, "" if the user just presses ok, or
+      // null if they press cancel.
+      let input = client.prompt(message, defaultValue);
+      if (input == null) {
+        return null;
+      }
+      if (trim) {
+        // input = trim && input.trim() || input; will shortcut incorrectly because "" == falsey
+        input = input.trim()
+      }
+      // Trim again in this check incase trim == false
+      if (!acceptEmpty && input.trim() == "") {
+        return null;
+      }
+      return input;
     },
     "editor.confirm": (_ctx, message: string): Promise<boolean> => {
       return client.confirm(message);

--- a/plug-api/syscalls/editor.ts
+++ b/plug-api/syscalls/editor.ts
@@ -351,6 +351,7 @@ export function dispatch(change: any): Promise<void> {
 export function prompt(
   message: string,
   defaultValue = "",
+  // TODO: also here
 ): Promise<string | undefined> {
   return syscall("editor.prompt", message, defaultValue);
 }


### PR DESCRIPTION
When working on #1831 I noticed that it was mishandling empty strings. `editor.prompt` could be expanded to do the  behaviour it was expecting, return null when no input is given. (note that in #1831, we're running in lua, where `""` is not falsey, in js these checks are ok aside from accepting `   ` as input.)

`client/window.prompt()` can return `null` (cancel), `""` (no input + ok), or whatever input the user entered. I think it probably makes a lot of sense to trim this input in most cases, eg filenames, titles, even input lines probably want to be trimmed most of the time, but sometimes a user may *want* to insert just whitespace (eg: indentation string for a function call?). In that case they could pass `trim = false`.

Since I felt like you may want untrimmed input (eg: `  space-around-my-string-for-visual-reasons  `), but would still want to consider `""` as "nothing", I separated out the checks for "entered nothing" and "trim or not".

This is an incomplete PR as it probably needs a number of checks to existing `editor.prompt` calls to check they act as expected, if the appetite for the change is there. It's also potentially breaking to downstream.