### PR TITLE
Fix: unwrap multi-return values in PropertyAccess and method calls

### DIFF
--- a/client/space_lua/eval.ts
+++ b/client/space_lua/eval.ts
@@ -972,9 +972,11 @@ function evalPrefixExpression(
       // Sync-first: evaluate object; avoid Promise when object is sync.
       const objV = evalPrefixExpression(pa.object, env, sf);
       if (!isPromise(objV)) {
-        return luaGet(objV, pa.property, pa.ctx, sf);
+        return luaGet(singleResult(objV), pa.property, pa.ctx, sf);
       }
-      return rpThen(objV, (obj) => luaGet(obj, pa.property, pa.ctx, sf));
+      return rpThen(objV, (obj) =>
+        luaGet(singleResult(obj), pa.property, pa.ctx, sf),
+      );
     }
 
     case "FunctionCall": {


### PR DESCRIPTION
evalPrefixExpression can return a LuaMultiRes (e.g. string.gsub returns (result, count)).

The TableAccess case already called singleResult() to unwrap this, but PropertyAccess and the method-call path in FunctionCall did not — causing "attempt to index a userdata value" when chaining on multi-return results.

This adds the missing singleResult() calls to match Lua's adjustment rules for single-value contexts.

I discovered this when adding support for https://fennel-lang.org . The fennel compiler, written in Lua, mostly works in your lua implementation, except for this issue (and Lezer doesn't handle parsing the fennel compiler source very well but that's out of scope of this PR) 