### PR TITLE
fix: prevent bullet points from causing extraneous line break on wrap

### DIFF
--- a/client/styles/editor.scss
+++ b/client/styles/editor.scss
@@ -100,7 +100,7 @@
   }
 
   .cm-list-bullet {
-    color: var(--editor-list-bullet-color, inherit);
+    color: var(--editor-list-bullet-color, inherit);   white-space: nowrap; // Prevent bullet from being a line-wrap opportunity (fixes #1829)
   }
 
   .cm-task-checked,


### PR DESCRIPTION
Added white-space property to prWhen a bullet list item's text is long enough to wrap, the browser can break right after the .cm-list-bullet span (the • character), causing a phantom blank line at the start of the wrapped item.

Fix: add white-space: nowrap to .cm-list-bullet so the bullet cannot be a line-wrap opportunity. Fixes #1829.event bullet line wrapping.