### PR TITLE
Fix: only treat known file extensions as document paths (page names with dots)

### DIFF
--- a/plug-api/lib/ref.test.ts
+++ b/plug-api/lib/ref.test.ts
@@ -16,7 +16,12 @@ test("parseToRef() default cases", () => {
   expect(parseToRef("foo.md")).toEqual({ path: "foo.md" });
   expect(parseToRef("foo.")).toEqual({ path: "foo..md" });
   expect(parseToRef("foo..")).toEqual({ path: "foo...md" });
-  expect(parseToRef(" .foo")).toEqual({ path: " .foo" });
+  // "foo" is not a known document extension, so this is a page name with a dot
+  expect(parseToRef(" .foo")).toEqual({ path: " .foo.md" });
+  // Page names ending in extension-like suffixes are pages, not documents
+  expect(parseToRef("Clippings/Article StrengthPlanet.com")).toEqual({
+    path: "Clippings/Article StrengthPlanet.com.md",
+  });
   expect(parseToRef("foo[bar")).toEqual({ path: "foo[bar.md" });
   expect(parseToRef("foo]bar")).toEqual({ path: "foo]bar.md" });
   expect(parseToRef("foo(bar")).toEqual({ path: "foo(bar.md" });

--- a/plug-api/lib/ref.ts
+++ b/plug-api/lib/ref.ts
@@ -51,9 +51,72 @@ export function isMarkdownPath(path: Path): boolean {
   return getPathExtension(path) === "md";
 }
 
+// Dot-suffixes that denote actual (document) file types. A name ending in any
+// OTHER dot-suffix — e.g. a clipped web page titled "... StrengthPlanet.com" —
+// is a markdown page whose name merely contains a dot, and must get the `.md`
+// extension appended like any other page name.
+const knownFileExtensions = new Set([
+  "md",
+  "conflicted",
+  // images
+  "png",
+  "jpg",
+  "jpeg",
+  "jfif",
+  "gif",
+  "webp",
+  "svg",
+  "bmp",
+  "ico",
+  "avif",
+  // documents
+  "pdf",
+  "epub",
+  "txt",
+  "rtf",
+  "docx",
+  "xlsx",
+  "pptx",
+  "odt",
+  "csv",
+  "tsv",
+  // audio/video
+  "mp3",
+  "wav",
+  "ogg",
+  "m4a",
+  "flac",
+  "mp4",
+  "webm",
+  "mov",
+  "avi",
+  "mkv",
+  // web/code
+  "html",
+  "htm",
+  "css",
+  "js",
+  "json",
+  "yaml",
+  "yml",
+  "xml",
+  "map",
+  "lua",
+  "php",
+  // archives
+  "zip",
+  "tar",
+  "gz",
+  "7z",
+  "rar",
+  // silverbullet
+  "canvas",
+  "excalidraw",
+]);
+
 /**
- * Adds an `md` extension to any path without an extension or a path ending in
- * `.conflicted`, except to the empty path
+ * Adds an `md` extension to any path that does not end in a known document
+ * file extension (or `.conflicted`), except to the empty path
  * @param path The path to normalize. Cannot contain any position or header
  * addons
  */
@@ -62,7 +125,12 @@ function normalizePath(path: string): Path {
     path = path.slice(1);
   }
 
-  if (/.+\.[a-zA-Z0-9]+$/.test(path) || path === "") {
+  if (path === "") {
+    return path as Path;
+  }
+
+  const extMatch = /.+\.([a-zA-Z0-9]+)$/.exec(path);
+  if (extMatch && knownFileExtensions.has(extMatch[1].toLowerCase())) {
     return path as Path;
   }
 


### PR DESCRIPTION
Fixes #1957

Implements the whitelist approach proposed by @zefhemel in the community thread [Page names with "." (again)](https://community.silverbullet.md/t/page-names-with-again/4083).

## Problem

`normalizePath` in `plug-api/lib/ref.ts` treats **any** dot-suffix as a file extension:

```ts
if (/.+\.[a-zA-Z0-9]+$/.test(path) || path === "") {
  return path as Path;   // treated as a document path, no .md appended
}
```

A page named `site.com` (or `My Notes 2.0`, `something.template`, any web-clipped article titled after its source domain) parses as a *document* ref, so navigation fetches `/.fs/site.com` literally and 404s — the page is unreachable by name even though `site.com.md` exists. In my space (with many imported web clippings titled `… « SiteName.com`) this affected 700+ pages.

## Fix

Per the proposal in the thread: a name ending in a dot-suffix is only a document path when the suffix is a **known file extension**; everything else is a page name that gets `.md` appended as usual. The whitelist covers images, documents, audio/video, web/code, archives, and SilverBullet's own types (`canvas`, `excalidraw`, `conflicted`).

`[[my.template]]` now resolves to `my.template.md`, while `[[diagram.png]]` still resolves to the document.

Making the whitelist configurable (as floated in the thread) would be a natural follow-up; this PR keeps it static to stay small.

## Testing

- Updated the `parseToRef(" .foo")` expectation in `ref.test.ts` (now a page, `" .foo.md"`) and added a case for a domain-suffixed page name.
- `npx vitest run` — 873 passed.
- Deployed on my own instance: previously-404 pages now open by name; document links (png/pdf/etc.) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
