### PR TITLE
Consider "" to be an invalid path

### DIFF
--- a/plug-api/lib/ref.ts
+++ b/plug-api/lib/ref.ts
@@ -87,7 +87,7 @@ export function isValidName(name: string): boolean {
 export function isValidPath(path: string): path is Path {
   const ref = parseToRef(path);
 
-  return !!ref && ref.path === path;
+  return !!ref && ref.path === path && path !== "";
 }
 
 /**


### PR DESCRIPTION
Uploading a file with "" will break the client. " " would still technically be a valid filename, so we don't check against that here but when creating files the caller should be trimming the path if appropriate.