### PR TITLE
Add support for proxying CalDAV HTTP methods

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -51,6 +51,10 @@ func Router(config *ServerConfig) chi.Router {
 
 	r.Use(httpStatsMiddleware(config))
 
+  // Enable support for additional HTTP methods
+  // PROPFIND (e.g. used by webdav)
+  chi.RegisterMethod("PROPFIND")
+
 	// Authentication middleware (applies to all routes after this point)
 	r.Use(authMiddleware(config))
 

--- a/server/server.go
+++ b/server/server.go
@@ -52,8 +52,13 @@ func Router(config *ServerConfig) chi.Router {
 	r.Use(httpStatsMiddleware(config))
 
   // Enable support for additional HTTP methods
-  // PROPFIND (e.g. used by webdav)
+  // Methods for CalDAV
   chi.RegisterMethod("PROPFIND")
+  chi.RegisterMethod("PROPPATCH")
+  chi.RegisterMethod("MKCALENDAR")
+  chi.RegisterMethod("MKCOL")
+  chi.RegisterMethod("REPORT")
+  chi.RegisterMethod("ACL")
 
 	// Authentication middleware (applies to all routes after this point)
 	r.Use(authMiddleware(config))


### PR DESCRIPTION
I tried to experiment with creating a plug to enable syncing with a CalDAV server (e.g. sync tasks or calendar entries from silverbullet). I noticed though that proxied requests are limited to HTTP methods supported by `chi`. CalDAV defines several additional methods though that `chi` does not support out of the box (e.g. `PROPFIND`). This results in a `405 Method Not Allowed` when such requests are proxied. I checked the [CalDAV rfc](https://www.rfc-editor.org/rfc/rfc4791.html) and the [documentation of the library](https://tsdav.vercel.app/docs/caldav/calendarQuery) I aim to use for required methods and registered them during setup of the main router. With this change I am able to proxy these methods successfully. 