### PR TITLE
Fix custom code widgets not being able to effect data objects

### DIFF
--- a/client/codemirror/fenced_code.ts
+++ b/client/codemirror/fenced_code.ts
@@ -24,7 +24,7 @@ export function fencedCodePlugin(client: Client) {
             return;
           }
           const text = state.sliceDoc(from, to);
-          const [_, lang] = text.match(/^(?:```+|~~~+)(\w+)?/)!;
+          const [_, lang] = text.match(/^(?:```+|~~~+)(\S+)?/)!;
           const renderMode = widgetRenderMode(client);
 
           const luaWidgetDef = lang


### PR DESCRIPTION
The previous regex wouldn't capture something like `#person`. The new regex can, allowing for data objects to have custom renderers.

While not strictly addressing the requested feature in #2054, this sufficiently fulfills my personal reasons for making said feature request.