### PR TITLE
Fix: Encode extra-ascii space path in HTTP header

### DIFF
--- a/client/spaces/http_space_primitives.ts
+++ b/client/spaces/http_space_primitives.ts
@@ -159,14 +159,19 @@ export class HttpSpacePrimitives implements SpacePrimitives {
    * The /.fs file listing and /.ping endpoints both expose the currently exposed space path, if this doesn't match what the client expects, the client has to restart
    */
   async validateSpacePathFromHeaders(resp: Response) {
-    if (
-      resp.status === 200 &&
-      this.expectedSpacePath &&
-      resp.headers.get("X-Space-Path") &&
-      resp.headers.get("X-Space-Path") !== this.expectedSpacePath
-    ) {
+    if (resp.status !== 200 || this.expectedSpacePath === null) {
+      return;
+    }
+
+    const spacePathRaw = resp.headers.get("X-Space-Path");
+    if (spacePathRaw === null) {
+      return;
+    }
+
+    const spacePath = decodeURIComponent(spacePathRaw);
+    if (spacePath != this.expectedSpacePath) {
       console.log("Expected space path", this.expectedSpacePath);
-      console.log("Got space path", resp.headers.get("X-Space-Path"));
+      console.log("Got space path", spacePath);
       await flushCachesAndUnregisterServiceWorker();
       this.authErrorCallback(wrongSpacePathError.message, "reload");
     }

--- a/server/fs.go
+++ b/server/fs.go
@@ -39,7 +39,7 @@ func handleFsList(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Header().Set("X-Space-Path", spaceConfig.SpaceFolderPath)
+		w.Header().Set("X-Space-Path", url.PathEscape(spaceConfig.SpaceFolderPath))
 		w.Header().Set("Cache-Control", "no-cache")
 		render.JSON(w, r, files)
 	} else {

--- a/server/integration_headless_test.go
+++ b/server/integration_headless_test.go
@@ -221,7 +221,10 @@ func TestIntegration_Headless(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		body, _ := io.ReadAll(resp.Body)
 		assert.Equal(t, "OK", string(body))
-		assert.Equal(t, ts.SpaceConfig.SpaceFolderPath, resp.Header.Get("X-Space-Path"))
+		assert.Equal(
+      t,
+      url.PathUnescape(ts.SpaceConfig.SpaceFolderPath, resp.Header.Get("X-Space-Path"))
+    )
 	})
 
 	t.Run("Config", func(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+  "net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -62,7 +63,7 @@ func Router(config *ServerConfig) chi.Router {
 	routes.Get("/.ping", func(w http.ResponseWriter, r *http.Request) {
 		spaceConfig := spaceConfigFromContext(r.Context())
 		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("X-Space-Path", spaceConfig.SpaceFolderPath)
+		w.Header().Set("X-Space-Path", url.PathEscape(spaceConfig.SpaceFolderPath))
 		w.Header().Set("X-Server-Version", config.Version)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK"))


### PR DESCRIPTION
Fixes #1988.

The space path was not correctly encoded when added to the HTTP header.