### PR TITLE
Fix: proper progress status update

### DIFF
--- a/client/editor_ui.tsx
+++ b/client/editor_ui.tsx
@@ -111,7 +111,13 @@ export class MainUI {
   }
 
   // Progress circle handling
-  private progressTimeout?: ReturnType<typeof setTimeout>;
+  private progressMap = new Map<
+    "index" | "sync",
+    {
+      percentage: number;
+      timeout: ReturnType<typeof setTimeout>;
+    }
+  >();
 
   viewDispatch: (action: Action) => void = () => {};
 
@@ -152,20 +158,54 @@ export class MainUI {
     }
   }
 
-  showProgress(progressPercentage?: number, progressType?: "sync" | "index") {
-    this.viewDispatch({
-      type: "set-progress",
-      progressPercentage,
-      progressType,
-    });
-    if (this.progressTimeout) {
-      clearTimeout(this.progressTimeout);
+  private dispatchProgressState() {
+    // Hide when nothing is active
+    if (this.progressMap.size === 0) {
+      this.viewDispatch({ type: "set-progress" });
+      return;
     }
-    this.progressTimeout = setTimeout(() => {
+
+    // Sync takes precedence over index so the indicator
+    // doesn't flip between the two when both streams are firing.
+    const progressType: "sync" | "index" = this.progressMap.has("sync")
+      ? "sync"
+      : "index";
+    const entry = this.progressMap.get(progressType);
+    if (entry) {
       this.viewDispatch({
         type: "set-progress",
+        progressPercentage: entry.percentage,
+        progressType,
       });
-    }, 5000);
+    }
+  }
+
+  private removeProgressType(progressType: "index" | "sync") {
+    const entry = this.progressMap.get(progressType);
+    if (entry) {
+      clearTimeout(entry.timeout);
+      this.progressMap.delete(progressType);
+    }
+  }
+
+  showProgress(
+    progressPercentage: number | undefined,
+    progressType: "sync" | "index",
+  ) {
+    this.removeProgressType(progressType);
+
+    if (progressPercentage !== undefined) {
+      const timeout = setTimeout(() => {
+        this.removeProgressType(progressType);
+        this.dispatchProgressState();
+      }, 5000);
+      this.progressMap.set(progressType, {
+        percentage: progressPercentage,
+        timeout,
+      });
+    }
+
+    this.dispatchProgressState();
   }
 
   filterBox(

--- a/client/editor_ui.tsx
+++ b/client/editor_ui.tsx
@@ -189,8 +189,8 @@ export class MainUI {
   }
 
   showProgress(
-    progressPercentage: number | undefined,
     progressType: "sync" | "index",
+    progressPercentage?: number,
   ) {
     this.removeProgressType(progressType);
 

--- a/client/plugos/syscalls/editor.ts
+++ b/client/plugos/syscalls/editor.ts
@@ -664,25 +664,25 @@ export function editorSyscalls(client: Client): SysCallMapping {
     "editor.showProgress": {
       callback: (
         _ctx,
-        progressPercentage?: number,
         progressType: "sync" | "index",
+        progressPercentage?: number,
       ) => {
-        client.ui.showProgress(progressPercentage, progressType);
+        client.ui.showProgress(progressType, progressPercentage);
       },
       description:
         "Shows, updates, or hides a sync or indexing progress indicator.",
       parameters: [
+        {
+          name: "progressType",
+          type: "sync | index",
+          description: "The operation represented by the indicator.",
+        },
         {
           name: "progressPercentage",
           type: "number",
           description:
             "Completion percentage, or undefined to hide the indicator.",
           optional: true,
-        },
-        {
-          name: "progressType",
-          type: "sync | index",
-          description: "The operation represented by the indicator.",
         },
       ],
     },

--- a/client/plugos/syscalls/editor.ts
+++ b/client/plugos/syscalls/editor.ts
@@ -665,7 +665,7 @@ export function editorSyscalls(client: Client): SysCallMapping {
       callback: (
         _ctx,
         progressPercentage?: number,
-        progressType?: "sync" | "index",
+        progressType: "sync" | "index",
       ) => {
         client.ui.showProgress(progressPercentage, progressType);
       },
@@ -683,7 +683,6 @@ export function editorSyscalls(client: Client): SysCallMapping {
           name: "progressType",
           type: "sync | index",
           description: "The operation represented by the indicator.",
-          optional: true,
         },
       ],
     },

--- a/plug-api/syscalls/editor.ts
+++ b/plug-api/syscalls/editor.ts
@@ -298,14 +298,14 @@ export function focus(): Promise<void> {
 }
 
 export function showProgress(
-  progressPercentage: number,
   progressType: "sync" | "index",
+  progressPercentage: number,
 ): Promise<void> {
-  return syscall("editor.showProgress", progressPercentage, progressType);
+  return syscall("editor.showProgress", progressType, progressPercentage);
 }
 
 export function hideProgress(progressType: "sync" | "index"): Promise<void> {
-  return syscall("editor.showProgress", undefined, progressType);
+  return syscall("editor.showProgress", progressType);
 }
 
 /**

--- a/plug-api/syscalls/editor.ts
+++ b/plug-api/syscalls/editor.ts
@@ -298,10 +298,14 @@ export function focus(): Promise<void> {
 }
 
 export function showProgress(
-  progressPercentage?: number,
-  progressType?: string,
+  progressPercentage: number,
+  progressType: "sync" | "index",
 ): Promise<void> {
   return syscall("editor.showProgress", progressPercentage, progressType);
+}
+
+export function hideProgress(progressType: "sync" | "index"): Promise<void> {
+  return syscall("editor.showProgress", undefined, progressType);
 }
 
 /**

--- a/plugs/index/queue.ts
+++ b/plugs/index/queue.ts
@@ -77,7 +77,7 @@ async function updateIndexProgressInUI() {
       if (lastProgress !== percentage || now - lastProgressAt >= 1000) {
         lastProgress = percentage;
         lastProgressAt = now;
-        await editor.showProgress(percentage, "index");
+        await editor.showProgress("index", percentage);
       }
     } else {
       await editor.hideProgress("index");

--- a/plugs/index/queue.ts
+++ b/plugs/index/queue.ts
@@ -65,20 +65,28 @@ async function totalItemsQueued() {
 async function updateIndexProgressInUI() {
   // Let's see if there's anything in the index queue
   let totalQueued = await totalItemsQueued();
+  let lastProgress = -1;
+  let lastProgressAt = 0;
   while (totalQueued > 0) {
     const percentage = Math.round(
       ((maximumObservedQueueSize - totalQueued) / maximumObservedQueueSize) *
         100,
     );
     if (percentage > 0 && percentage <= 99) {
-      await editor.showProgress(percentage, "index");
+      const now = Date.now();
+      if (lastProgress !== percentage || now - lastProgressAt >= 1000) {
+        lastProgress = percentage;
+        lastProgressAt = now;
+        await editor.showProgress(percentage, "index");
+      }
     } else {
-      // Hide progress circle
-      await editor.showProgress();
+      await editor.hideProgress("index");
+      lastProgressAt = 0;
     }
-    await sleep(1000);
+    await sleep(40);
     totalQueued = await totalItemsQueued();
   }
+  await editor.hideProgress("index");
   // Schedule again
   setTimeout(updateIndexProgressInUI, uiUpdateInterval);
 }

--- a/plugs/sync/sync.ts
+++ b/plugs/sync/sync.ts
@@ -58,7 +58,7 @@ export async function updateSyncStatus(event: {
     if (lastProgress !== percentage || now - lastProgressAt >= 1000) {
       lastProgress = percentage;
       lastProgressAt = now;
-      await editor.showProgress(percentage, "sync");
+      await editor.showProgress("sync", percentage);
     }
   }
 }

--- a/plugs/sync/sync.ts
+++ b/plugs/sync/sync.ts
@@ -5,6 +5,9 @@ import {
   sync,
 } from "@silverbulletmd/silverbullet/syscalls";
 
+let lastProgress = -1;
+let lastProgressAt = 0;
+
 export async function syncSpaceCommand() {
   await editor.flashNotification("Syncing space...");
   await sync.performSpaceSync();
@@ -48,9 +51,15 @@ export async function updateSyncStatus(event: {
   );
   if (percentage >= 99) {
     // Just hide it
-    await editor.showProgress();
+    await editor.hideProgress("sync");
+    lastProgressAt = 0;
   } else {
-    await editor.showProgress(percentage, "sync");
+    const now = Date.now();
+    if (lastProgress !== percentage || now - lastProgressAt >= 1000) {
+      lastProgress = percentage;
+      lastProgressAt = now;
+      await editor.showProgress(percentage, "sync");
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes several problems with progress status widget:

1. Sync and index showProgress fire at the same time leading to sync progress blink (because index calls hide progress)
2. Index progress updates once a second which is not as smooth as sync progress which shows each percent
3. Index progress might get stuck under 100 because of 1s sleep and indexing is done after sleep finished. So UI shows 98 and clears only after 5s timeout

Also I made progress type required since UI needs it anyway. And added extra api function hideProgress so we don't need to send undefined to mark "no progress" (syscall is reused).

This is how it looked before (all three bugs are present):

https://github.com/user-attachments/assets/072b2971-d9ea-4920-b915-0aab7c78049f

And this is now (no blinking, index is updated smoothly and hidden as soon as index is completed):

https://github.com/user-attachments/assets/5f603b9d-d395-4f7d-82e8-2d8c74153a26

