### PR TITLE
fix: prevent links with escaped brackets from being parsed as tasks

### DIFF
--- a/client/markdown_parser/extended_task.ts
+++ b/client/markdown_parser/extended_task.ts
@@ -11,7 +11,7 @@ import { TaskStateTag } from "./customtags.ts";
 // Taken from https://github.com/lezer-parser/markdown/blob/main/src/extension.ts and adapted
 
 class MultiStatusTaskParser implements LeafBlockParser {
-  constructor(private status: string) {}
+  constructor(private status: string) { }
 
   nextLine() {
     return false;
@@ -50,7 +50,8 @@ export const TaskList: MarkdownConfig = {
       name: "TaskList",
       leaf(cx, leaf) {
         // Note: task states cannot contain : to avoid ambiguity with attribute syntax
-        const match = /^\[([^\]:]+)\](?:[ \t]|$)/.exec(leaf.content);
+        // Also they shouldn't contain [, \ or ] to avoid parsing escaped links as tasks
+        const match = /^\[([^\]:[\\]+)\](?:[ \t]|$)/.exec(leaf.content);
         return match && cx.parentType().name === "ListItem"
           ? new MultiStatusTaskParser(match[1])
           : null;

--- a/client/markdown_parser/extended_task.ts
+++ b/client/markdown_parser/extended_task.ts
@@ -11,7 +11,7 @@ import { TaskStateTag } from "./customtags.ts";
 // Taken from https://github.com/lezer-parser/markdown/blob/main/src/extension.ts and adapted
 
 class MultiStatusTaskParser implements LeafBlockParser {
-  constructor(private status: string) { }
+  constructor(private status: string) {}
 
   nextLine() {
     return false;

--- a/client/markdown_parser/parser.test.ts
+++ b/client/markdown_parser/parser.test.ts
@@ -361,8 +361,9 @@ Bare $ alone is not an anchor.
 A $100 dollar bill (digit-leading is not an anchor).
 `,
   );
-  const anchors = collectNodesOfType(tree, "NamedAnchor")
-    .map((n) => renderToText(n));
+  const anchors = collectNodesOfType(tree, "NamedAnchor").map((n) =>
+    renderToText(n),
+  );
   expect(anchors).toEqual(["$toc1", "$tasks/7", "$work-1", "$sec1"]);
 });
 

--- a/client/markdown_parser/parser.test.ts
+++ b/client/markdown_parser/parser.test.ts
@@ -104,6 +104,12 @@ test("Test multi-status tasks", () => {
   expect(tasks[2].children![0].children![1].text).toEqual("TODO");
 });
 
+test("Test escaped brackets in list item does not parse as task", () => {
+  const tree = parseMarkdown(`- [\\[Sample Text\\]](https://example.org/)`);
+  const tasks = collectNodesOfType(tree, "Task");
+  expect(tasks.length).toEqual(0);
+});
+
 test("Test lua directive parser", () => {
   const simpleExample = `Simple \${query_coll("something")}`;
   console.log(JSON.stringify(parseMarkdown(simpleExample), null, 2));


### PR DESCRIPTION
This PR fixes a bug where list items starting with escaped square brackets (e.g., `- [\[Sample Text\]](https://example.org/)`) were incorrectly parsed and rendered as Tasks (`<Task>`) instead of normal list items with links.

Previously, the `MultiStatusTaskParser` used the regular expression `/^\[([^\]:]+)\](?:[ \t]|$)/` to match task states. This regex eagerly ingested escaped bracket sequences like `\[Sample Text` as custom task states. 

By updating the regex to `/^\[([^\]:[\\]+)\](?:[ \t]|$)/` (explicitly rejecting `[` and `\`), we ensure that task states only match valid, plain identifiers like `x`, ` `, or `TODO`, safely letting standard Markdown link parsing handle such escaped links properly.