### PR TITLE
Fix typo in Library Manager documentation

### DIFF
--- a/libraries/Library/Std/Pages/Library Manager.md
+++ b/libraries/Library/Std/Pages/Library Manager.md
@@ -1,6 +1,6 @@
 #meta
 
-From here you can extend SilverBullet with additional functionality throught he use of [libraries](https://silverbullet.md/Libraries).
+From here you can extend SilverBullet with additional functionality through the use of [libraries](https://silverbullet.md/Libraries).
 
 # Installed Libraries
 ${widgets.commandButton("Update All", "Library: Update All")}


### PR DESCRIPTION
A very minor documentation-only change to fix a typo.