### PR TITLE
Add Claude Agent SDK bridge via Node.js sidecar - allows using Claude subscription for `silverbullet-ai`

### DIFF
--- a/agent-bridge/index.mjs
+++ b/agent-bridge/index.mjs
@@ -1,0 +1,289 @@
+import http from "node:http";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+/**
+ * Convert Anthropic Messages API messages to a prompt string.
+ * System messages are extracted separately.
+ */
+function messagesToPrompt(messages) {
+  let systemPrompt = "";
+  const turns = [];
+
+  for (const msg of messages) {
+    let text = "";
+    if (typeof msg.content === "string") {
+      text = msg.content;
+    } else if (Array.isArray(msg.content)) {
+      text = msg.content
+        .filter((b) => b.type === "text" && b.text)
+        .map((b) => b.text)
+        .join("\n");
+    }
+
+    switch (msg.role) {
+      case "system":
+        systemPrompt += (systemPrompt ? "\n\n" : "") + text;
+        break;
+      case "user":
+        turns.push("Human: " + text);
+        break;
+      case "assistant":
+        turns.push("Assistant: " + text);
+        break;
+    }
+  }
+
+  // Single user message: pass directly without conversation framing
+  let prompt;
+  if (turns.length === 1 && turns[0].startsWith("Human: ")) {
+    prompt = turns[0].slice(7);
+  } else {
+    prompt = turns.join("\n\n");
+  }
+
+  return { systemPrompt, prompt };
+}
+
+/**
+ * Extract system prompt from the request's top-level system field.
+ */
+function extractSystemPrompt(system) {
+  if (!system) return "";
+  if (typeof system === "string") return system;
+  if (Array.isArray(system)) {
+    return system
+      .filter((b) => b.text)
+      .map((b) => b.text)
+      .join("\n");
+  }
+  return "";
+}
+
+/**
+ * Handle POST /v1/messages
+ */
+async function handleMessages(req, res) {
+  let body = "";
+  for await (const chunk of req) body += chunk;
+
+  let request;
+  try {
+    request = JSON.parse(body);
+  } catch {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: { type: "invalid_request_error", message: "Invalid JSON" } }));
+    return;
+  }
+
+  const { systemPrompt: msgSystemPrompt, prompt } = messagesToPrompt(request.messages || []);
+  const topLevelSystem = extractSystemPrompt(request.system);
+  const systemPrompt = [topLevelSystem, msgSystemPrompt].filter(Boolean).join("\n\n");
+
+  const options = {
+    maxTurns: 1,
+    permissionMode: "bypassPermissions",
+    includePartialMessages: true,
+  };
+
+  if (request.model) {
+    options.model = request.model;
+  }
+
+  if (systemPrompt) {
+    // The Agent SDK accepts system prompt via the prompt itself
+    // Prepend it as context
+  }
+
+  const fullPrompt = systemPrompt
+    ? `System instructions: ${systemPrompt}\n\n${prompt}`
+    : prompt;
+
+  if (request.stream) {
+    await handleStreaming(res, fullPrompt, options);
+  } else {
+    await handleNonStreaming(res, fullPrompt, options);
+  }
+}
+
+/**
+ * Stream response as Anthropic SSE events.
+ */
+async function handleStreaming(res, prompt, options) {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+    "Access-Control-Allow-Origin": "*",
+  });
+
+  try {
+    const conversation = query({ prompt, options });
+
+    for await (const message of conversation) {
+      if (message.type === "stream_event" && message.event) {
+        // message.event IS a raw Anthropic SSE event -- forward directly
+        const eventType = message.event.type;
+        res.write(`event: ${eventType}\ndata: ${JSON.stringify(message.event)}\n\n`);
+      }
+    }
+  } catch (err) {
+    console.error("[agent-bridge] Streaming error:", err.message);
+    // Try to send error as SSE if headers not yet flushed
+    const errorEvent = {
+      type: "error",
+      error: { type: "server_error", message: err.message },
+    };
+    res.write(`event: error\ndata: ${JSON.stringify(errorEvent)}\n\n`);
+  }
+
+  // Ensure message_stop is sent
+  res.write(`event: message_stop\ndata: {"type":"message_stop"}\n\n`);
+  res.end();
+}
+
+/**
+ * Collect full response and return as Anthropic Messages API JSON.
+ */
+async function handleNonStreaming(res, prompt, options) {
+  try {
+    const conversation = query({ prompt, options });
+
+    let assistantMessage = null;
+    let resultText = "";
+
+    for await (const message of conversation) {
+      if (message.type === "assistant" && message.message) {
+        assistantMessage = message.message;
+      } else if (message.type === "result") {
+        resultText = message.result || "";
+      }
+    }
+
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    });
+
+    if (assistantMessage) {
+      res.end(JSON.stringify(assistantMessage));
+    } else {
+      // Fallback: construct minimal response
+      res.end(
+        JSON.stringify({
+          id: "msg_bridge",
+          type: "message",
+          role: "assistant",
+          model: options.model || "unknown",
+          content: [{ type: "text", text: resultText }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 0, output_tokens: 0 },
+        })
+      );
+    }
+  } catch (err) {
+    console.error("[agent-bridge] Non-streaming error:", err.message);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        error: { type: "server_error", message: err.message },
+      })
+    );
+  }
+}
+
+/**
+ * Handle GET /v1/models -- return available models.
+ */
+async function handleModels(req, res) {
+  try {
+    // Try to get models from the SDK
+    const conversation = query({ prompt: "", options: { maxTurns: 0 } });
+    const models = await conversation.supportedModels();
+    conversation.close();
+
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    });
+    res.end(
+      JSON.stringify({
+        data: models.map((m) => ({
+          id: m.id || m.name || m,
+          object: "model",
+        })),
+      })
+    );
+  } catch {
+    // Fallback to well-known models
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    });
+    res.end(
+      JSON.stringify({
+        data: [
+          { id: "claude-sonnet-4-20250514", object: "model" },
+          { id: "claude-opus-4-20250514", object: "model" },
+          { id: "claude-haiku-4-20250506", object: "model" },
+        ],
+      })
+    );
+  }
+}
+
+// HTTP server
+const server = http.createServer(async (req, res) => {
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Api-Key, Anthropic-Version",
+    });
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === "GET" && url.pathname === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end('{"status":"ok"}');
+    return;
+  }
+
+  if (req.method === "POST" && url.pathname === "/v1/messages") {
+    await handleMessages(req, res);
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/v1/models") {
+    await handleModels(req, res);
+    return;
+  }
+
+  res.writeHead(404, { "Content-Type": "application/json" });
+  res.end('{"error":"not found"}');
+});
+
+const port = parseInt(process.env.PORT || "0", 10);
+
+server.listen(port, "127.0.0.1", () => {
+  const actualPort = server.address().port;
+  // Signal readiness to the Go process manager
+  process.stdout.write(`READY:${actualPort}\n`);
+  console.error(`[agent-bridge] Listening on 127.0.0.1:${actualPort}`);
+});
+
+// Graceful shutdown
+process.on("SIGTERM", () => {
+  console.error("[agent-bridge] Received SIGTERM, shutting down...");
+  server.close(() => process.exit(0));
+  // Force exit after 5 seconds
+  setTimeout(() => process.exit(1), 5000);
+});
+
+process.on("SIGINT", () => {
+  server.close(() => process.exit(0));
+  setTimeout(() => process.exit(1), 5000);
+});

--- a/agent-bridge/package.json
+++ b/agent-bridge/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "silverbullet-agent-bridge",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.1.0"
+  }
+}

--- a/server/claude_bridge.go
+++ b/server/claude_bridge.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// buildClaudeBridgeRoutes creates the Claude bridge router.
+// All requests are reverse-proxied to the Node.js agent bridge sidecar.
+func buildClaudeBridgeRoutes(bridge *NodeBridge) chi.Router {
+	r := chi.NewRouter()
+
+	// CORS preflight
+	r.Options("/*", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Api-Key, Anthropic-Version")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if bridge != nil {
+		r.Handle("/v1/*", bridge.ProxyHandler())
+	} else {
+		r.HandleFunc("/v1/*", func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+				"error": map[string]string{
+					"type":    "server_error",
+					"message": "Claude agent bridge is not available. Ensure Node.js is installed and the agent-bridge script is present.",
+				},
+			})
+		})
+	}
+
+	return r
+}

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -224,6 +224,41 @@ func buildConfig(bundledFiles fs.FS, args []string, buildTime string) *server.Se
 		}
 	}
 
+	// Agent Bridge: auto-enable if Node.js and agent-bridge script are available
+	agentBridgeEnv := os.Getenv("SB_AGENT_BRIDGE")
+	if agentBridgeEnv != "0" && agentBridgeEnv != "false" && !rootSpaceConfig.ReadOnlyMode {
+		nodePath := os.Getenv("SB_NODE_PATH")
+		if nodePath == "" {
+			nodePath, _ = exec.LookPath("node")
+		}
+		if nodePath != "" {
+			scriptPath := os.Getenv("SB_AGENT_BRIDGE_PATH")
+			if scriptPath == "" {
+				// Look relative to the executable first, then working directory
+				if exePath, err := os.Executable(); err == nil {
+					candidate := filepath.Join(filepath.Dir(exePath), "agent-bridge", "index.mjs")
+					if _, err := os.Stat(candidate); err == nil {
+						scriptPath = candidate
+					}
+				}
+				if scriptPath == "" {
+					scriptPath = "agent-bridge/index.mjs"
+				}
+			}
+			if _, err := os.Stat(scriptPath); err == nil {
+				serverConfig.NodeBridgeConfig = &server.NodeBridgeConfig{
+					NodePath:   nodePath,
+					ScriptPath: scriptPath,
+				}
+				log.Printf("Agent bridge enabled (Node: %s, script: %s)", nodePath, scriptPath)
+			} else {
+				log.Println("Agent bridge disabled: agent-bridge/index.mjs not found")
+			}
+		} else {
+			log.Println("Agent bridge disabled: Node.js not found")
+		}
+	}
+
 	// Initialize shell backend
 	backendConfig := os.Getenv("SB_SHELL_BACKEND")
 	if backendConfig == "" && !rootSpaceConfig.ReadOnlyMode {

--- a/server/node_bridge.go
+++ b/server/node_bridge.go
@@ -1,0 +1,233 @@
+package server
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// NodeBridgeConfig holds configuration for the Node.js agent bridge sidecar.
+type NodeBridgeConfig struct {
+	NodePath   string // path to node binary
+	ScriptPath string // path to agent-bridge/index.mjs
+}
+
+// NodeBridge manages a Node.js sidecar process that runs the Claude Agent SDK bridge.
+type NodeBridge struct {
+	config   *NodeBridgeConfig
+	cmd      *exec.Cmd
+	port     int
+	proxy    *httputil.ReverseProxy
+	done     chan struct{}
+	readyCh  chan struct{}
+	readyErr error
+	mu       sync.Mutex
+}
+
+// StartNodeBridge launches the Node.js agent bridge process.
+func StartNodeBridge(config *NodeBridgeConfig) (*NodeBridge, error) {
+	nb := &NodeBridge{
+		config: config,
+		done:   make(chan struct{}),
+	}
+
+	if err := nb.launch(); err != nil {
+		return nil, err
+	}
+
+	// Start auto-restart monitor
+	go nb.monitor()
+
+	return nb, nil
+}
+
+func (nb *NodeBridge) launch() error {
+	// Verify node binary exists
+	if _, err := exec.LookPath(nb.config.NodePath); err != nil {
+		return fmt.Errorf("node binary not found at %q: %w", nb.config.NodePath, err)
+	}
+
+	// Verify script exists
+	if _, err := os.Stat(nb.config.ScriptPath); err != nil {
+		return fmt.Errorf("agent bridge script not found at %q: %w", nb.config.ScriptPath, err)
+	}
+
+	cmd := exec.Command(nb.config.NodePath, nb.config.ScriptPath)
+	cmd.Env = append(os.Environ(), "PORT=0")
+	cmd.Stderr = os.Stderr // Forward Node stderr to server stderr
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start node bridge: %w", err)
+	}
+
+	nb.mu.Lock()
+	nb.cmd = cmd
+	nb.mu.Unlock()
+
+	// Read READY:<port> from stdout
+	readyCh := make(chan struct{})
+	nb.readyCh = readyCh
+	nb.readyErr = nil
+
+	go func() {
+		defer close(readyCh)
+		scanner := bufio.NewScanner(stdout)
+		timeout := time.NewTimer(30 * time.Second)
+		defer timeout.Stop()
+
+		readyReceived := make(chan string, 1)
+		go func() {
+			for scanner.Scan() {
+				line := scanner.Text()
+				if strings.HasPrefix(line, "READY:") {
+					readyReceived <- line
+					return
+				}
+			}
+		}()
+
+		select {
+		case line := <-readyReceived:
+			portStr := strings.TrimPrefix(line, "READY:")
+			port, err := strconv.Atoi(portStr)
+			if err != nil {
+				nb.readyErr = fmt.Errorf("invalid port in READY line: %q", line)
+				return
+			}
+			nb.mu.Lock()
+			nb.port = port
+			proxyURL, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
+			nb.proxy = httputil.NewSingleHostReverseProxy(proxyURL)
+			nb.mu.Unlock()
+			log.Printf("[AgentBridge] Node sidecar ready on port %d", port)
+		case <-timeout.C:
+			nb.readyErr = fmt.Errorf("timeout waiting for node bridge to become ready")
+			cmd.Process.Kill()
+		}
+	}()
+
+	return nil
+}
+
+// WaitReady blocks until the node bridge is ready or fails.
+func (nb *NodeBridge) WaitReady() error {
+	if nb.readyCh == nil {
+		return fmt.Errorf("node bridge not started")
+	}
+	<-nb.readyCh
+	return nb.readyErr
+}
+
+// Stop shuts down the Node.js bridge process.
+func (nb *NodeBridge) Stop() {
+	close(nb.done)
+
+	nb.mu.Lock()
+	cmd := nb.cmd
+	nb.mu.Unlock()
+
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+
+	// Send SIGTERM for graceful shutdown
+	cmd.Process.Signal(syscall.SIGTERM)
+
+	// Wait up to 5 seconds for exit
+	exitCh := make(chan struct{})
+	go func() {
+		cmd.Wait()
+		close(exitCh)
+	}()
+
+	select {
+	case <-exitCh:
+		log.Println("[AgentBridge] Node bridge stopped gracefully")
+	case <-time.After(5 * time.Second):
+		cmd.Process.Kill()
+		log.Println("[AgentBridge] Node bridge force-killed after timeout")
+	}
+}
+
+// monitor watches for process exit and restarts with exponential backoff.
+func (nb *NodeBridge) monitor() {
+	backoff := 2 * time.Second
+	maxBackoff := 2 * time.Minute
+
+	for {
+		// Wait for process to exit
+		nb.mu.Lock()
+		cmd := nb.cmd
+		nb.mu.Unlock()
+
+		if cmd != nil {
+			cmd.Wait()
+		}
+
+		// Check if we're shutting down
+		select {
+		case <-nb.done:
+			return
+		default:
+		}
+
+		log.Printf("[AgentBridge] Node bridge exited unexpectedly, restarting in %v...", backoff)
+
+		select {
+		case <-nb.done:
+			return
+		case <-time.After(backoff):
+		}
+
+		if err := nb.launch(); err != nil {
+			log.Printf("[AgentBridge] Restart failed: %v", err)
+			backoff = min(backoff*2, maxBackoff)
+			continue
+		}
+
+		if err := nb.WaitReady(); err != nil {
+			log.Printf("[AgentBridge] Restart readiness failed: %v", err)
+			backoff = min(backoff*2, maxBackoff)
+			continue
+		}
+
+		log.Println("[AgentBridge] Restart successful")
+		backoff = 2 * time.Second
+	}
+}
+
+// ProxyHandler returns an HTTP handler that reverse-proxies to the Node sidecar.
+func (nb *NodeBridge) ProxyHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nb.mu.Lock()
+		proxy := nb.proxy
+		nb.mu.Unlock()
+
+		if proxy == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+				"error": map[string]string{
+					"type":    "server_error",
+					"message": "Agent bridge is not ready",
+				},
+			})
+			return
+		}
+
+		proxy.ServeHTTP(w, r)
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -87,6 +87,9 @@ func Router(config *ServerConfig) chi.Router {
 	// Shell endpoint
 	routes.Post("/.shell", handleShellEndpoint)
 
+	// Claude agent bridge (Anthropic Messages API via Claude Agent SDK)
+	routes.Mount("/.claude", buildClaudeBridgeRoutes(config.NodeBridge))
+
 	// Log collection endpoint
 	routes.Post("/.logs", handleLogsEndpoint)
 
@@ -169,6 +172,20 @@ func RunServer(config *ServerConfig) error {
 		config.RuntimeBridge = NewRuntimeBridge(nil)
 	}
 
+	// Start Node agent bridge if configured
+	if config.NodeBridgeConfig != nil {
+		bridge, err := StartNodeBridge(config.NodeBridgeConfig)
+		if err != nil {
+			log.Printf("[AgentBridge] Failed to start: %v (Claude bridge will be unavailable)", err)
+		} else {
+			if err := bridge.WaitReady(); err != nil {
+				log.Printf("[AgentBridge] Failed to become ready: %v", err)
+			} else {
+				config.NodeBridge = bridge
+			}
+		}
+	}
+
 	r := Router(config)
 
 	addr := fmt.Sprintf("%s:%d", config.BindHost, config.Port)
@@ -205,6 +222,11 @@ func RunServer(config *ServerConfig) error {
 	// Block on incoming signals.
 	s := <-signalChannel
 	log.Println("Received signal:", s)
+
+	// Stop Node agent bridge (if running) before server shutdown
+	if config.NodeBridge != nil {
+		config.NodeBridge.Stop()
+	}
 
 	// Stop headless browser (if running) before server shutdown
 	config.RuntimeBridge.Stop()

--- a/server/types.go
+++ b/server/types.go
@@ -24,6 +24,13 @@ type ServerConfig struct {
 	// HeadlessConfig holds configuration for the headless browser (nil = disabled)
 	HeadlessConfig *HeadlessConfig
 
+	// NodeBridgeConfig holds configuration for the Node.js agent bridge (nil = disabled)
+	NodeBridgeConfig *NodeBridgeConfig
+
+	// NodeBridge manages the Node.js agent bridge sidecar process.
+	// Created in RunServer before Router; nil if not configured.
+	NodeBridge *NodeBridge
+
 	// RuntimeBridge manages the Runtime API bridge to the headless browser.
 	// Created in RunServer before Router; Router falls back to NewRuntimeBridge(nil) if nil.
 	RuntimeBridge *RuntimeBridge


### PR DESCRIPTION
Adds a built-in Claude Agent SDK bridge to the SilverBullet server, designed for use with the silverbullet-ai plugin's ClaudeCLI provider: https://github.com/gleber/silverbullet-ai/tree/claude-agent-bridge [ see https://github.com/justyns/silverbullet-ai/pull/122, @justyns FYI ]

The Go server manages a Node.js sidecar process that exposes Anthropic Messages API endpoints at /.claude/v1/messages, backed by the SDK's query() function. Enables subscription-based Claude access (no API key) using the same mechanism as t3code.

- agent-bridge/: Node.js HTTP server using claude-agent-sdk query()
- server/node_bridge.go: Go process manager with auto-restart
- server/claude_bridge.go: thin reverse proxy to the Node sidecar
- server/cmd/server.go: auto-detect Node.js and enable bridge
- server/server.go: lifecycle management (start/stop with server)

@zefhemel Is this something you would be interested in getting merged? For now this is a quick vibecoding experiment. But if this is something interesting for you, I am willing to go full length and get this up to your standards.