### PR TITLE
[LIQ/doc] Fix docs typo

### DIFF
--- a/website/Space Lua/Lua Integrated Query.md
+++ b/website/Space Lua/Lua Integrated Query.md
@@ -97,7 +97,7 @@ Example:
 ${query[[
   from p = index.tag "tag"
   group by p.name
-  select { name = p.name, count = #p.group }
+  select { name = name, count = #group }
   limit 5
 ]]}
 


### PR DESCRIPTION
The `select` part operates not over a single record, but over each group (i.e., the set of records sharing the same group key). The `select` clause's environment is generally:

* `name` (the group key)

* `group` (the table of records in the group)

Note: no `p` is bound (`p` is not set; it was the row variable during scan, but we are now at the group level).

In the `select { name = name }` the name refers to the group key (what we `group by`-ed).

We typically use:

* `name = name` (group key, as in the query), or

* if we want data from the first record (say all grouped `p.name` are the same and non-`nil`) then `name = group[1].name`.