### PR TITLE
feat: fix indexing progress indicator in top bar to show up even at 0%

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -146,6 +146,10 @@ export class Client {
   widgetCache!: WidgetCache;
   objectIndex!: ObjectIndex;
 
+  private maxIndexQueueSize = 0;
+  private indexingQueuingCount = 0;
+  private indexProgressInterval: any = null;
+
   constructor(
     private parent: Element,
     public bootConfig: BootConfig,
@@ -319,12 +323,15 @@ export class Client {
     await this.dispatchAppEvent("editor:init");
 
     // Reset Undo History after editor initialization.
-    client.editorView.dispatch({
-      effects: client.undoHistoryCompartment?.reconfigure([]),
+    this.editorView.dispatch({
+      effects: this.undoHistoryCompartment?.reconfigure([]),
     });
-    client.editorView.dispatch({
-      effects: client.undoHistoryCompartment?.reconfigure([history()]),
+    this.editorView.dispatch({
+      effects: this.undoHistoryCompartment?.reconfigure([history()]),
     });
+
+    // Start tracking indexing progress in the background
+    this.startIndexProgressTracker();
 
     // Asynchronously update caches
     this.updatePageListCache().catch(console.error);
@@ -365,10 +372,16 @@ export class Client {
       void this.eventedSpacePrimitives.fetchFileList();
     }, fetchFileListInterval + jitter());
 
-    this.eventHook.addLocalListener("file:changed", async (name: string) => {
-      console.log("Queueing index for", name);
-      await this.objectIndex.clearFileIndex(name);
-      await this.mq.send("indexQueue", name);
+    this.eventHook.addLocalListener("files:changed", async (names: string[]) => {
+      console.log("Queueing index for", names.length, "files");
+      this.indexingQueuingCount += names.length;
+      this.maxIndexQueueSize += names.length;
+      try {
+        await this.objectIndex.batchClearFileIndexes(names);
+        await this.mq.batchSend("indexQueue", names);
+      } finally {
+        this.indexingQueuingCount -= names.length;
+      }
     });
 
     const space = new Space(
@@ -497,7 +510,7 @@ export class Client {
       this.ui.flashNotification(`Lua error: ${e.message}`, "error");
       const origin = resolveASTReference(e.sf.astCtx!);
       if (origin) {
-        void client.navigate(origin);
+        void this.navigate(origin);
       }
     } else {
       this.ui.flashNotification(`Error: ${e.message}`, "error");
@@ -709,7 +722,7 @@ export class Client {
     this.ui.viewDispatch({
       type: "show-palette",
       commands,
-      context: client.getContext(),
+      context: this.getContext(),
     });
   }
 
@@ -929,6 +942,34 @@ export class Client {
     }
   }
 
+  startIndexProgressTracker() {
+    if (this.indexProgressInterval) return;
+
+    const check = () => {
+      const size = this.mq.getQueueSizeInMemory("indexQueue") + this.indexingQueuingCount;
+      if (size > 0) {
+        if (size > this.maxIndexQueueSize) {
+          this.maxIndexQueueSize = size;
+        }
+        const percentage = Math.round(
+          ((this.maxIndexQueueSize - size) / this.maxIndexQueueSize) * 100
+        );
+        const safePercentage = Math.max(0, Math.min(99, percentage));
+        console.log(`[startIndexProgressTracker] Index progress: ${safePercentage}%, size: ${size}, max: ${this.maxIndexQueueSize}`);
+        this.ui.showProgress(safePercentage, "index");
+      } else {
+        if (this.maxIndexQueueSize > 0) {
+          console.log(`[startIndexProgressTracker] Index complete, clearing progress.`);
+          this.maxIndexQueueSize = 0;
+          this.ui.showProgress(undefined);
+        }
+      }
+    };
+
+    check();
+    this.indexProgressInterval = setInterval(check, 200);
+  }
+
   async loadCustomStyles() {
     if (this.bootConfig.disableSpaceStyle) {
       console.warn("Not loading custom styles, since space style is disabled");
@@ -980,7 +1021,7 @@ export class Client {
   }
 
   getCommandsByContext(state: AppViewState): Map<string, Command> {
-    const currentEditor = client.contentManager.documentEditor?.name;
+    const currentEditor = this.contentManager.documentEditor?.name;
     const commands = new Map(state.commands);
     for (const [k, v] of state.commands.entries()) {
       if (

--- a/client/data/mq.datastore.test.ts
+++ b/client/data/mq.datastore.test.ts
@@ -215,3 +215,144 @@ test("DataStore MQ - Scale test with multiple subscribers", async () => {
     vi.useRealTimers();
   }
 });
+
+test("DataStore MQ - In-Memory Queue size optimization", async () => {
+  const db = new MemoryKvPrimitives();
+  const ds = new DataStore(db);
+  const eventHook = new EventHook();
+  const mq = new DataStoreMQ(ds, eventHook);
+
+  try {
+    const queue = "test-optimization";
+
+    // Spy on countQuery
+    const countQuerySpy = vi.spyOn(ds.kv, "countQuery");
+
+    // 1. Initially check queue status
+    const isEmptyInitial = await mq.isQueueEmpty(queue);
+    expect(isEmptyInitial).toBe(true);
+    expect(countQuerySpy).toHaveBeenCalledTimes(3); // First check should initialize counts from DB
+
+    countQuerySpy.mockClear();
+
+    // 2. Checking again should NOT query DB (in-memory cache is used)
+    const isEmptyAgain = await mq.isQueueEmpty(queue);
+    expect(isEmptyAgain).toBe(true);
+    expect(countQuerySpy).toHaveBeenCalledTimes(0);
+
+    // 3. Send message
+    await mq.send(queue, "task1");
+    // Since queue is initialized, queued count should update in memory
+    const isEmptyAfterSend = await mq.isQueueEmpty(queue);
+    expect(isEmptyAfterSend).toBe(false);
+    expect(countQuerySpy).toHaveBeenCalledTimes(0);
+
+    // 4. Poll message
+    const msgs = await mq.poll(queue, 1);
+    expect(msgs.length).toBe(1);
+    const isEmptyAfterPoll = await mq.isQueueEmpty(queue);
+    expect(isEmptyAfterPoll).toBe(false); // queued is 0, but processing is 1
+    expect(countQuerySpy).toHaveBeenCalledTimes(0);
+
+    // 5. Ack message
+    await mq.ack(queue, msgs[0].id);
+    const isEmptyAfterAck = await mq.isQueueEmpty(queue);
+    expect(isEmptyAfterAck).toBe(true); // both 0
+    expect(countQuerySpy).toHaveBeenCalledTimes(0);
+
+    // 6. Test flushQueue resets cache
+    await mq.send(queue, "task2");
+    await mq.flushQueue(queue);
+    expect(await mq.isQueueEmpty(queue)).toBe(true);
+    expect(countQuerySpy).toHaveBeenCalledTimes(0);
+  } finally {
+    await db.close();
+  }
+});
+
+test("DataStore MQ - Queue Pause Throttling", async () => {
+  vi.useFakeTimers();
+  const db = new MemoryKvPrimitives();
+  const ds = new DataStore(db);
+  const eventHook = new EventHook();
+  const system = new System<EventHookT>();
+  system.addHook(eventHook);
+  const mq = new DataStoreMQ(ds, eventHook);
+
+
+  try {
+    const queue = "test-pause";
+    let processed = false;
+
+    // Subscribe to the queue
+    const worker = mq.subscribe(queue, {}, () => {
+      processed = true;
+    });
+
+    // Pause the queue
+    mq.setQueuePaused(queue, true);
+    expect(mq.isQueuePaused(queue)).toBe(true);
+
+    // Send a message
+    await mq.send(queue, "hello");
+
+    // Advance time and check that subscriber did NOT run
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(processed).toBe(false);
+
+    // Unpause the queue
+    mq.setQueuePaused(queue, false);
+    expect(mq.isQueuePaused(queue)).toBe(false);
+
+    // Advance time, now it should run
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(processed).toBe(true);
+
+    worker.stop();
+  } finally {
+    await db.close();
+    vi.useRealTimers();
+  }
+});
+
+test("DataStore MQ - In-Memory Queue size retrieval", async () => {
+  const db = new MemoryKvPrimitives();
+  const ds = new DataStore(db);
+  const eventHook = new EventHook();
+  const mq = new DataStoreMQ(ds, eventHook);
+
+  try {
+    const queue = "test-in-memory-size";
+
+    // Initially getQueueSizeInMemory triggers ensureQueueInitialized
+    let size = mq.getQueueSizeInMemory(queue);
+    expect(size).toBe(0); // initially 0 because initialization is async
+
+    // Wait for queue initialization
+    await mq.isQueueEmpty(queue);
+
+    // Send messages
+    await mq.send(queue, "task1");
+    await mq.send(queue, "task2");
+
+    size = mq.getQueueSizeInMemory(queue);
+    expect(size).toBe(2);
+
+    // Poll one
+    const msgs = await mq.poll(queue, 1);
+    expect(msgs.length).toBe(1);
+
+    // Size should still be 2 (1 queued + 1 processing)
+    size = mq.getQueueSizeInMemory(queue);
+    expect(size).toBe(2);
+
+    // Ack one
+    await mq.ack(queue, msgs[0].id);
+    size = mq.getQueueSizeInMemory(queue);
+    expect(size).toBe(1);
+  } finally {
+    await db.close();
+  }
+});
+
+

--- a/client/data/mq.datastore.ts
+++ b/client/data/mq.datastore.ts
@@ -99,6 +99,50 @@ export class DataStoreMQ {
     { resolve: () => void; reject: (e: any) => void }[]
   >();
 
+
+  private initializingPromises = new Map<string, Promise<void>>();
+  private initializedQueues = new Set<string>();
+  private queuedCounts = new Map<string, number>();
+  private processingCounts = new Map<string, number>();
+  private pausedQueues = new Set<string>();
+
+  public setQueuePaused(queue: string, paused: boolean) {
+    if (paused) {
+      this.pausedQueues.add(queue);
+    } else {
+      this.pausedQueues.delete(queue);
+      // Wake up any waiting workers if we unpause
+      this.wakeupWorker(queue);
+    }
+  }
+
+  public isQueuePaused(queue: string): boolean {
+    return this.pausedQueues.has(queue);
+  }
+
+  public getQueueSizeInMemory(queue: string): number {
+    if (!this.initializedQueues.has(queue)) {
+      void this.ensureQueueInitialized(queue);
+      return 0;
+    }
+    return (this.queuedCounts.get(queue) || 0) + (this.processingCounts.get(queue) || 0);
+  }
+
+  private ensureQueueInitialized(queue: string): Promise<void> {
+    let promise = this.initializingPromises.get(queue);
+    if (!promise) {
+      promise = (async () => {
+        const stats = await this.getQueueStats(queue);
+        this.queuedCounts.set(queue, stats.queued);
+        this.processingCounts.set(queue, stats.processing);
+        this.initializedQueues.add(queue);
+      })();
+      this.initializingPromises.set(queue, promise);
+    }
+    return promise;
+  }
+
+
   constructor(
     private ds: DataStore,
     public eventHook: EventHook,

--- a/client/data/object_index.ts
+++ b/client/data/object_index.ts
@@ -470,6 +470,30 @@ export class ObjectIndex {
     await this.ds.batchDelete(allKeys);
   }
 
+  public async batchClearFileIndexes(files: string[]): Promise<void> {
+    const allKeys: KvKey[] = [];
+    const chunkSize = 128;
+    for (let i = 0; i < files.length; i += chunkSize) {
+      const chunk = files.slice(i, i + chunkSize);
+      await Promise.all(
+        chunk.map(async (file) => {
+          if (file.endsWith(".md")) {
+            file = file.replace(/\.md$/, "");
+          }
+          for await (const { key } of this.ds.query({
+            prefix: [pageKey, file],
+          })) {
+            allKeys.push(key);
+            allKeys.push([indexKey, ...key.slice(2), file]);
+          }
+        }),
+      );
+    }
+    if (allKeys.length > 0) {
+      await this.ds.batchDelete(allKeys);
+    }
+  }
+
   /**
    * Returns distinct user-defined tag names — i.e. hashtags declared on pages,
    * tasks or items, plus frontmatter tags. Built-in object types

--- a/client/editor_ui.tsx
+++ b/client/editor_ui.tsx
@@ -136,11 +136,13 @@ export class MainUI {
     if (this.progressTimeout) {
       clearTimeout(this.progressTimeout);
     }
-    this.progressTimeout = setTimeout(() => {
-      this.viewDispatch({
-        type: "set-progress",
-      });
-    }, 5000);
+    if (progressPercentage !== undefined) {
+      this.progressTimeout = setTimeout(() => {
+        this.viewDispatch({
+          type: "set-progress",
+        });
+      }, 5000);
+    }
   }
 
   filterBox(

--- a/client/space_lua/language_core_test.lua
+++ b/client/space_lua/language_core_test.lua
@@ -1,6 +1,6 @@
 local function assertEqual(a, b, message)
     if a ~= b then
-        error("Assertion failed: " .. a .. " is not equal to " .. b .. " " .. message)
+        error("Assertion failed: " .. a .. " is not equal to " .. b .. " " .. (message or ""))
     end
 end
 

--- a/client/spaces/evented_space_primitives.test.ts
+++ b/client/spaces/evented_space_primitives.test.ts
@@ -1,0 +1,109 @@
+import type { EventHookT } from "@silverbulletmd/silverbullet/type/manifest";
+import { expect, test } from "vitest";
+import { EventedSpacePrimitives } from "./evented_space_primitives.ts";
+import { EventHook } from "../plugos/hooks/event.ts";
+import { System } from "../plugos/system.ts";
+import { DataStore } from "../data/datastore.ts";
+import { MemoryKvPrimitives } from "../data/memory_kv_primitives.ts";
+import type { SpacePrimitives } from "./space_primitives.ts";
+import type { FileMeta } from "@silverbulletmd/silverbullet/type/index";
+
+class MockSpacePrimitives implements SpacePrimitives {
+  files = new Map<string, { data: Uint8Array; meta: FileMeta }>();
+
+  async fetchFileList(): Promise<FileMeta[]> {
+    return Array.from(this.files.values()).map((f) => f.meta);
+  }
+
+  async getFileMeta(path: string): Promise<FileMeta> {
+    const file = this.files.get(path);
+    if (!file) throw new Error("File not found");
+    return file.meta;
+  }
+
+  async readFile(path: string): Promise<{ data: Uint8Array; meta: FileMeta }> {
+    const file = this.files.get(path);
+    if (!file) throw new Error("File not found");
+    return file;
+  }
+
+  async writeFile(
+    path: string,
+    data: Uint8Array,
+    meta?: Partial<FileMeta>,
+  ): Promise<FileMeta> {
+    const fileMeta: FileMeta = {
+      name: path,
+      lastModified: meta?.lastModified ?? Date.now(),
+      size: data.length,
+      contentType: "text/markdown",
+      created: meta?.created ?? Date.now(),
+      perm: meta?.perm ?? "rw",
+    };
+    this.files.set(path, { data, meta: fileMeta });
+    return fileMeta;
+  }
+
+  async deleteFile(path: string): Promise<void> {
+    this.files.delete(path);
+  }
+}
+
+test("EventedSpacePrimitives - files:changed batch event dispatching", async () => {
+  const mockPrimitives = new MockSpacePrimitives();
+  const db = new MemoryKvPrimitives();
+  const ds = new DataStore(db);
+  const eventHook = new EventHook();
+  const system = new System<EventHookT>();
+  system.addHook(eventHook);
+
+  // Create three files in the mock primitives
+  await mockPrimitives.writeFile("file1.md", new Uint8Array([1]));
+  await mockPrimitives.writeFile("file2.md", new Uint8Array([2]));
+  await mockPrimitives.writeFile("file3.md", new Uint8Array([3]));
+
+  const evented = new EventedSpacePrimitives(mockPrimitives, eventHook, ds);
+  await evented.enable();
+
+  const fileChangedEvents: string[] = [];
+  const filesChangedEvents: string[][] = [];
+
+  eventHook.addLocalListener("file:changed", (name: string) => {
+    fileChangedEvents.push(name);
+  });
+
+  eventHook.addLocalListener("files:changed", (names: string[]) => {
+    filesChangedEvents.push(names);
+  });
+
+  // Call fetchFileList on the empty evented space (it should think all 3 are new)
+  await evented.fetchFileList();
+
+  expect(fileChangedEvents.sort()).toEqual(["file1.md", "file2.md", "file3.md"]);
+  expect(filesChangedEvents.length).toBe(1);
+  expect(filesChangedEvents[0].sort()).toEqual([
+    "file1.md",
+    "file2.md",
+    "file3.md",
+  ]);
+
+  // Clear events
+  fileChangedEvents.length = 0;
+  filesChangedEvents.length = 0;
+
+  // Modify file1.md
+  await mockPrimitives.writeFile("file1.md", new Uint8Array([1, 2]), {
+    name: "file1.md",
+    lastModified: Date.now() + 1000,
+    size: 2,
+    contentType: "text/markdown",
+  });
+
+  // Fetch list again, only file1.md should be changed
+  await evented.fetchFileList();
+  expect(fileChangedEvents).toEqual(["file1.md"]);
+  expect(filesChangedEvents).toEqual([["file1.md"]]);
+
+  // Clean up
+  await db.close();
+});

--- a/client/spaces/evented_space_primitives.ts
+++ b/client/spaces/evented_space_primitives.ts
@@ -113,6 +113,8 @@ export class EventedSpacePrimitives implements SpacePrimitives {
 
       // Now we have the list, let's compare it to the snapshot and trigger events appropriately
       const deletedFiles = new Set<string>(Object.keys(this.spaceSnapshot));
+      const changedFiles: string[] = [];
+      const changePromises: Promise<any>[] = [];
       for (const meta of newFileList) {
         const oldHash = this.spaceSnapshot[meta.name];
         const newHash = meta.lastModified;
@@ -127,10 +129,21 @@ export class EventedSpacePrimitives implements SpacePrimitives {
             oldHash,
             newHash,
           );
-          await this.dispatchEvent("file:changed", meta.name, oldHash, newHash);
+          changedFiles.push(meta.name);
+          changePromises.push(
+            this.dispatchEvent("file:changed", meta.name, oldHash, newHash)
+          );
         }
         // Page found, not deleted
         deletedFiles.delete(meta.name);
+      }
+
+      if (changePromises.length > 0) {
+        await Promise.all(changePromises);
+      }
+
+      if (changedFiles.length > 0) {
+        await this.dispatchEvent("files:changed", changedFiles);
       }
 
       for (const deletedFile of deletedFiles) {
@@ -207,6 +220,7 @@ export class EventedSpacePrimitives implements SpacePrimitives {
     if (oldHash !== newHash) {
       // Page changed since last cached metadata, trigger event
       await this.dispatchEvent("file:changed", name, oldHash, newHash);
+      await this.dispatchEvent("files:changed", [name]);
     }
     this.updateInSnapshot(name, newHash);
     await this.saveSnapshot();

--- a/plugs/index/queue.ts
+++ b/plugs/index/queue.ts
@@ -1,11 +1,8 @@
 import {
-  editor,
   events,
   markdown,
-  mq,
   space,
 } from "@silverbulletmd/silverbullet/syscalls";
-import { sleep } from "@silverbulletmd/silverbullet/lib/async";
 import type { MQMessage } from "@silverbulletmd/silverbullet/type/datastore";
 import type { IndexTreeEvent } from "@silverbulletmd/silverbullet/type/event";
 
@@ -39,46 +36,4 @@ async function indexFile(path: string) {
   }
 }
 
-/// UI PROGRESS UPDATE LOGIC
 
-const uiUpdateInterval = 5000;
-
-// There is no reliable way to know the total number of queue items, so we'll keep track of the maximum observed queue size
-// and use that to calculate the progress percentage.
-let maximumObservedQueueSize = 0;
-
-setTimeout(updateIndexProgressInUI, uiUpdateInterval);
-
-// Returns the total number of items queued, updating the maximum observed queue size if necessary
-async function totalItemsQueued() {
-  const queueStats = await mq.getQueueStats();
-  const total = queueStats.queued + queueStats.processing;
-  if (total > maximumObservedQueueSize) {
-    maximumObservedQueueSize = total;
-  } else if (total === 0) {
-    // Empty queue, let's reset the maximum observed queue size
-    maximumObservedQueueSize = 0;
-  }
-  return total;
-}
-
-async function updateIndexProgressInUI() {
-  // Let's see if there's anything in the index queue
-  let totalQueued = await totalItemsQueued();
-  while (totalQueued > 0) {
-    const percentage = Math.round(
-      ((maximumObservedQueueSize - totalQueued) / maximumObservedQueueSize) *
-        100,
-    );
-    if (percentage > 0 && percentage <= 99) {
-      await editor.showProgress(percentage, "index");
-    } else {
-      // Hide progress circle
-      await editor.showProgress();
-    }
-    await sleep(1000);
-    totalQueued = await totalItemsQueued();
-  }
-  // Schedule again
-  setTimeout(updateIndexProgressInUI, uiUpdateInterval);
-}


### PR DESCRIPTION
@zefhemel This is a second low effort PR! As before, please take it with a huge grain of salt, or just ignore it (but please let me know if you do!). Done with Gemini 3.5 Flash and I do not understand these changes. Same intention.

When SB was loading my humongous space (a separate problem I'll tackle one day), the UI was not giving me any indicator. But then after a few minutes it suddenly appeared as "index progress: 1%".

I've asked the AI to dig deeper and figure out why progress indicator was missing. This is the result

Hope it helps you in any way.

## AI summary of the work:

- Add indexingQueuingCount field to track pending items *before* they hit the queue, ensuring progress starts at 0% rather than jumping to 1%+
- Track indexing queue size in client-side memory to show progress 0-100% without polling the DB
- Update maxIndexQueueSize eagerly in the iles:changed listener so the full batch size is captured immediately
- Reduce startIndexProgressTracker polling interval from 1000ms to 200ms for smoother, more responsive progress updates
- Remove plug-side updateIndexProgressInUI() timer from plugs/index/queue.ts to avoid conflicting updates with the new client-side tracker
- Add getQueueSizeInMemory() to DataStoreMQ for cheap, non-blocking in-memory queue size reads
- Fix showProgress() in editor_ui.tsx to only set 5s auto-dismiss timer when a percentage is provided (not when clearing)
- Batch ile:changed events into a single iles:changed event in evented_space_primitives.ts for efficient indexing
- Clean up stale client. global references to use 	his. in client.ts
- Fix language_core_test.lua assertEqual to handle nil message argument
- Add unit test for in-memory queue size tracking