### PR TITLE
Fix table cell alignment for missing and misaligned cells

### DIFF
--- a/client/markdown_renderer/markdown_render.ts
+++ b/client/markdown_renderer/markdown_render.ts
@@ -421,7 +421,18 @@ function render(
         body: cleanTags(mapRender(t.children!)),
       };
     case "TableRow": {
-      normalizeTableRow(t);
+      const table = t.parent;
+      const header = table?.children?.find((c) => c.type === "TableHeader");
+      let columnCount = 0;
+      let headerHasLeadingDelim: boolean | undefined;
+      if (header) {
+        normalizeTableRow(header);
+        headerHasLeadingDelim = header.children?.[0]?.type === "TableDelimiter";
+        for (const c of header.children ?? []) {
+          if (c.type === "TableCell") columnCount++;
+        }
+      }
+      normalizeTableRow(t, columnCount, headerHasLeadingDelim);
       return {
         name: "tr",
         body: cleanTags(mapRender(t.children!), true),

--- a/plug-api/lib/tree.ts
+++ b/plug-api/lib/tree.ts
@@ -191,8 +191,14 @@ export function nodeAtPos(tree: ParseTree, pos: number): ParseTree | null {
   return null;
 }
 
-// Ensure a TableRow has a TableCell between every pair of TableDelimiters
-export function normalizeTableRow(row: ParseTree): void {
+// Ensure a TableRow/TableHeader has a TableCell between every pair of
+// TableDelimiters, and optionally pad to match columnCount.
+// headerHasLeadingDelim indicates whether the header starts with a delimiter.
+export function normalizeTableRow(
+  row: ParseTree,
+  columnCount?: number,
+  headerHasLeadingDelim?: boolean,
+): void {
   const children = row.children;
   if (!children) return;
   const normalized: ParseTree[] = [];
@@ -210,6 +216,26 @@ export function normalizeTableRow(row: ParseTree): void {
     normalized.push(child);
   }
   row.children = normalized;
+
+  // Fix leading-pipe mismatch: row has leading delimiter but header doesn't
+  if (headerHasLeadingDelim === false) {
+    if (row.children.length > 0 && row.children[0].type === "TableDelimiter") {
+      // Insert empty cell after the leading delimiter
+      row.children.splice(1, 0, { type: "TableCell", children: [] });
+    }
+  }
+
+  // Pad trailing empty cells to match header column count
+  if (columnCount !== undefined) {
+    let cellCount = 0;
+    for (const child of row.children) {
+      if (child.type === "TableCell") cellCount++;
+    }
+    while (cellCount < columnCount) {
+      row.children.push({ type: "TableCell", children: [] });
+      cellCount++;
+    }
+  }
 }
 
 // Turn ParseTree back into text

--- a/plugs/index/table.ts
+++ b/plugs/index/table.ts
@@ -63,20 +63,21 @@ export function indexTables(
   ).forEach(
     (table) => {
       const rows = collectNodesOfType(table, "TableRow");
-      const header = collectNodesOfType(table, "TableHeader")[0]; //Use first header. As per markdown spec there can only be exactly one
+      const header = collectNodesOfType(table, "TableHeader")[0];
+      normalizeTableRow(header);
+      const headerHasLeadingDelim =
+        header.children?.[0]?.type === "TableDelimiter";
       const headerLabels = collectNodesOfType(header, "TableCell").map((cell) =>
         concatChildrenTexts(cell.children!)
       ).map(cleanHeaderFieldName);
-      //console.log("Header labels", headerLabels);
 
       for (const row of rows) {
         const tags = new Set<string>();
         collectNodesOfType(row, "Hashtag").forEach((h) => {
-          // Push tag to the list, removing the initial #
           tags.add(extractHashtag(h.children![0].text!));
         });
 
-        normalizeTableRow(row);
+        normalizeTableRow(row, headerLabels.length, headerHasLeadingDelim);
 
         const cells = collectNodesOfType(row, "TableCell");
 


### PR DESCRIPTION
The table style is determined by the header row. After normalizing the header (filling empty cells between consecutive delimiters), extract two properties: the column count and whether the header starts with a delimiter.

For each data row, normalization proceeds in three steps. First, fill in empty cells between consecutive delimiters (this handles empty cells in the middle of a row). Second, if the header has no leading delimiter but the row does, insert an empty cell after the row's leading delimiter (this corrects the one-position shift caused by the row having a leading pipe that the header lacks. Third, if the row has fewer cells than the header column count, pad with empty cells at the end (this handles rows that are shorter than the header because trailing pipes or cells were omitted).

The same normalization is applied both in the renderer and the indexer.