### PR TITLE
Increase boot fetch timeout for authenticated reverse proxies

### DIFF
--- a/client/boot.ts
+++ b/client/boot.ts
@@ -311,8 +311,9 @@ async function cachedFetch(path: string): Promise<string> {
     const response = await fetch(path, {
       // We don't want to follow redirects, we want to get the redirect header in case of auth issues
       redirect: "manual",
-      // Add short timeout in case of a bad internet connection, this would block loading of the UI
-      signal: AbortSignal.timeout(1000),
+      // Tinyauth/forward-auth can take longer than 1s on cold or remote auth checks.
+      // Keep this bounded, but do not abort normal authenticated startup requests too aggressively.
+      signal: AbortSignal.timeout(10000),
       headers: {
         "X-Sync-Mode": "1",
       },


### PR DESCRIPTION
## Summary

This PR increases the timeout used by the client boot-time `cachedFetch` calls from 1 second to 10 seconds.

These fetches load critical startup resources such as:

- `.config`
- `.fs/Library/Std/APIs/Schema.md`
- `.fs/Library/Std/Config.md`
- `.fs/Library/Std/APIs/Tag.md`
- `.fs/CONFIG.md`

The current 1 second timeout is too aggressive for deployments behind authenticated reverse proxies, especially when the proxy performs a forward-auth/OIDC/session validation request before proxying to SilverBullet.

## Problem

SilverBullet can show a blank white screen during startup when deployed behind a reverse proxy with authentication.

In the browser console this can look like:

```text
[Client] Falling back to cache for .config
TypeError: Cannot set properties of undefined (setting 'enableClientEncryption')
    at boot.ts:137
```

In DevTools Network, the `.config` request may appear as `canceled` rather than returning a normal HTTP status. This is not necessarily a server failure. It can happen because the browser aborts the fetch after the hard-coded 1 second timeout.

The failure path is:

1. The client starts booting and immediately fetches `.config` and several `.fs/...` boot resources.
2. The request goes through a reverse proxy authentication layer.
3. The authentication layer may need to validate a session cookie or redirect through an auth flow.
4. Even for already-authenticated users, this forward-auth check can take longer than 1 second on cold paths, mobile networks, remote auth providers, or under normal network latency.
5. The client aborts the request via `AbortSignal.timeout(1000)`.
6. `cachedFetch` falls back to local cache.
7. If there is no valid cached `.config`, or if the cached state is stale/incomplete, boot continues with missing config and can fail with the `enableClientEncryption` error.

This is particularly confusing because the server-side route may be healthy. A manual request to `/.config` can return `200 application/json`, while the browser boot fetch still gets canceled because the timeout is client-side.

## Why this fix

The current timeout is intended to avoid blocking the UI indefinitely on bad connections. That behavior is still useful, but 1 second is too short for authenticated proxy deployments.

Increasing the timeout to 10 seconds keeps the request bounded while giving legitimate authenticated startup requests enough time to complete. This avoids treating normal auth/proxy latency as an offline failure.

This does not change redirect handling, authentication behavior, cache fallback behavior, or the set of resources fetched during boot. It only changes the abort deadline for those fetches.

## Real-world reproduction

This was observed with SilverBullet behind Caddy plus a forward-auth service. The service itself was healthy, and direct requests through the proxy eventually returned the correct `.config` JSON. However, the auth check often took around 1-2 seconds, causing the boot request to be aborted by the browser before the response could arrive.

Relevant symptoms:

- White screen after authentication.
- `.config` request shown as `canceled` in DevTools.
- Console logs show fallback to cache for `.config` and boot resources.
- No corresponding SilverBullet server error.
- Reverse proxy/auth logs show successful auth responses, but often slower than 1 second.

## Testing

Manual verification performed in a reverse-proxy/auth deployment:

- Rebuilt the client with `AbortSignal.timeout(10000)`.
- Confirmed the served client bundle contains the longer timeout.
- Confirmed `/.client/client.js` is served successfully.
- Confirmed SilverBullet starts and serves `/.config`.
- Confirmed the deployment no longer aborts boot fetches at the 1 second mark.