### PR TITLE
Fix: highlight not rendering in task items

### DIFF
--- a/client/markdown_renderer/markdown_render.test.ts
+++ b/client/markdown_renderer/markdown_render.test.ts
@@ -177,6 +177,17 @@ test("Unmatched HTML tags render as literal text", () => {
   expect(html).toEqual('<span class="p">text &lt;b&gt;unclosed</span>');
 });
 
+test("Inline HTML renders inside task items", () => {
+  const tree = parse(
+    extendedMarkdownLanguage,
+    "* [ ] <mark>highlighted</mark> task",
+  );
+  const html = renderMarkdownToHtml(tree, { failOnUnknown: true });
+  expect(html).toEqual(
+    '<ul><li><span class="sb-task"><input type="checkbox" data-state=" "> <mark>highlighted</mark> task</span></li></ul>',
+  );
+});
+
 test("CustomSyntaxRenderedHtml renders raw HTML", () => {
   // Directly test the renderer with a synthetic parse tree
   const tree = {

--- a/client/markdown_renderer/markdown_render.ts
+++ b/client/markdown_renderer/markdown_render.ts
@@ -259,7 +259,7 @@ function render(t: ParseTree, options: MarkdownRenderOptions = {}): Tag | null {
       return {
         name: "span",
         attrs: {
-          class: "highlight",
+          class: "sb-highlight",
         },
         body: cleanTags(mapRender(t.children!)),
       };
@@ -453,6 +453,7 @@ function render(t: ParseTree, options: MarkdownRenderOptions = {}): Tag | null {
         }
       });
 
+      const hasHtml = t.children!.some((c) => c.type === "HTMLTag");
       return {
         name: "span",
         attrs: {
@@ -461,7 +462,11 @@ function render(t: ParseTree, options: MarkdownRenderOptions = {}): Tag | null {
             ? { "data-external-task-ref": externalTaskRef }
             : {}),
         },
-        body: cleanTags(mapRender(t.children!)),
+        body: cleanTags(
+          hasHtml
+            ? groupInlineHtml(t.children!, options, posPreservingRender)
+            : mapRender(t.children!),
+        ),
       };
     }
     case "TaskState": {


### PR DESCRIPTION
## Problem

Described in #2087.

`==text==` is rendered correctly in the editor (CodeMirror live preview) but appears as unstyled plain text in query
results.

Root cause: Markdown renderer emitted `<span class="highlight">`, but no `.highlight` CSS rule actually exists.
Editor uses `.sb-highlight`.

## Solution

1. Changed `class: "highlight"` to `class: "sb-highlight"` so `==` now works in queries.
2. Added call to `groupInlineHtml()` in `Task` renderer case similar to how `Paragraph` does it.
3. Added small unit test that checks that `Task` renders correctly with inline HTML.
