### PR TITLE
fix: Add box-sizing to modals

### DIFF
--- a/client/styles/modals.scss
+++ b/client/styles/modals.scss
@@ -5,6 +5,7 @@
   max-width: 90%;
   border-radius: 8px;
   overflow: hidden;
+  box-sizing: border-box;
 
   &::backdrop {
     background-color: var(--modal-backdrop-color);


### PR DESCRIPTION
Today modal boxes have a 1px offscreen as borders arent taken into account for max-width in smaller screens. I believe this is the correct place to fix it. (I have a custom space-style for the fix) If not let me know.

Now:
<img width="414" height="846" alt="Screenshot 2026-07-11 at 15-04-56 00 Infra_Styles" src="https://github.com/user-attachments/assets/a72d141a-7a8a-4060-bb3e-e3fa92e491b8" />

Fixed:
<img width="414" height="846" alt="Screenshot 2026-07-11 at 15-05-12 00 Infra_Styles" src="https://github.com/user-attachments/assets/70d63724-47a8-4820-b2ad-a8e40b2a4f94" />
