### PR TITLE
Configurable default attachment path (#1215)

### DIFF
--- a/client/codemirror/editor_paste.ts
+++ b/client/codemirror/editor_paste.ts
@@ -9,9 +9,15 @@ import {
   findParentMatching,
   nodeAtPos,
 } from "@silverbulletmd/silverbullet/lib/tree";
-import { maximumDocumentSize } from "@silverbulletmd/silverbullet/constants";
+import {
+  defaultAttachmentPath,
+  maximumDocumentSize,
+} from "@silverbulletmd/silverbullet/constants";
 import { safeRun } from "@silverbulletmd/silverbullet/lib/async";
-import { resolveMarkdownLink } from "@silverbulletmd/silverbullet/lib/resolve";
+import {
+  resolveAttachmentPath,
+  resolveMarkdownLink,
+} from "@silverbulletmd/silverbullet/lib/resolve";
 import { localDateString } from "@silverbulletmd/silverbullet/lib/dates";
 import type { UploadFile } from "@silverbulletmd/silverbullet/type/client";
 import { isValidName, isValidPath } from "@silverbulletmd/silverbullet/lib/ref";
@@ -280,6 +286,11 @@ export function documentExtension(editor: Client) {
     const maxSize = maximumDocumentSize;
     const invalidPathMessage =
       "Unable to upload file, invalid target filename or path";
+    // Note: duplicate any modifications here to plugs/editor/upload.ts
+    const attachmentPath = editor.config.get(
+      "attachmentPath",
+      defaultAttachmentPath,
+    );
 
     if (file.content.length > maxSize * 1024 * 1024) {
       editor.ui.flashNotification(
@@ -291,8 +302,9 @@ export function documentExtension(editor: Client) {
 
     let desiredFilePath = await editor.ui.prompt(
       "File name for pasted document",
-      resolveMarkdownLink(
+      resolveAttachmentPath(
         client.currentPath(),
+        attachmentPath,
         ensureValidFilenameWithExtension(file.name),
       ),
     );

--- a/libraries/Library/Std/Config.md
+++ b/libraries/Library/Std/Config.md
@@ -121,6 +121,13 @@ config.define("shortWikiLinks", {
   ui = { category = "Editor", label = "Short wiki links", priority = 1 },
 })
 
+config.define("attachmentPath", {
+  description = "Default folder prefix used to pre-fill the file name prompt when pasting or uploading an attachment (image or other file). Leave empty (the default) to keep today's behavior of suggesting the current page's folder. A leading '/' makes the prefix absolute from the space root regardless of which page you're on, e.g. '/Assets/'. Without a leading '/', the prefix is resolved relative to the current page's folder, e.g. 'attachments/'.",
+  type = "string",
+  default = "",
+  ui = { category = "Editor", label = "Attachment path", priority = 2 },
+})
+
 config.define("frontmatterFolding", {
   description = "Configure folding behavior for YAML frontmatter at the top of pages",
   type = "object",

--- a/plug-api/constants.ts
+++ b/plug-api/constants.ts
@@ -1,5 +1,8 @@
 export const maximumDocumentSize: number = 10; // MiB
 export const defaultLinkStyle: string = "wikilink";
+// Default folder prefix for pasted/uploaded attachments. Empty means "no
+// prefix", i.e. today's behavior (save next to the current page).
+export const defaultAttachmentPath: string = "";
 export const offlineError: Error = new Error("Offline");
 export const notFoundError: Error = new Error("Not found");
 export const notAuthenticatedError: Error = new Error("Unauthenticated");

--- a/plug-api/lib/resolve.test.ts
+++ b/plug-api/lib/resolve.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "vitest";
-import { resolveMarkdownLink } from "@silverbulletmd/silverbullet/lib/resolve";
+import {
+  resolveAttachmentPath,
+  resolveMarkdownLink,
+} from "@silverbulletmd/silverbullet/lib/resolve";
 
 test("Test URL resolver", () => {
   // Absolute paths
@@ -17,5 +20,35 @@ test("Test URL resolver", () => {
   expect(resolveMarkdownLink("bar", "../../foo/baz")).toEqual("foo/baz");
   expect(resolveMarkdownLink("bar/qux", "foo/../baz")).toEqual(
     "bar/foo/../baz",
+  );
+});
+
+// See https://github.com/silverbulletmd/silverbullet/issues/1215 - lets users
+// configure a default folder prefix for pasted/uploaded attachments instead
+// of having to type one manually every time.
+test("Test resolveAttachmentPath (issue #1215: configurable attachment path)", () => {
+  // Default (empty) attachmentPath: behavior is unchanged from before the
+  // setting existed - same folder as the current page.
+  expect(resolveAttachmentPath("Folder/Page", "", "image.png")).toEqual(
+    "Folder/image.png",
+  );
+  expect(resolveAttachmentPath("Page", "", "image.png")).toEqual("image.png");
+
+  // Relative attachmentPath (no leading "/"): resolved relative to the
+  // current page's folder, e.g. a per-note "attachments/" subfolder.
+  expect(
+    resolveAttachmentPath("Folder/Page", "attachments/", "image.png"),
+  ).toEqual("Folder/attachments/image.png");
+  expect(resolveAttachmentPath("Page", "attachments/", "image.png")).toEqual(
+    "attachments/image.png",
+  );
+
+  // Absolute attachmentPath (leading "/"): always resolves to the same
+  // space-root-relative folder, regardless of the current page's location.
+  expect(
+    resolveAttachmentPath("Folder/Sub/Page", "/Assets/", "image.png"),
+  ).toEqual("Assets/image.png");
+  expect(resolveAttachmentPath("Page", "/Assets/", "image.png")).toEqual(
+    "Assets/image.png",
   );
 });

--- a/plug-api/lib/resolve.ts
+++ b/plug-api/lib/resolve.ts
@@ -63,6 +63,26 @@ export function resolveMarkdownLink(
 }
 
 /**
+ * Computes the file path to pre-fill the "save attachment" prompt with, when
+ * pasting or uploading a file (image or otherwise) on `currentPagePath`.
+ *
+ * `attachmentPath` is the value of the `attachmentPath` config setting and
+ * follows the same absolute/relative convention as `resolveMarkdownLink`: a
+ * leading "/" makes it absolute from the space root (e.g. "/Assets/"),
+ * regardless of the current page; without a leading "/" it's resolved
+ * relative to the current page's folder (e.g. "attachments/"). An empty
+ * `attachmentPath` (the default) leaves the suggested path unchanged from
+ * before this setting existed.
+ */
+export function resolveAttachmentPath(
+  currentPagePath: string,
+  attachmentPath: string,
+  filename: string,
+): string {
+  return resolveMarkdownLink(currentPagePath, `${attachmentPath}${filename}`);
+}
+
+/**
  * Turns an absolute path into a relative path, relative to some base directory. USE WITH CAUTION, definitely buggy
  */
 export function absoluteToRelativePath(base: string, absolute: string): string {

--- a/plugs/editor/upload.ts
+++ b/plugs/editor/upload.ts
@@ -1,9 +1,13 @@
 import { editor, space, system } from "@silverbulletmd/silverbullet/syscalls";
 import {
+  defaultAttachmentPath,
   defaultLinkStyle,
   maximumDocumentSize,
 } from "@silverbulletmd/silverbullet/constants";
-import { resolveMarkdownLink } from "@silverbulletmd/silverbullet/lib/resolve";
+import {
+  resolveAttachmentPath,
+  resolveMarkdownLink,
+} from "@silverbulletmd/silverbullet/lib/resolve";
 import {
   encodePageURI,
   isValidPath,
@@ -25,6 +29,10 @@ export async function saveFile(file: UploadFile) {
     "maximumDocumentSize",
     maximumDocumentSize,
   );
+  const attachmentPath = await system.getConfig<string>(
+    "attachmentPath",
+    defaultAttachmentPath,
+  );
 
   if (typeof maxSize !== "number") {
     await editor.flashNotification(
@@ -42,8 +50,9 @@ export async function saveFile(file: UploadFile) {
 
   let desiredFilePath = await editor.prompt(
     "File name for uploaded document",
-    resolveMarkdownLink(
+    resolveAttachmentPath(
       await editor.getCurrentPath(),
+      attachmentPath,
       ensureValidFilenameWithExtension(file.name),
     ),
   );


### PR DESCRIPTION
Closes #1215.

Adds an `attachmentPath` setting that pre-fills the file name prompt when pasting or uploading an attachment, so you don't have to type a folder prefix every time.

I went with reusing the absolute/relative convention `resolveMarkdownLink` already uses for wikilinks instead of inventing new syntax: a leading `/` (e.g. `/Assets/`) is absolute from the space root, no leading slash (e.g. `attachments/`) resolves relative to the current page's folder, and leaving it empty (default) keeps today's behavior untouched. This also covers what @dbsavage asked for in the comment (per-note relative folders), not just the original absolute-prefix request, without any extra work.

The only new logic (`resolveAttachmentPath` in `plug-api/lib/resolve.ts`) is unit tested. I didn't add an integration/E2E test for the full paste-to-save flow — `createMockSystem()` doesn't register the `editor.*` syscalls that `upload.ts`/`editor_paste.ts` need, and mocking that whole surface felt like it'd test the mock more than the behavior. Tested manually instead: ran the server locally, uploaded and pasted a file with the setting on and off, confirmed the path prefix shows up correctly and that leaving it unset behaves exactly like before.

One thing I'm not sure about: the setting name. I called it `attachmentPath` for consistency with other flat settings like `shortWikiLinks`, but happy to rename if there's a preferred convention for this kind of thing.
