### PR TITLE
Disable splitting to prevent including `import` statements in `service_worker.js`

### DIFF
--- a/build/build_client.ts
+++ b/build/build_client.ts
@@ -33,7 +33,7 @@ export async function buildClient(): Promise<void> {
     minify: true,
     jsxFactory: "h",
     // metafile: true,
-    splitting: true,
+    splitting: false,
     format: "esm",
     chunkNames: ".client/[name]-[hash]",
     jsx: "automatic",

--- a/build/build_client.ts
+++ b/build/build_client.ts
@@ -14,17 +14,7 @@ export async function buildClient(): Promise<void> {
 
   console.log("Now ESBuilding the client and service workers...");
 
-  const result = await esbuild.build({
-    entryPoints: [
-      {
-        in: "client/boot.ts",
-        out: ".client/client",
-      },
-      {
-        in: "client/service_worker.ts",
-        out: "service_worker",
-      },
-    ],
+  const baseBuildConfig: esbuild.BuildOptions = {
     outdir: "client_bundle/client",
     absWorkingDir: process.cwd(),
     bundle: true,
@@ -33,17 +23,43 @@ export async function buildClient(): Promise<void> {
     minify: true,
     jsxFactory: "h",
     // metafile: true,
-    splitting: false,
     format: "esm",
     chunkNames: ".client/[name]-[hash]",
     jsx: "automatic",
     jsxFragment: "Fragment",
     jsxImportSource: "preact",
-  });
+  }
 
-  if (result.metafile) {
-    const text = await esbuild.analyzeMetafile(result.metafile!);
-    console.log("Bundle info", text);
+  const buildConfigs: Array<[String, esbuild.BuildOptions]> = [
+    ["client", {
+      ...baseBuildConfig,
+      entryPoints: [
+        {
+          in: "client/boot.ts",
+          out: ".client/client",
+        }
+      ],
+      splitting: true
+    }],
+    ["service worker", {
+      ...baseBuildConfig,
+      entryPoints: [
+        {
+          in: "client/service_worker.ts",
+          out: "service_worker",
+        },
+      ],
+      splitting: false
+    }]
+  ]
+
+  for (const [buildName, buildConfig] of buildConfigs) {
+    const result = await esbuild.build(buildConfig)
+
+    if (result.metafile) {
+      const text = await esbuild.analyzeMetafile(result.metafile!);
+      console.log(`Bundle info for ${buildName}`, text);
+    }
   }
 
   await copyAssets("client_bundle/client/.client");


### PR DESCRIPTION
`import` statements in Service Workers fail in any Firefox version older than 147. Latest Firefox version is 150, but I suggest to disable this setting to make SilverBullet work for latest Firefox ESR, which right now sits at 140 and is the version packaged by Debian stable (13).

Next ESR version that should support the feature is expected for July 21st: https://whattrainisitnow.com/release/?version=esr