### PR TITLE
Add optional stdin to shell syscall in plug-api

### DIFF
--- a/plug-api/syscalls/shell.ts
+++ b/plug-api/syscalls/shell.ts
@@ -4,11 +4,14 @@ import { syscall } from "../syscall.ts";
  * Runs a shell command.
  * @param cmd the command to run
  * @param args the arguments to pass to the command
+ * @param stdin optional string to pass as stdin to the command
  * @returns the stdout, stderr, and exit code of the command
  */
 export function run(
   cmd: string,
   args: string[],
+  stdin?: string,
 ): Promise<{ stdout: string; stderr: string; code: number }> {
-  return syscall("shell.run", cmd, args);
+  return syscall("shell.run", cmd, args, stdin);
 }
+


### PR DESCRIPTION
The plug-api doesn't expose stdin while the underlying syscall actually does.

Not sure if there was a reason, otherwise I would find it convenient to have it.

Thanks!