### PR TITLE
Add css class for sb-layout-prefix

### DIFF
--- a/client/codemirror/clean.ts
+++ b/client/codemirror/clean.ts
@@ -4,6 +4,7 @@ import { blockquotePlugin } from "./block_quote.ts";
 import { admonitionPlugin } from "./admonition.ts";
 import { hideHeaderMarkPlugin, hideMarksPlugin } from "./hide_mark.ts";
 import { cleanBlockPlugin } from "./block.ts";
+import { layoutPrefixPlugin } from "./layout_prefix.ts";
 import { linkPlugin } from "./link.ts";
 import { listBulletPlugin } from "./list.ts";
 import { tablePlugin } from "./table.ts";
@@ -29,6 +30,7 @@ export function cleanModePlugins(client: Client) {
     attributePlugin(),
     frontmatterPlugin(client),
     customSyntaxPlugin(client),
+    layoutPrefixPlugin(),
   ];
 
   if (client.ui.viewState.uiOptions.markdownSyntaxRendering) {

--- a/client/codemirror/layout_prefix.ts
+++ b/client/codemirror/layout_prefix.ts
@@ -1,0 +1,41 @@
+import { syntaxTree } from "@codemirror/language";
+import { type EditorState, type Range } from "@codemirror/state";
+import { Decoration } from "@codemirror/view";
+import { decoratorStateField } from "./util.ts";
+
+const PREFIX_NODES = new Set(["ListMark", "QuoteMark", "TaskState"]);
+
+// Wraps the line-leading whitespace + structural marker (bullet,
+// blockquote `>`, task `[ ]`, ...) + optional trailing space in
+// `sb-layout-prefix`, so the prefix can be styled separately from the
+// rest of the line.
+export function layoutPrefixPlugin() {
+  return decoratorStateField((state) => {
+    const widgets: Range<Decoration>[] = [];
+    syntaxTree(state).iterate({
+      enter: ({ type, from, to }) => {
+        if (PREFIX_NODES.has(type.name)) {
+          const prefix = layoutPrefixMark(state, from, to);
+          if (prefix) widgets.push(prefix);
+        }
+      },
+    });
+    return Decoration.set(widgets, true);
+  });
+}
+
+function layoutPrefixMark(
+  state: EditorState,
+  markerFrom: number,
+  markerTo: number,
+): Range<Decoration> | undefined {
+  const line = state.doc.lineAt(markerFrom);
+  const hasTrailingSpace =
+    markerTo < state.doc.length &&
+    state.sliceDoc(markerTo, markerTo + 1) === " ";
+  const prefixEnd = hasTrailingSpace ? markerTo + 1 : markerTo;
+  if (line.from >= prefixEnd) return undefined;
+  return Decoration.mark({
+    class: "sb-layout-prefix",
+  }).range(line.from, prefixEnd);
+}

--- a/client/styles/editor.scss
+++ b/client/styles/editor.scss
@@ -221,6 +221,13 @@
     /* U+2022 BULLET */
   }
 
+  // Keep the layout prefix (leading whitespace + bullet/quote/task
+  // marker + trailing space) on a single line. See
+  // silverbulletmd/silverbullet#1829.
+  .sb-layout-prefix {
+    white-space: nowrap;
+  }
+
   .cm-task-checked,
   .sb-line-task:has(.cm-task-checked) .sb-wiki-link {
     text-decoration: line-through !important;


### PR DESCRIPTION
This fixes #1829 by wrapping the breaky sections in a no-wrap. Let me know if it's too heavy-handed, maybe there's a better way.

Some context:
I actually was exploring adding this in order to improve proportional font handling in the editor -- basically if you add a
```
.sb-layout-prefix {
  font-family: monospace;
}
```
or similar (`var(--editor-font)` etc), then you can turn the layout-related characters back to mono, which feels better to me locally. (It mostly improves the line wrapping on bullets when using proportional fonts) <3

There are a couple other tweaks I needed to make bullets nicely work in my proportional setup, mostly this:
```
#sb-main .cm-editor .cm-list-bullet::after {
  left: 0 !important;
  text-indent: 0 !important;
}
```
... but I don't 100% understand what's going on there still so I'm happy doing that override in `space-style` for now rather than trying to upstream it cleanly 😆 