### PR TITLE
Fix inverted check in refreshLogin

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -291,7 +291,7 @@ func authMiddleware(config *ServerConfig) func(http.Handler) http.Handler {
 // refreshLogin refreshes the login cookie if needed
 func refreshLogin(w http.ResponseWriter, r *http.Request, config *ServerConfig, host string, spaceConfig *SpaceConfig) {
 	// if cookie doesn't exist, return
-	if getCookie(r, "refreshLogin") != "" {
+	if getCookie(r, "refreshLogin") == "" {
 		return
 	}
 	oldJwt := getCookie(r, authCookieName(host))


### PR DESCRIPTION
I noticed I was being prompted to log in about once a week even with "Remember me" checked. Looking at `refreshLogin` in `server/auth.go`, I think the guard is inverted: it returns early when the `refreshLogin` marker cookie is present, but that cookie is only set when "Remember me" was checked at login, so the refresh never runs for the sessions it was meant to extend.
Kinda seems like the comment didn't match the code in any case.

This flips the check to `== ""` so the function runs when the marker is present. Maybe I'm missing something if this is working for others!