### PR TITLE
Wire sb-directive class up to ${...} blocks

### DIFF
--- a/client/markdown_parser/parser.ts
+++ b/client/markdown_parser/parser.ts
@@ -87,7 +87,10 @@ const WikiLink: MarkdownConfig = {
 
 const LuaDirectives: MarkdownConfig = {
   defineNodes: [
-    { name: "LuaDirective" },
+    {
+      name: "LuaDirective",
+      style: { "LuaDirective/...": ct.DirectiveTag },
+    },
     { name: "LuaExpressionDirective" },
     { name: "LuaDirectiveMark", style: ct.DirectiveMarkTag },
   ],


### PR DESCRIPTION
The `sb-directive` class was defined in `client/markdown_parser/customtags.ts` and mapped to `ct.DirectiveTag` in `client/style.ts`, but the parser never actually attached `DirectiveTag` to any node — seems like it wasn't being used?

This makes themes / `space-style` overrides unable to target query bodies, which came up when I was trying to do something like https://github.com/silverbulletmd/silverbullet/issues/1494