### PR TITLE
Add openssh-client to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM alpine:latest
 # binary (silverbullet-amd64 / silverbullet-arm64, built on the CI runner).
 ARG TARGETARCH
 
-RUN apk add --no-cache git curl bash tini
+RUN apk add --no-cache git curl bash tini openssh-client
 
 ENV SB_HOSTNAME=0.0.0.0 \
     SB_FOLDER=/space \


### PR DESCRIPTION
Alpine's git package doesn't pull in an ssh client, so git autosync over ssh fails inside the container with `ssh: not found`. Adds `openssh-client` alongside the existing packages.

Tested locally: with `~/.ssh` mounted in, `git clone`/`ls-remote` over ssh work fine after this change; without it they fail with the missing ssh error.

Closes #2066