### PR TITLE
fix: allow colons in SB_USER password

### DIFF
--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -103,7 +103,7 @@ func buildConfig(bundledFiles fs.FS, args []string, buildTime string) *server.Se
 	}
 
 	if os.Getenv("SB_USER") != "" {
-		pieces := strings.Split(os.Getenv("SB_USER"), ":")
+		pieces := strings.SplitN(os.Getenv("SB_USER"), ":", 2)
 		if len(pieces) != 2 {
 			log.Fatal("SB_USER must be in the format user:pass")
 		}


### PR DESCRIPTION
strings.Split splits on every colon, rejecting passwords that contain colons. Use strings.SplitN with a limit of 2 to only split on the first colon, treating everything after it as the password.