### PR TITLE
[LIQ] Implement implicit single group for aggregates without `group by`

### DIFF
--- a/client/space_lua/query_collection.ts
+++ b/client/space_lua/query_collection.ts
@@ -39,6 +39,9 @@ import type { KvKey } from "../../plug-api/types/datastore.ts";
 import { executeAggregate, getAggregateSpec } from "./aggregates.ts";
 import { Config } from "../config.ts";
 
+// Implicit single group map key (aggregates without `group by`)
+const IMPLICIT_GROUP_KEY: unique symbol = Symbol("implicit-group");
+
 // Build environment for post-`group by` clauses. Injects `key` and `group`
 // as top-level variables. Unpacks first group item fields and group-by key
 // fields as locals so that bare field access works after grouping.
@@ -679,6 +682,15 @@ export async function applyQuery(
     results = filteredResults;
   }
 
+  // Implicit single group
+  if (
+    !query.groupBy &&
+    ((query.select && containsAggregate(query.select, config)) ||
+      (query.having && containsAggregate(query.having, config)))
+  ) {
+    query = { ...query, groupBy: [] };
+  }
+
   const grouped = !!query.groupBy;
 
   // Collect group-by key names for unpacking into the post-group environment.
@@ -698,7 +710,7 @@ export async function applyQuery(
       })
       .filter(Boolean);
 
-    const groups = new Map<string, { key: any; items: any[] }>();
+    const groups = new Map<string | symbol, { key: any; items: any[] }>();
     const groupByExprs = query.groupBy as LuaExpression[];
 
     for (const item of results) {
@@ -722,14 +734,20 @@ export async function applyQuery(
         }
       }
 
-      const compositeKey =
-        keyParts.length === 1
-          ? generateKey(keyParts[0])
-          : JSON.stringify(keyParts.map(generateKey));
+      // Implicit single group uses a symbol key
+      const compositeKey: string | symbol =
+        keyParts.length === 0
+          ? IMPLICIT_GROUP_KEY
+          : keyParts.length === 1
+            ? generateKey(keyParts[0])
+            : JSON.stringify(keyParts.map(generateKey));
       let entry = groups.get(compositeKey);
       if (!entry) {
         let keyVal: any;
-        if (keyParts.length === 1) {
+        if (keyParts.length === 0) {
+          // Implicit single group — key is `nil`
+          keyVal = null;
+        } else if (keyParts.length === 1) {
           keyVal = keyParts[0];
         } else {
           const kt = new LuaTable();

--- a/website/Space Lua/Lua Integrated Query/Aggregating.md
+++ b/website/Space Lua/Lua Integrated Query/Aggregating.md
@@ -11,8 +11,37 @@ All aggregate functions (such as `count`, `sum`, `min`, `max`, `avg`, and custom
 
 Field names used in `group by` are exposed as locals in `having`, `select`, and `order by`. Use `#group` to obtain the item count per group.
 
+> **note** The `having` clause acts only on grouped output. For filtering individual items, use `where` prior to grouping.
+
+> **warning** Inside a grouped query bare function names that match registered aggregates are treated as aggregates! To call a global function with the same name, use qualified access (e.g., `_G.sum(x)`).
+
+# Aggregates without `group by`
+When an aggregate function appears in `select` or `having` but no `group by` clause is present, the entire result set is treated as a single implicit group. The `key` variable is `nil` in this case.
+
+This is useful for computing a single summary value over a collection:
+
+${query [[
+  from p = index.tag "page"
+  select { total = count(p.name), biggest = max(p.size) }
+]]}
+
+A simple sum over a list:
+
+${query [[
+  from n = {10, 20, 30}
+  select sum(n)
+]]}
+
+The `having` clause also works without `group by` — it filters the single implicit group:
+
+${query [[
+  from n = {1, 2, 3}
+  having sum(n) > 5
+  select sum(n)
+]]}
+
 > **note** Note
-> The `having` clause acts only on grouped output. For filtering individual items, use `where` prior to grouping.
+> Without `group by`, the query always returns at most one row. If `having` rejects the implicit group, the result is empty.
 
 # Available aggregates
 


### PR DESCRIPTION
* Allow aggregate functions in `select`/`having` without an explicit `group by` clause. The entire result set is treated as one group.

  Note: Uses a `Symbol` as the map key for the implicit single group to avoid any collision with string keys from `generateKey`.

* Extend documentation.