### PR TITLE
Run lint/fmt in CI

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: 'npm'
 
       - name: Setup Rust (linux musl + windows-gnu + freebsd targets)
         uses: dtolnay/rust-toolchain@stable
@@ -102,6 +103,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: 'npm'
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,32 @@ jobs:
 
           echo "publish=$publish is_edge=$is_edge is_tag=$is_tag"
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: lint
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build client bundle
+        run: npm run build
+
+      - name: Run checks
+        run: make check
+
   test-frontend:
     runs-on: ubuntu-latest
     steps:
@@ -94,6 +120,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -120,6 +147,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: 'npm'
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -157,6 +185,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: 'npm'
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -202,6 +231,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: 'npm'
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -238,7 +268,7 @@ jobs:
     secrets: inherit
 
   release:
-    needs: [config, build, test-frontend, test-rust, test-e2e, test-e2e-release]
+    needs: [config, build, test-frontend, test-rust, test-e2e, test-e2e-release, lint]
     if: needs.config.outputs.publish == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -255,6 +285,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: 'npm'
           registry-url: "https://registry.npmjs.org"
 
       - name: Install npm dependencies
@@ -314,7 +345,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   docker:
-    needs: [config, build, test-frontend, test-rust, test-e2e, test-e2e-release]
+    needs: [config, build, test-frontend, test-rust, test-e2e, test-e2e-release, lint]
     if: needs.config.outputs.publish == 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/e2e/blockquote.test.ts
+++ b/e2e/blockquote.test.ts
@@ -332,7 +332,7 @@ test("a marker spacer has a client rect with real height", async ({
   const heights = await page.evaluate(() =>
     [...document.querySelectorAll(".sb-quote-spacer")].map(
       (s) => s.getBoundingClientRect().height,
-    )
+    ),
   );
   expect(heights.length).toBeGreaterThan(0);
   for (const h of heights) expect(h).toBeGreaterThan(0);

--- a/e2e/comments.test.ts
+++ b/e2e/comments.test.ts
@@ -122,12 +122,12 @@ test("Comment: Selection uses the language's own syntax inside fenced code", asy
       view.dispatch({ selection: { anchor: at, head: at + needle.length } });
     }, needle);
     await page.evaluate(() =>
-      (globalThis as any).client.runCommandByName("Comment: Selection")
+      (globalThis as any).client.runCommandByName("Comment: Selection"),
     );
   };
   const doc = () =>
     page.evaluate(() =>
-      (globalThis as any).client.editorView.state.doc.toString()
+      (globalThis as any).client.editorView.state.doc.toString(),
     );
 
   await runOn("const x = 1;");


### PR DESCRIPTION
## Problem

CI currently runs type-checks and tests but skips lint and formatting for both client and server. So
formatting-breaking commits land on `main` regularly.
`make check` already covered everything locally (but not client formatting), but CI only ran a
subset (`npm run check` + tests) and reimplemented it inline, so the two drifted apart.

| Check                      | `make check` | `ci.yml` |
|----------------------------|--------------|----------|
| `tsc --noEmit`             | yes          | yes      |
| `biome lint`               | yes          | **no**   |
| `biome format`             | **no**       | **no**   |
| `cargo fmt --check`        | yes          | **no**   |
| `cargo clippy -D warnings` | yes          | **no**   |

## Solution

- Added `npx biome format .` to the `make check` (since cargo fmt was already there)
- Added separate `lint` job that runs `make check` in `ci.yml`
- Added `cache: 'npm'` to all `setup-node` steps (it's a bit faster with it on subsequent runs)
- Ran `make fmt` and committed changes to separate commit

## Suggestion

For this to actually block bad commits, the `lint` job needs to be marked as a **required status check**
under **Settings → Branches → branch protection rules → `main`**.
Without that it's advisory only. The existing `test-*` jobs likely want the same rule.