### PR TITLE
fix(client): append file input to body to fix iOS Safari upload dialog

### DIFF
--- a/client/plugos/syscalls/editor.ts
+++ b/client/plugos/syscalls/editor.ts
@@ -284,7 +284,10 @@ export function editorSyscalls(client: Client): SysCallMapping {
           reject(e);
         };
 
+        input.style.display = "none";
+        document.body.appendChild(input);
         input.click();
+        setTimeout(() => document.body.removeChild(input), 1000);
       });
     },
     "editor.flashNotification": (


### PR DESCRIPTION
## Summary
Fixes an issue where the file picker dialog does not pop up in iOS/iPadOS Safari when invoking `File:Upload` or using the `Upload: File` command button.

## Problem
Fixes #1883.
On iOS Safari, calling `.click()` on an isolated, detached DOM `<input type="file">` element (created dynamically via `document.createElement`) does not reliably trigger the native OS file picker overlay unless the input element is part of the active DOM tree.

## Solution
Briefly appended the hidden `<input>` element to `document.body` before calling `.click()`, then cleaned it up from the DOM shortly after (1 second delay to ensure the OS has time to present the dialog before removing the source element).