### PR TITLE
Add UNIX socket support for server

### DIFF
--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -49,6 +49,10 @@ func buildConfig(bundledFiles fs.FS, args []string, buildTime string) *server.Se
 		serverConfig.Port = int(port)
 	}
 
+	if os.Getenv("SB_UNIX_SOCKET") != "" {
+		serverConfig.UnixSocket = os.Getenv("SB_UNIX_SOCKET")
+	}
+
 	if os.Getenv("SB_INDEX_PAGE") != "" {
 		rootSpaceConfig.IndexPage = os.Getenv("SB_INDEX_PAGE")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -171,18 +171,29 @@ func RunServer(config *ServerConfig) error {
 
 	r := Router(config)
 
+	network := "tcp"
 	addr := fmt.Sprintf("%s:%d", config.BindHost, config.Port)
-	listener, err := net.Listen("tcp", addr)
+
+	if config.UnixSocket != "" {
+		network = "unix"
+		addr = config.UnixSocket
+	}
+
+	listener, err := net.Listen(network, addr)
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
 
 	// Display the final server running message
-	visibleHostname := config.BindHost
+	visibleAddr := "http://" + addr
 	if config.BindHost == "127.0.0.1" {
-		visibleHostname = "localhost"
+		visibleAddr = fmt.Sprintf("http://localhost:%d", config.Port)
 	}
-	log.Printf("SilverBullet is now running: http://%s:%d", visibleHostname, config.Port)
+
+	if config.UnixSocket != "" {
+		visibleAddr = "unix://" + config.UnixSocket
+	}
+	log.Printf("SilverBullet is now running: %s", visibleAddr)
 
 	server := &http.Server{
 		Handler: r,

--- a/server/types.go
+++ b/server/types.go
@@ -12,6 +12,7 @@ type ServerConfig struct {
 
 	BindHost          string
 	Port              int
+	UnixSocket        string
 	MetricsPort       int
 	EnableHTTPLogging bool
 	// TODO: Ideally this is configurable per space, but kinda hard

--- a/website/Install/Configuration.md
+++ b/website/Install/Configuration.md
@@ -12,6 +12,7 @@ SilverBullet is primarily configured via environment variables. This page gives 
 # Network
 * `SB_HOSTNAME`: Set to the hostname to bind to (defaults to `127.0.0.0`, set to `0.0.0.0` to accept outside connections for the local setup, defaults to `0.0.0.0` for docker)
 * `SB_PORT`: Sets the port to listen to, e.g. `SB_PORT=1234`, default is `3000`
+* `SB_UNIX_SOCKET`: Instead of listening to a TCP port, listen to a Unix socket at the specified path, e.g. `SB_UNIX_SOCKET=/tmp/silverbullet.sock`. Note: when this is set, `SB_HOSTNAME` and `SB_PORT` are ignored.
 * `SB_URL_PREFIX`: Host SilverBullet on a particular URL prefix, e.g. `SB_URL_PREFIX=/notes`
 
 # Authentication


### PR DESCRIPTION
Add UNIX socket support for server.

More here: https://serverfault.com/questions/124517/what-is-the-difference-between-unix-sockets-and-tcp-ip-sockets

> UNIX domain sockets know that they’re executing on the same system, so they can avoid some checks and operations (like routing); which makes them faster and lighter than IP sockets. So if you plan to communicate with processes on the same host, this is a better option than IP sockets.