### PR TITLE
fix: prevent editor:pageCreating from firing twice in Vim mode

### DIFF
--- a/client/content_manager.ts
+++ b/client/content_manager.ts
@@ -147,15 +147,27 @@ export class ContentManager {
     });
   }
 
-  async reloadEditor() {
+async reloadEditor() {
     if (!this.client.systemReady) return;
-
     console.log("Reloading editor");
     clearTimeout(this.saveTimeout);
 
     try {
       if (isMarkdownPath(this.client.currentPath())) {
-        await this.loadPage({ path: this.client.currentPath() }, false);
+        const pageName = getNameFromPath(this.client.currentPath());
+        const currentText = this.client.editorView.state.sliceDoc();
+        // Rebuild the editor state in-place using the text already in memory,
+        // avoiding a full loadPage() call which re-dispatches
+        // editor:pageCreating for virtual/new pages (fixes #2012).
+        const currentMeta = this.client.ui.viewState.current?.meta;
+        const isReadOnly = currentMeta?.perm === "ro";
+        const editorState = createEditorState(
+          this.client,
+          pageName,
+          currentText,
+          isReadOnly,
+        );
+        this.client.editorView.setState(editorState);
       } else {
         await this.loadDocumentEditor({ path: this.client.currentPath() });
       }


### PR DESCRIPTION
When toggling Vim mode, setUiOption calls reloadEditor() which calls loadPage(). For virtual/new pages, loadPage() hits a notFoundError in readPage(), causing editor:pageCreating to fire a second time unexpectedly (issue #2012).

Fix: rebuild the editor state directly using the text already in memory (sliceDoc + createEditorState) instead of going through the full loadPage() path, which avoids re-dispatching editor:pageCreating.