### PR TITLE
Resolve virtual pages natively (instead of via editor:pageCreating)

### DIFF
--- a/client/content_manager.ts
+++ b/client/content_manager.ts
@@ -28,6 +28,7 @@ import { fsEndpoint } from "./spaces/constants.ts";
 import { parseMarkdown } from "./markdown_parser/parser.ts";
 import type { Client } from "./client.ts";
 import type { LocationState } from "./navigator.ts";
+import { resolveVirtualPage } from "./virtual_pages.ts";
 
 const frontMatterRegex = /^---\n(([^\n]|\n)*?)---\n/;
 
@@ -262,6 +263,7 @@ export class ContentManager {
     // Fetch next page to open
     let doc;
     let markerIndex = -1;
+    let isVirtual = false;
     try {
       doc = await this.client.space.readPage(pageName);
     } catch (e: any) {
@@ -279,12 +281,24 @@ export class ContentManager {
           pageName,
         );
       }
+    }
 
+    // Check for matching virtual page before creating empty page
+    if (!doc) {
+      const virtual = await resolveVirtualPage(this.client, pageName);
+      if (virtual) {
+        doc = virtual.doc;
+        markerIndex = virtual.markerIndex;
+        isVirtual = true;
+      }
+    }
+
+    if (!doc) {
       // Scenarios:
       // 1. We got a not found error -> Create an empty page
       // 2. We got a offline error (which meant that the service worker didn't locally retrieve the page either so likely it doesn't exist) -> Create a new page
-      // Either way... we create an empty page!
-
+      // plus -- No virtual page matches the pattern
+      // so, either way... we create an empty page!
       console.log(`Page doesn't exist, creating new page: ${pageName}`);
 
       // Mock up the page. We won't yet safe it, because the user may not even
@@ -388,7 +402,10 @@ export class ContentManager {
       this.applyExternalPatches(doc.text);
     }
 
-    this.client.space.watchFile(path);
+    // Don't watch virtual pages (there's nothing to watch)
+    if (!isVirtual) {
+      this.client.space.watchFile(path);
+    }
 
     if (navigateWithinPage) {
       // Setup scroll position, cursor position, etc

--- a/client/virtual_pages.ts
+++ b/client/virtual_pages.ts
@@ -1,0 +1,61 @@
+import { patternMatch } from "./space_lua/stdlib/pattern.ts";
+import type { Client } from "./client.ts";
+import type { PageMeta } from "@silverbulletmd/silverbullet/type/index";
+
+type VirtualPageDef = {
+  pattern: string;
+  run: (...args: any[]) => Promise<string> | string;
+};
+
+export type VirtualPageResult = {
+  doc: { text: string; meta: PageMeta };
+  markerIndex: number;
+};
+
+const CURSOR_MARKER = "|^|";
+
+/**
+ * Resolve a page name through `config.virtualPages`
+ * (populated by `virtualPage.define`)
+ */
+export async function resolveVirtualPage(
+  client: Client,
+  pageName: string,
+): Promise<VirtualPageResult | null> {
+  const defs = client.config.get<Record<string, VirtualPageDef>>(
+    "virtualPages",
+    {},
+  );
+
+  for (const def of Object.values(defs)) {
+    const captures = patternMatch(pageName, def.pattern);
+    if (!captures) continue;
+
+    const args = captures.map((c) => ("s" in c ? c.s : c.position));
+    const text = await def.run(...args);
+    if (typeof text !== "string") {
+      throw new Error(
+        `virtualPage \`${def.pattern}\` returned ${typeof text}, expected string`,
+      );
+    }
+
+    const idx = text.indexOf(CURSOR_MARKER);
+    return {
+      doc: {
+        text: idx === -1
+          ? text
+          : text.slice(0, idx) + text.slice(idx + CURSOR_MARKER.length),
+        meta: {
+          ref: pageName,
+          tags: ["page"],
+          name: pageName,
+          lastModified: "",
+          created: "",
+          perm: "ro",
+        } as PageMeta,
+      },
+      markerIndex: idx,
+    };
+  }
+  return null;
+}

--- a/libraries/Library/Std/APIs/Virtual Page.md
+++ b/libraries/Library/Std/APIs/Virtual Page.md
@@ -23,6 +23,10 @@ virtualPage.define {
 ```
 
 # Implementation
+Resolution happens in the client (TypeScript), so this Lua API only needs to
+record definitions. SilverBullet reads `config.virtualPages` directly when a
+page is being loaded — see `client/virtual_pages.ts`.
+
 ```space-lua
 -- priority: 99
 virtualPage = virtualPage or {}
@@ -33,24 +37,4 @@ virtualPage = virtualPage or {}
 function virtualPage.define(def)
   config.set({"virtualPages", def.pattern}, def)
 end
-```
-
-```space-lua
--- priority: -1
-event.listen {
-  name = "editor:pageCreating",
-  run = function(e)
-    local pageName = e.data.name
-    for _, def in pairs(config.get("virtualPages", {})) do
-      local match = pageName:match(def.pattern)
-      if match != nil then
-        -- we got an actual match
-        return {
-          text = def.run(match),
-          perm = "ro"
-        }
-      end
-    end
-  end
-}
 ```

--- a/website/Event.md
+++ b/website/Event.md
@@ -36,7 +36,7 @@ Here is a list of built-in events triggered by SilverBullet's core:
 * `editor:pageReloaded`: A page was reloaded (e.g. after being changed on disk)
 * `editor:pageSaving`: A page is about to be saved
 * `editor:pageSaved`: A page has been saved
-* `editor:pageCreating`: A page is being created (can return content — used by [[Virtual Pages]])
+* `editor:pageCreating`: A page is being created
 * `editor:pageModified`: A change was made to the document (fires in real-time)
 * `editor:documentSaving`: A document (non-page file) is about to be saved
 * `editor:documentSaved`: A document was saved

--- a/website/Virtual Pages.md
+++ b/website/Virtual Pages.md
@@ -70,6 +70,8 @@ virtualPage.define {
 ```
 
 # How it works under the hood
-Virtual page definitions are stored in the config system under the `virtualPages` key. When a page is being created, SilverBullet fires the `editor:pageCreating` event. The standard library's event listener checks all registered patterns against the page name. If a match is found, the corresponding `run` function is called, and its return value becomes the page content with read-only permissions.
+Virtual page definitions are stored in the config system under the `virtualPages` key. When you navigate to a page, SilverBullet first tries to load it as a real file; only if that lookup misses does it check the registered patterns against the page name. If a pattern matches, the corresponding `run` function is called and its return value becomes the page content with read-only permissions.
+
+This means a real file always shadows a matching virtual page — for example, creating `tag:my-tag.md` overrides the default tag virtual page just for that one tag.
 
 See also: [[API/event]], [[API/config]]


### PR DESCRIPTION
Partial fix for #1781 (the `editor:pageCreating` half).
Fix for #1956

Move virtual page resolution out of `editor:pageCreating` and into the client. We try to read the real page first, on a miss we check `config.virtualPages`. @zefhemel I hope this is anything like you were imagining 😆 

This fixes the 404-loop that you get on virtual pages.
I'm interested in tacking the second half of #1781 next to see if we can somehow/partially index the virtual pages so that they can show up in the picker and maybe that linking to them doesn't look like a dead link? And not show up in aspiring pages. But wanted to do this part first.

Could also probably pull out the cursor `|^|` extraction bit into a util at this point