### PR TITLE
ui: remove staircase from progress indicator

### DIFF
--- a/client/components/top_bar.tsx
+++ b/client/components/top_bar.tsx
@@ -93,11 +93,12 @@ function SyncProgressIndicator({
         className="progress-wrapper"
         title={`${type} progress: ${percentage}%`}
       >
-        <div
-          className="progress-bar"
-          style={`background: radial-gradient(closest-side, var(--top-background-color) 79%, transparent 80% 100%), conic-gradient(var(--progress-${type}-color) ${percentage}%, var(--progress-background-color) 0);`}
-        >
-          {percentage}
+        <div className="progress-bar">
+          <div
+            className="progress-ring"
+            style={`background: conic-gradient(var(--progress-${type}-color) ${percentage}%, var(--progress-background-color) 0);`}
+          />
+          <div className="progress-hole">{percentage}</div>
         </div>
       </div>
     </div>

--- a/client/styles/top.scss
+++ b/client/styles/top.scss
@@ -88,14 +88,30 @@
   }
 
   .progress-bar {
+    position: relative;
+    width: 24px;
+    height: 24px;
+    font-size: 8px;
+  }
+
+  .progress-ring {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+  }
+
+  .progress-hole {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 19px;
+    height: 19px;
+    border-radius: 50%;
+    background-color: var(--top-background-color);
     display: flex;
     justify-content: center;
     align-items: center;
-
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    font-size: 8px;
   }
 }
 


### PR DESCRIPTION
## Problem

Sync/index progress indicator showed a visible rendering artifact: the outer edge of the ring was smooth and anti-aliased, but the inner edge had a hard, staircase/"nearest-neighbor" look.

This is because ring was painted with two stacked CSS gradients on a single element:

- The outer edge came from `border-radius: 50%`, browser anti-aliases it with sub-pixel coverage. Smooth at any size.
- The inner edge came from a steep `radial-gradient` color stop (`79% → 80%`). That lead to hard transition.

## Solution

Drop the gradients-as-hole approach. Use two real `border-radius: 50%` circles stacked on top of each other so both edges are vector clips.

| Before | After |
|--------|-------|
| <img width="336" height="336" alt="image" src="https://github.com/user-attachments/assets/7af86cb7-5832-4e2d-b249-852e37fa93d7" />  |  <img width="336" height="336" alt="image" src="https://github.com/user-attachments/assets/767f5ffe-5ed5-4b12-9f2c-e6d2642ce25d" />     |



