### PR TITLE
Fixing #1935

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,7 +23,7 @@ else
     echo "Creating 'silverbullet' group (with GID $PGID) and 'silverbullet' user (with UID $PUID) inside container"
     # Create silverbullet user and group ad-hoc mapped to PUID and PGID if they don't already exist
     getent group silverbullet > /dev/null || addgroup -g $PGID silverbullet
-    getent passwd silverbullet > /dev/null || adduser -D -H -G silverbullet -u $PUID silverbullet
+    getent passwd silverbullet > /dev/null || adduser -D -G silverbullet -u $PUID silverbullet
     args="$@"
     # And run via su as requested PUID
     echo "Running SilverBullet as user configured with PUID $PUID and PGID $PGID"


### PR DESCRIPTION
Fixes this issue https://github.com/silverbulletmd/silverbullet/issues/1935

By removing the -H flag from adduser, the adduser utility creates a /home/silverbullet folder. This is needed for Chromium, since it doesn't start without a home folder, breaking the Runtime API.

This doesn't affect Chromium, if the Container runs as root, since the root user always has its home under /root. But this fixes things for other users.