### PR TITLE
fix: check SB_READ_ONLY for "true" instead of any non-empty value

### DIFF
--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -78,7 +78,7 @@ func buildConfig(bundledFiles fs.FS, args []string, buildTime string) *server.Se
 	var spacePrimitives server.SpacePrimitives
 	spacePrimitives, err := server.NewDiskSpacePrimitives(rootSpaceConfig.SpaceFolderPath, rootSpaceConfig.GitIgnore)
 
-	rootSpaceConfig.ReadOnlyMode = os.Getenv("SB_READ_ONLY") != ""
+	rootSpaceConfig.ReadOnlyMode = os.Getenv("SB_READ_ONLY") == "true"
 
 	if rootSpaceConfig.ReadOnlyMode {
 		log.Println("Starting in read-only mode.")


### PR DESCRIPTION
Setting SB_READ_ONLY=false incorrectly enabled read-only mode because the check used `!= ""` instead of `== "true"`. This contradicts the documented behavior which states to set the variable to "true" to enable read-only mode.