### PR TITLE
Fix Runtime API startup when authentication is enabled

### DIFF
--- a/bin/silverbullet/tests/runtime_e2e.rs
+++ b/bin/silverbullet/tests/runtime_e2e.rs
@@ -23,6 +23,18 @@ impl Drop for Server {
 mod common;
 use common::free_port;
 
+const AUTH_TOKEN: &str = "runtime-e2e-token";
+
+fn chrome_available() -> bool {
+    std::env::var("SB_CHROME_PATH")
+        .ok()
+        .is_some_and(|path| std::path::Path::new(&path).is_file())
+        || std::env::var("CHROMIUM_PATH")
+            .ok()
+            .is_some_and(|path| std::path::Path::new(&path).is_file())
+        || silverbullet_server_runtime_chrome::find_chrome().is_some()
+}
+
 /// Poll `cond` until it returns true or the deadline passes. On timeout, dump the
 /// server's captured stdout/stderr and panic with `msg`.
 fn wait_until(
@@ -58,7 +70,7 @@ fn dump_and_panic(server: &mut Server, msg: &str) -> ! {
 
 #[test]
 fn runtime_api_evaluates_lua_against_headless_chrome() {
-    if silverbullet_server_runtime_chrome::find_chrome().is_none() {
+    if !chrome_available() {
         eprintln!("skipping runtime_e2e: no Chrome/Chromium found on this machine");
         return;
     }
@@ -74,6 +86,8 @@ fn runtime_api_evaluates_lua_against_headless_chrome() {
         .arg("-L")
         .arg("127.0.0.1")
         .arg("--single")
+        .env("SB_USER", "runtime-e2e:runtime-e2e-password")
+        .env("SB_AUTH_TOKEN", AUTH_TOKEN)
         .env("SB_DISABLE_SERVICE_WORKER", "1")
         .env("SB_CHROME_DATA_DIR", &chrome_data)
         .stdout(Stdio::piped())
@@ -84,6 +98,18 @@ fn runtime_api_evaluates_lua_against_headless_chrome() {
 
     let base = format!("http://127.0.0.1:{port}");
     let http = reqwest::blocking::Client::builder()
+        .default_headers({
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert(
+                reqwest::header::AUTHORIZATION,
+                format!("Bearer {AUTH_TOKEN}").parse().unwrap(),
+            );
+            headers
+        })
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+    let anonymous_http = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(15))
         .build()
         .unwrap();
@@ -101,7 +127,18 @@ fn runtime_api_evaluates_lua_against_headless_chrome() {
         "server never answered /.ping",
     );
 
-    // 2) Runtime ready: /.runtime/lua returns 200 (not 503 bridge_unavailable)
+    // 2) The runtime endpoint itself remains protected.
+    assert_eq!(
+        anonymous_http
+            .post(format!("{base}/.runtime/lua"))
+            .body("1 + 1")
+            .send()
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+
+    // 3) Runtime ready: /.runtime/lua returns 200 (not 503 bridge_unavailable)
     //    once the headless client has connected. Body `1 + 1` is an expression;
     //    evalLua prepends `return `, so it evaluates to 2.
     let mut lua_result = String::new();
@@ -128,7 +165,7 @@ fn runtime_api_evaluates_lua_against_headless_chrome() {
         "1 + 1 should eval to 2"
     );
 
-    // 3) lua_script: a full script (no implicit `return` prepended).
+    // 4) lua_script: a full script (no implicit `return` prepended).
     let script = http
         .post(format!("{base}/.runtime/lua_script"))
         .body("return 1 + 1")

--- a/server-runtime-chrome/src/config.rs
+++ b/server-runtime-chrome/src/config.rs
@@ -5,9 +5,8 @@ use std::path::Path;
 pub struct ChromeConfig {
     pub chrome_path: String,
     pub server_url: String,
-    /// Headless auth token, always appended to the page URL as `&token=…`. When
-    /// authentication is disabled the open server ignores it; when enabled, the
-    /// headless-token authorizer accepts it so the headless page is authorized.
+    /// Headless auth token seeded as a same-origin, HTTP-only session cookie
+    /// before the managed browser navigates to the SilverBullet client.
     pub headless_token: String,
     pub user_data_dir: String,
     pub show: bool,

--- a/server-runtime-chrome/src/supervisor.rs
+++ b/server-runtime-chrome/src/supervisor.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use chromiumoxide::browser::{Browser, BrowserConfig};
+use chromiumoxide::cdp::browser_protocol::network::{CookieParam, CookieSameSite};
 use chromiumoxide::cdp::js_protocol::runtime::{
     ConsoleApiCalledType, EvaluateParams, EventConsoleApiCalled,
 };
@@ -19,6 +20,7 @@ use chromiumoxide::error::CdpError;
 use chromiumoxide::page::Page;
 use futures::StreamExt;
 use serde_json::Value;
+use silverbullet_server::auth::HEADLESS_AUTH_COOKIE;
 use silverbullet_server::runtime::{LogBuffer, LogEntry, RuntimeError};
 use tokio::sync::{Mutex, Notify};
 
@@ -111,12 +113,40 @@ fn now_millis() -> i64 {
         .unwrap_or(0)
 }
 
-/// Build the headless page URL from the configured server URL, trimming a
-/// trailing slash and appending `?headless=1&token=…`. The token is always
-/// present; an open (no-auth) server simply ignores it.
+/// Build the headless page URL from the configured server URL. Authentication
+/// is carried in a same-origin, HTTP-only cookie seeded through CDP before
+/// navigation rather than in the URL.
 fn page_url(config: &ChromeConfig) -> String {
     let base = config.server_url.trim_end_matches('/');
-    format!("{base}/?headless=1&token={}", config.headless_token)
+    format!("{base}/?headless=1")
+}
+
+fn cookie_path(server_url: &str) -> String {
+    let path = server_url
+        .split_once("://")
+        .and_then(|(_, authority_and_path)| {
+            authority_and_path
+                .find('/')
+                .map(|index| &authority_and_path[index..])
+        })
+        .unwrap_or("/");
+    let path = path.trim_end_matches('/');
+    if path.is_empty() {
+        "/".to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+fn headless_cookie(config: &ChromeConfig) -> Result<CookieParam, String> {
+    CookieParam::builder()
+        .name(HEADLESS_AUTH_COOKIE)
+        .value(&config.headless_token)
+        .url(&config.server_url)
+        .path(cookie_path(&config.server_url))
+        .http_only(true)
+        .same_site(CookieSameSite::Strict)
+        .build()
 }
 
 /// Launch a fresh browser + page, attach console capture, wait for the client
@@ -165,9 +195,16 @@ async fn launch_once(
     });
 
     let page = browser
-        .new_page(page_url(config).as_str())
+        .new_page("about:blank")
         .await
         .map_err(|e| format!("new page: {e}"))?;
+
+    page.set_cookie(headless_cookie(config)?)
+        .await
+        .map_err(|e| format!("headless auth cookie: {e}"))?;
+    page.goto(page_url(config).as_str())
+        .await
+        .map_err(|e| format!("headless page navigation: {e}"))?;
 
     attach_console_capture(&page, logs, config.log_console)
         .await
@@ -343,6 +380,44 @@ pub async fn supervise(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn config(server_url: &str) -> ChromeConfig {
+        ChromeConfig {
+            chrome_path: "/chrome".to_string(),
+            server_url: server_url.to_string(),
+            headless_token: "secret".to_string(),
+            user_data_dir: "/tmp/chrome".to_string(),
+            show: false,
+            log_console: false,
+        }
+    }
+
+    #[test]
+    fn headless_navigation_uses_cookie_instead_of_query_token() {
+        let config = config("http://127.0.0.1:3000");
+        assert_eq!(page_url(&config), "http://127.0.0.1:3000/?headless=1");
+        assert!(!page_url(&config).contains("secret"));
+
+        let cookie = headless_cookie(&config).unwrap();
+        assert_eq!(cookie.name, HEADLESS_AUTH_COOKIE);
+        assert_eq!(cookie.value, "secret");
+        assert_eq!(cookie.url.as_deref(), Some("http://127.0.0.1:3000"));
+        assert_eq!(cookie.path.as_deref(), Some("/"));
+        assert_eq!(cookie.http_only, Some(true));
+        assert_eq!(cookie.same_site, Some(CookieSameSite::Strict));
+        assert_eq!(cookie.expires, None);
+    }
+
+    #[test]
+    fn headless_cookie_is_scoped_to_space_prefix() {
+        let config = config("http://127.0.0.1:3000/spaces/my-space");
+        let cookie = headless_cookie(&config).unwrap();
+        assert_eq!(cookie.path.as_deref(), Some("/spaces/my-space"));
+        assert_eq!(
+            page_url(&config),
+            "http://127.0.0.1:3000/spaces/my-space/?headless=1"
+        );
+    }
 
     #[test]
     fn console_level_maps_severity() {

--- a/server/src/auth/headless_token.rs
+++ b/server/src/auth/headless_token.rs
@@ -1,9 +1,15 @@
 use crate::auth::authorizer::{AuthContext, RequestAuthorizer};
 use crate::auth::config::constant_time_eq;
+use crate::auth::cookie::cookie_value;
+
+/// Session cookie used only by the server-managed headless Chrome runtime.
+pub const HEADLESS_AUTH_COOKIE: &str = "silverbullet_headless";
 
 /// Wraps an inner authorizer, additionally accepting any request that carries
-/// `?token=<headless_token>` in its query string (constant-time compared). This
-/// lets the headless browser page authenticate via the URL the server hands it.
+/// the headless token in its query string or dedicated session cookie
+/// (constant-time compared). The query form authenticates the initial page on
+/// older runtime clients; current clients seed the cookie through CDP so every
+/// subsequent same-origin request remains authenticated.
 pub struct HeadlessTokenAuthorizer {
     inner: Box<dyn RequestAuthorizer>,
     token: String,
@@ -28,11 +34,21 @@ impl HeadlessTokenAuthorizer {
         }
         false
     }
+
+    fn cookie_token_matches(&self, headers: &axum::http::HeaderMap) -> bool {
+        if self.token.is_empty() {
+            return false;
+        }
+        cookie_value(headers, HEADLESS_AUTH_COOKIE)
+            .is_some_and(|value| constant_time_eq(value.as_bytes(), self.token.as_bytes()))
+    }
 }
 
 impl RequestAuthorizer for HeadlessTokenAuthorizer {
     fn is_authorized(&self, ctx: &AuthContext) -> bool {
-        self.query_token_matches(ctx.query) || self.inner.is_authorized(ctx)
+        self.query_token_matches(ctx.query)
+            || self.cookie_token_matches(ctx.headers)
+            || self.inner.is_authorized(ctx)
     }
 }
 
@@ -69,6 +85,28 @@ mod tests {
         let a = HeadlessTokenAuthorizer::new(Box::new(DenyAll), "secret".into());
         assert!(a.is_authorized(&ctx(Some("headless=1&token=secret"), &h)));
         assert!(a.is_authorized(&ctx(Some("token=secret"), &h)));
+    }
+
+    #[test]
+    fn accepts_matching_headless_cookie() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            "cookie",
+            "other=value; silverbullet_headless=secret".parse().unwrap(),
+        );
+        let a = HeadlessTokenAuthorizer::new(Box::new(DenyAll), "secret".into());
+        assert!(a.is_authorized(&ctx(None, &h)));
+    }
+
+    #[test]
+    fn rejects_wrong_headless_cookie() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            "cookie",
+            "silverbullet_headless=wrong; other=value".parse().unwrap(),
+        );
+        let a = HeadlessTokenAuthorizer::new(Box::new(DenyAll), "secret".into());
+        assert!(!a.is_authorized(&ctx(None, &h)));
     }
 
     #[test]

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -20,7 +20,7 @@ pub use cookie::{
     auth_cookie_name, cookie_value, is_secure_request, request_host, scoped_auth_cookie_name,
     CookieOptions,
 };
-pub use headless_token::HeadlessTokenAuthorizer;
+pub use headless_token::{HeadlessTokenAuthorizer, HEADLESS_AUTH_COOKIE};
 pub use jwt_authorizer::JwtAuthorizer;
 pub use lockout::LockoutTimer;
 pub use login::LoginManager;


### PR DESCRIPTION
## Summary

- seed the server-managed headless authentication token as a same-origin, HTTP-only session cookie before navigating Chromium
- keep query-token authorization for compatibility with older runtime clients
- scope the cookie to the active space prefix and remove the token from the navigation URL
- make the Runtime API end-to-end test run with authentication enabled and verify anonymous requests remain unauthorized

## Problem

With `SB_USER` enabled, the initial headless page load was authorized by the `token` query parameter, but subsequent client requests did not carry it. The client was redirected to `/.auth`, the CDP bridge disconnected, and Runtime API calls returned `bridge_unavailable`.

## Validation

- `make fmt`
- `npm run check`
- `npx biome lint .`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `npx vitest run` (1,162 passed; 5 skipped)
- `cargo test --workspace --all-features`
- authenticated Chromium end-to-end test: `/.runtime/lua` returns `{"result":2}` while the anonymous request returns HTTP 401