### PR TITLE
Make ToC widget collapsible

### DIFF
--- a/libraries/Library/Std/Widgets/Widgets.md
+++ b/libraries/Library/Std/Widgets/Widgets.md
@@ -124,8 +124,9 @@ function widgets.toc(options)
   options = options or config.get("std.widgets.toc")
   options.minHeaders = options.minHeaders or 3
   options.minLevel = options.minLevel or 1
-  options.defaultOpen = options.defaultOpen or nil
   options.header = options.header or "Table of Contents"
+  local defaultOpen = (options.defaultOpen ~= false) or nil
+
   local text = editor.getText()
   local pageName = editor.getCurrentPage()
   local parsedMarkdown = markdown.parseMarkdown(text)
@@ -194,7 +195,7 @@ function widgets.toc(options)
   -- Wrap in a <details> element for native show/hide toggle
   return widget.new {
     html = dom.details {
-      open = options.defaultOpen,
+      open = defaultOpen,
       dom.summary {
         class = "sb-toc-summary",
         options.header


### PR DESCRIPTION
This replaces the current markdown based ToC widget in the `std` library with a dom elements based one. This allows us to wrap the whole list in a `<details>` element that provides a native open/close ability, making the ToC collapsible. It comes with an additional option to define whether the ToC shall be open or collapsed by default.

**Pictures**:

<img width="45%" alt="collapsed" src="https://github.com/user-attachments/assets/a8d3eb7a-7387-4572-98b3-b85f4a76d022" />
<img width="45%" alt="open" src="https://github.com/user-attachments/assets/a8f84013-212f-4339-bebe-82c304591c04" />
