### PR TITLE
draft: feat: native OIDC authentication (authorization-code + PKCE)

### DIFF
--- a/OIDC_DESIGN.md
+++ b/OIDC_DESIGN.md
@@ -1,0 +1,98 @@
+# OIDC Integration — SilverBullet self-contained authentication
+
+This is a pure OIDC branch rebuilt on upstream `main`; it contains no
+proxy-auth implementation.
+
+## Goal
+
+SilverBullet handles its own authentication against Authentik via OIDC, so
+Traefik no longer needs ForwardAuth on every request (pure forwarding). SB:
+initiates login (302 -> Authentik authorize), exchanges the code, verifies the
+ID token via JWKS, mints its own session cookie (existing `Authenticator`), and
+authorizes per space via `members` (spaces.json). Anonymous browsing of public
+spaces stays open; private spaces require a session.
+
+## Context
+
+- The implementation is rebuilt directly on the latest upstream multi-space
+  infrastructure. No trusted-header authentication code is included.
+- Existing infrastructure reused by the implementation:
+  - `Authenticator` (self-signed JWT + cookie helpers) in
+    `server/src/auth/authenticator.rs`; cookie helpers in `auth/cookie.rs`
+    (`auth_cookie_name`, `cookie_value`, `request_host`, ...).
+  - `RequestAuthorizer` trait (`authorize(method, path, headers) ->
+    Option<AuthOutcome>`), `AuthContext`, `Actor` extension —
+    `server/src/auth/authorizer.rs`.
+  - `JwtAuthorizer` (`auth/jwt_authorizer.rs`) with `with_filter(authenticator,
+    audience, issuer, filter: Fn(&Claims) -> bool)`.
+  - `require_authorization` middleware wiring in `server/src/router.rs`.
+  - `/.profile` handler returns the Actor; front-end reads it.
+  - Front-end 401 handling in `client/spaces/http_space_primitives.ts`:
+    follows a `location` response header (redirects to it), reloads when a
+    401/403 has no header.
+
+## New env vars
+
+- `SB_OIDC_ISSUER` — issuer base URL, e.g. `https://auth.xiteng.site/application/o/wiki/`
+  (discovery document at `<issuer>/.well-known/openid-configuration`).
+- `SB_OIDC_CLIENT_ID`, `SB_OIDC_CLIENT_SECRET`.
+- `SB_OIDC_REDIRECT_URI` — e.g. `https://wiki.xiteng.site/.oidc/callback`.
+- OIDC mode activates when `SB_OIDC_ISSUER` and `SB_OIDC_CLIENT_ID` are set.
+- `SB_PROXY_ADMINS` — comma-separated OIDC administrator usernames. The name
+  is retained for deployment compatibility with the fork; a future upstream
+  discussion can rename it to `SB_OIDC_ADMINS`.
+
+## Implementation outline
+
+1. **New `server/src/auth/oidc.rs`**:
+   - `OidcConfig::from_env() -> Option<OidcConfig>` (None unless configured).
+   - Discovery fetch (reqwest; cache the document) for authorize_endpoint,
+     token_endpoint, jwks_uri, issuer.
+   - `authorize_url(return_to) -> String`: response_type=code, client_id,
+     redirect_uri, scope=openid+profile, state (HMAC-signed return path with a
+     server secret — stateless), PKCE code_challenge (S256) with code_verifier
+     kept in a short-lived signed state too (or HMAC both into state).
+   - `handle_callback(code, state) -> Result<username, OidcError>`: verify
+     state signature, PKCE verifier, POST token exchange, verify ID token
+     signature via JWKS (rsa/simple ES), check issuer/aud/exp, extract
+     `preferred_username` (fall back to `sub`).
+   - Mint an SB session JWT using the existing `Authenticator`
+     (`issue`/session API) and set the auth cookie — mirror what
+     `LoginManager` does for username+password, minus the verifier.
+2. **Routes** (in `server/src/router.rs`, alongside `/.auth`):
+   - `GET /.oidc/login?return_to=...` -> 302 to Authentik authorize.
+   - `GET /.oidc/callback?code=...&state=...` -> exchange, mint cookie,
+     302 back to the original page (from state).
+   - `GET /.oidc/logout` -> clear cookie, redirect to
+     `SB_OIDC_ISSUER`-based logout or `/`.
+3. **Space authorization** (`server/src/multi/instance.rs`, Accounts branch):
+   - OIDC mode: authorizer = `JwtAuthorizer::with_filter(authenticator, "", "",
+     filter)` where filter allows `members.contains(username)` (admins via
+     `SB_PROXY_ADMINS`). Identity comes from the SB session JWT (already
+     signed by our Authenticator). login stays None (no SB login page).
+   - Public spaces keep (None, None) -> anonymous open.
+   - Ensure the 401 path from `require_authorization` carries a
+     `location: /.oidc/login` header (or the front-end gets a
+     redirect header) so the client bounces to Authentik. Check
+     `server/src/router.rs` / `server/src/handlers/auth.rs` for where 401s
+     are built; the front-end (`http_space_primitives.ts`) already follows a
+     `location` header on 401/403.
+4. **spaces_ui** (`server/src/multi/space_index.rs`): OIDC mode verifies the
+   host-wide JWT cookie via `state.authenticator`, accepts only versionless
+   claims, and reads the administrator flag from `SB_PROXY_ADMINS`.
+5. `server/src/multi/admin_api.rs`: OIDC mode uses the same JWT-based admin
+   gate, also restricted to versionless sessions and `SB_PROXY_ADMINS`.
+
+## Tests
+
+- Unit tests for state signing/verification, authorize URL construction,
+  ID-token claim extraction (no network).
+- Full workspace build and test suites are green.
+
+## Constraints
+
+- With OIDC unset, upstream account/password behavior is unchanged.
+- `members` policy stays in spaces.json. OIDC deployments may omit users.json.
+- The implementation uses the workspace's existing `reqwest`, `jsonwebtoken`,
+  `sha2`, and `base64` dependencies; it adds no crates.
+- Trusted-header authentication is intentionally outside this branch.

--- a/bin/silverbullet/src/boot.rs
+++ b/bin/silverbullet/src/boot.rs
@@ -169,6 +169,10 @@ pub fn detect(
         // that way — `run_setup` refuses once users.json is there — so say so
         // rather than looping the operator through a wizard that will 400.
         match silverbullet_server::multi::users::UsersConfig::load(&folder.join("users.json"))? {
+            None if silverbullet_server::auth::oidc_enabled() => {
+                tracing::info!("boot mode: multi-space (OIDC enabled — users.json not needed)");
+                return Ok(BootMode::Multi);
+            }
             None => {
                 tracing::info!(
                     "boot mode: setup (spaces.json present, but no users.json — no admin yet)"
@@ -176,6 +180,12 @@ pub fn detect(
                 return Ok(BootMode::Setup);
             }
             Some(cfg) if !cfg.users.values().any(|u| u.admin) => {
+                if silverbullet_server::auth::oidc_enabled() {
+                    tracing::info!(
+                        "boot mode: multi-space (OIDC enabled — users.json admin flag ignored)"
+                    );
+                    return Ok(BootMode::Multi);
+                }
                 return Err(
                     "users.json contains no admin account, so nobody could administer this \
                      server. Set \"admin\": true on a user in users.json and restart"

--- a/bin/silverbullet/src/multi.rs
+++ b/bin/silverbullet/src/multi.rs
@@ -62,10 +62,19 @@ pub async fn build_multi_stack(
     warn_if_world_readable(&root.join("users.json"));
     warn_if_world_readable(&root.join(MULTI_AUTH_FILE_NAME));
 
-    let store = UserStore::open(&root)?.ok_or_else(|| {
-        "no users.json found: this folder is not fully provisioned, complete setup first"
-            .to_string()
-    })?;
+    let store = match UserStore::open(&root)? {
+        Some(store) => store,
+        None if silverbullet_server::auth::oidc_enabled() => {
+            tracing::info!("no users.json (OIDC mode): the OIDC provider is the identity source");
+            UserStore::empty(&root)?
+        }
+        None => {
+            return Err(
+                "no users.json found: this folder is not fully provisioned, complete setup first"
+                    .to_string(),
+            )
+        }
+    };
     let authenticator = Arc::new(
         Authenticator::load_or_init_with_stamp_named(
             &root,

--- a/server/src/auth/authenticator.rs
+++ b/server/src/auth/authenticator.rs
@@ -4,6 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use base64::Engine;
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 /// Claims carried in a session JWT.
 #[derive(Debug, Serialize, Deserialize)]
@@ -165,6 +166,18 @@ impl Authenticator {
             &Validation::new(Algorithm::HS256),
         )?;
         Ok(data.claims)
+    }
+
+    /// Derive a purpose-specific key from the persisted session secret.
+    /// Keeping the context ahead of the secret provides domain separation
+    /// without exposing or reusing the raw JWT signing key directly.
+    pub(crate) fn derive_key(&self, context: &[u8]) -> Vec<u8> {
+        let mut hash = Sha256::new();
+        hash.update(b"SilverBullet derived key\0");
+        hash.update(context);
+        hash.update([0]);
+        hash.update(&self.secret);
+        hash.finalize().to_vec()
     }
 
     /// Load the signing secret from `<space_dir>/.silverbullet.auth.json`,

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -13,6 +13,7 @@ pub mod jwt_authorizer;
 pub mod lockout;
 pub mod login;
 pub mod oauth;
+pub mod oidc;
 pub mod password;
 
 pub use authenticator::{Authenticator, AUTH_FILE_NAME, MULTI_AUTH_FILE_NAME};
@@ -28,6 +29,7 @@ pub use jwt_authorizer::JwtAuthorizer;
 pub use lockout::LockoutTimer;
 pub use login::LoginManager;
 pub use oauth::{AuthCodeStore, CodeGrant, OAuthError, CLIENT_ID};
+pub use oidc::{oidc_enabled, OidcClient, OidcConfig};
 
 /// Verifies a username/password pair against some backing credential store.
 /// Lets `LoginManager` drive either the legacy single-user `AuthConfig` or a

--- a/server/src/auth/oidc.rs
+++ b/server/src/auth/oidc.rs
@@ -1,0 +1,857 @@
+//! Self-contained OpenID Connect authorization-code flow for account-managed
+//! servers. The browser round trip is stateless: the return path, PKCE
+//! verifier, and nonce live in a short-lived HS256-signed `state` value.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Query, State};
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use jsonwebtoken::jwk::{AlgorithmParameters, Jwk, JwkSet, KeyOperations, PublicKeyUse};
+use jsonwebtoken::{
+    decode, decode_header, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::auth::authenticator::Authenticator;
+use crate::auth::cookie::{
+    auth_cookie_name, is_secure_request, request_host, set_cookie_value, CookieOptions,
+};
+use crate::auth::login::SESSION_EXPIRY_SECS;
+use crate::state::ServerState;
+
+const STATE_TTL_SECS: u64 = 10 * 60;
+const STATE_KEY_CONTEXT: &[u8] = b"oidc-state-v1";
+
+/// Environment-backed OIDC relying-party configuration.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OidcConfig {
+    pub issuer: String,
+    pub client_id: String,
+    pub client_secret: String,
+    pub redirect_uri: String,
+}
+
+impl OidcConfig {
+    /// OIDC mode activates only when both issuer and client id are non-empty.
+    /// The remaining values are checked when a login is attempted so this
+    /// method can retain the documented two-variable activation rule.
+    pub fn from_env() -> Option<Self> {
+        let issuer = nonempty_env("SB_OIDC_ISSUER")?;
+        let client_id = nonempty_env("SB_OIDC_CLIENT_ID")?;
+        Some(Self {
+            issuer,
+            client_id,
+            client_secret: std::env::var("SB_OIDC_CLIENT_SECRET").unwrap_or_default(),
+            redirect_uri: std::env::var("SB_OIDC_REDIRECT_URI")
+                .unwrap_or_default()
+                .trim()
+                .to_string(),
+        })
+    }
+}
+
+fn nonempty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// Whether the two OIDC activation variables are configured.
+pub fn oidc_enabled() -> bool {
+    nonempty_env("SB_OIDC_ISSUER").is_some() && nonempty_env("SB_OIDC_CLIENT_ID").is_some()
+}
+
+fn admin_list_contains(value: &str, username: &str) -> bool {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+        .any(|candidate| candidate == username)
+}
+
+/// Whether `username` is an OIDC administrator.
+///
+/// The `SB_PROXY_ADMINS` name is retained for deployment compatibility with
+/// the fork this implementation came from. A future upstream change can
+/// discuss renaming it to `SB_OIDC_ADMINS` separately.
+pub fn oidc_is_admin(username: &str) -> bool {
+    std::env::var("SB_PROXY_ADMINS")
+        .map(|value| admin_list_contains(&value, username))
+        .unwrap_or(false)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum OidcError {
+    #[error("invalid OIDC configuration: {0}")]
+    InvalidConfiguration(String),
+    #[error("OIDC provider request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("OIDC JWT validation failed: {0}")]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+    #[error("invalid OIDC state: {0}")]
+    InvalidState(&'static str),
+    #[error("invalid OIDC response: {0}")]
+    InvalidResponse(&'static str),
+    #[error("could not obtain secure random bytes")]
+    Random,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct DiscoveryDocument {
+    issuer: String,
+    authorization_endpoint: String,
+    token_endpoint: String,
+    jwks_uri: String,
+    #[serde(default)]
+    token_endpoint_auth_methods_supported: Vec<String>,
+    #[serde(default)]
+    end_session_endpoint: Option<String>,
+}
+
+/// OIDC client plus the existing SilverBullet session issuer. Discovery is
+/// fetched lazily and cached for the lifetime of this server state.
+pub struct OidcClient {
+    config: OidcConfig,
+    authenticator: Arc<Authenticator>,
+    state_key: Vec<u8>,
+    http: reqwest::Client,
+    discovery: tokio::sync::OnceCell<DiscoveryDocument>,
+}
+
+impl OidcClient {
+    pub fn new(config: OidcConfig, authenticator: Arc<Authenticator>) -> Self {
+        let state_key = authenticator.derive_key(STATE_KEY_CONTEXT);
+        Self {
+            config,
+            authenticator,
+            state_key,
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+            discovery: tokio::sync::OnceCell::new(),
+        }
+    }
+
+    async fn discovery(&self) -> Result<&DiscoveryDocument, OidcError> {
+        self.discovery
+            .get_or_try_init(|| async {
+                let url = format!(
+                    "{}/.well-known/openid-configuration",
+                    self.config.issuer.trim_end_matches('/')
+                );
+                let document = self
+                    .http
+                    .get(url)
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .json::<DiscoveryDocument>()
+                    .await?;
+                if canonical_issuer(&document.issuer) != canonical_issuer(&self.config.issuer) {
+                    return Err(OidcError::InvalidConfiguration(
+                        "discovery issuer does not match SB_OIDC_ISSUER".to_string(),
+                    ));
+                }
+                validate_endpoint("authorization_endpoint", &document.authorization_endpoint)?;
+                validate_endpoint("token_endpoint", &document.token_endpoint)?;
+                validate_endpoint("jwks_uri", &document.jwks_uri)?;
+                if let Some(endpoint) = document.end_session_endpoint.as_deref() {
+                    validate_endpoint("end_session_endpoint", endpoint)?;
+                }
+                Ok(document)
+            })
+            .await
+    }
+
+    /// Build the provider authorization URL after cached discovery.
+    pub async fn authorize_url(&self, return_to: &str) -> Result<String, OidcError> {
+        self.validate_login_config()?;
+        let discovery = self.discovery().await?;
+        let verifier = random_urlsafe(32)?;
+        let nonce = random_urlsafe(24)?;
+        let challenge = pkce_challenge(&verifier);
+        let state = self.sign_state(
+            &safe_return_to(return_to),
+            &verifier,
+            &nonce,
+            now_secs().saturating_add(STATE_TTL_SECS),
+        )?;
+        self.build_authorize_url(
+            &discovery.authorization_endpoint,
+            &state,
+            &challenge,
+            &nonce,
+        )
+    }
+
+    fn validate_login_config(&self) -> Result<(), OidcError> {
+        if self.config.redirect_uri.is_empty() {
+            return Err(OidcError::InvalidConfiguration(
+                "SB_OIDC_REDIRECT_URI is required".to_string(),
+            ));
+        }
+        validate_endpoint("SB_OIDC_REDIRECT_URI", &self.config.redirect_uri)
+    }
+
+    fn build_authorize_url(
+        &self,
+        authorization_endpoint: &str,
+        state: &str,
+        challenge: &str,
+        nonce: &str,
+    ) -> Result<String, OidcError> {
+        let mut url = reqwest::Url::parse(authorization_endpoint).map_err(|error| {
+            OidcError::InvalidConfiguration(format!("invalid authorization_endpoint: {error}"))
+        })?;
+        url.query_pairs_mut()
+            .append_pair("response_type", "code")
+            .append_pair("client_id", &self.config.client_id)
+            .append_pair("redirect_uri", &self.config.redirect_uri)
+            .append_pair("scope", "openid profile")
+            .append_pair("state", state)
+            .append_pair("code_challenge", challenge)
+            .append_pair("code_challenge_method", "S256")
+            .append_pair("nonce", nonce);
+        Ok(url.into())
+    }
+
+    fn sign_state(
+        &self,
+        return_to: &str,
+        code_verifier: &str,
+        nonce: &str,
+        exp: u64,
+    ) -> Result<String, OidcError> {
+        let claims = StateClaims {
+            return_to: safe_return_to(return_to),
+            code_verifier: code_verifier.to_string(),
+            nonce: nonce.to_string(),
+            exp: exp as usize,
+        };
+        Ok(encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(&self.state_key),
+        )?)
+    }
+
+    fn verify_state(&self, state: &str) -> Result<StateClaims, OidcError> {
+        let claims = decode::<StateClaims>(
+            state,
+            &DecodingKey::from_secret(&self.state_key),
+            &Validation::new(Algorithm::HS256),
+        )?
+        .claims;
+        if safe_return_to(&claims.return_to) != claims.return_to {
+            return Err(OidcError::InvalidState("invalid return path"));
+        }
+        if !valid_pkce_verifier(&claims.code_verifier) {
+            return Err(OidcError::InvalidState("invalid PKCE verifier"));
+        }
+        if claims.nonce.is_empty() || claims.nonce.len() > 256 {
+            return Err(OidcError::InvalidState("invalid nonce"));
+        }
+        Ok(claims)
+    }
+
+    /// Verify state, exchange the authorization code, and validate the signed
+    /// ID token against the provider's JWKS.
+    pub async fn handle_callback(
+        &self,
+        code: &str,
+        state: &str,
+    ) -> Result<OidcCallback, OidcError> {
+        self.validate_login_config()?;
+        if code.is_empty() {
+            return Err(OidcError::InvalidResponse("authorization code is empty"));
+        }
+        let state = self.verify_state(state)?;
+        let discovery = self.discovery().await?;
+        let id_token = self
+            .exchange_code(code, &state.code_verifier, discovery)
+            .await?;
+        let username = self
+            .verify_id_token(&id_token, &state.nonce, discovery)
+            .await?;
+        Ok(OidcCallback {
+            username,
+            return_to: state.return_to,
+        })
+    }
+
+    async fn exchange_code(
+        &self,
+        code: &str,
+        verifier: &str,
+        discovery: &DiscoveryDocument,
+    ) -> Result<String, OidcError> {
+        let mut form = vec![
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", self.config.redirect_uri.as_str()),
+            ("code_verifier", verifier),
+        ];
+
+        let use_secret_post = !self.config.client_secret.is_empty()
+            && discovery
+                .token_endpoint_auth_methods_supported
+                .iter()
+                .any(|method| method == "client_secret_post")
+            && !discovery
+                .token_endpoint_auth_methods_supported
+                .iter()
+                .any(|method| method == "client_secret_basic");
+
+        let mut request = self.http.post(&discovery.token_endpoint);
+        if self.config.client_secret.is_empty() {
+            form.push(("client_id", self.config.client_id.as_str()));
+        } else if use_secret_post {
+            form.push(("client_id", self.config.client_id.as_str()));
+            form.push(("client_secret", self.config.client_secret.as_str()));
+        } else {
+            request = request.basic_auth(&self.config.client_id, Some(&self.config.client_secret));
+        }
+
+        let token = request
+            .form(&form)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<TokenResponse>()
+            .await?;
+        if token.id_token.is_empty() {
+            return Err(OidcError::InvalidResponse(
+                "token response did not contain an ID token",
+            ));
+        }
+        Ok(token.id_token)
+    }
+
+    async fn verify_id_token(
+        &self,
+        id_token: &str,
+        expected_nonce: &str,
+        discovery: &DiscoveryDocument,
+    ) -> Result<String, OidcError> {
+        let header = decode_header(id_token)?;
+        if !supported_signature_algorithm(header.alg) {
+            return Err(OidcError::InvalidResponse(
+                "unsupported ID-token signing algorithm",
+            ));
+        }
+
+        let jwks = self
+            .http
+            .get(&discovery.jwks_uri)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<JwkSet>()
+            .await?;
+        let jwk = select_jwk(&jwks, header.kid.as_deref(), header.alg)?;
+        let key = DecodingKey::from_jwk(jwk)?;
+        let mut validation = Validation::new(header.alg);
+        validation.set_audience(&[self.config.client_id.as_str()]);
+        validation.set_issuer(&[discovery.issuer.as_str()]);
+        validation.set_required_spec_claims(&["exp", "iss", "aud", "sub"]);
+        let claims = decode::<IdTokenClaims>(id_token, &key, &validation)?.claims;
+
+        let Some(nonce) = claims.nonce.as_deref() else {
+            return Err(OidcError::InvalidResponse("ID token omitted nonce"));
+        };
+        if !crate::auth::config::constant_time_eq(nonce.as_bytes(), expected_nonce.as_bytes()) {
+            return Err(OidcError::InvalidResponse("ID-token nonce mismatch"));
+        }
+        if (claims.aud.len() > 1 || claims.azp.is_some())
+            && claims.azp.as_deref() != Some(self.config.client_id.as_str())
+        {
+            return Err(OidcError::InvalidResponse(
+                "ID-token authorized party mismatch",
+            ));
+        }
+        username_from_claims(&claims)
+    }
+
+    /// Mint the ordinary host-wide SilverBullet session used by
+    /// `JwtAuthorizer` after OIDC authentication succeeds.
+    pub fn issue_session(&self, username: &str) -> Result<(String, u64), OidcError> {
+        let jwt = self
+            .authenticator
+            .issue_jwt(username, SESSION_EXPIRY_SECS)?;
+        Ok((jwt, SESSION_EXPIRY_SECS))
+    }
+
+    async fn logout_url(&self) -> String {
+        if let Ok(discovery) = self.discovery().await {
+            if let Some(endpoint) = discovery.end_session_endpoint.as_ref() {
+                return endpoint.clone();
+            }
+        }
+        let candidate = format!("{}/end-session/", self.config.issuer.trim_end_matches('/'));
+        reqwest::Url::parse(&candidate)
+            .map(String::from)
+            .unwrap_or_else(|_| "/".to_string())
+    }
+}
+
+pub struct OidcCallback {
+    pub username: String,
+    pub return_to: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct StateClaims {
+    return_to: String,
+    code_verifier: String,
+    nonce: String,
+    exp: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    id_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct IdTokenClaims {
+    sub: String,
+    #[serde(default)]
+    preferred_username: Option<String>,
+    aud: IdTokenAudience,
+    #[serde(default)]
+    azp: Option<String>,
+    #[serde(default)]
+    nonce: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum IdTokenAudience {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl IdTokenAudience {
+    fn len(&self) -> usize {
+        match self {
+            Self::One(value) => usize::from(!value.is_empty()),
+            Self::Many(values) => values.len(),
+        }
+    }
+}
+
+fn username_from_claims(claims: &IdTokenClaims) -> Result<String, OidcError> {
+    let candidate = claims
+        .preferred_username
+        .as_deref()
+        .map(str::trim)
+        .filter(|username| !username.is_empty())
+        .unwrap_or_else(|| claims.sub.trim());
+    if candidate.is_empty() || candidate.len() > 256 || candidate.chars().any(char::is_control) {
+        return Err(OidcError::InvalidResponse(
+            "ID token did not contain a usable username",
+        ));
+    }
+    Ok(candidate.to_string())
+}
+
+fn canonical_issuer(issuer: &str) -> &str {
+    issuer.trim().trim_end_matches('/')
+}
+
+fn validate_endpoint(name: &str, value: &str) -> Result<(), OidcError> {
+    let url = reqwest::Url::parse(value)
+        .map_err(|error| OidcError::InvalidConfiguration(format!("invalid {name}: {error}")))?;
+    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+        return Err(OidcError::InvalidConfiguration(format!(
+            "{name} must be an absolute HTTP(S) URL"
+        )));
+    }
+    Ok(())
+}
+
+fn random_urlsafe(bytes: usize) -> Result<String, OidcError> {
+    let mut value = vec![0u8; bytes];
+    getrandom::getrandom(&mut value).map_err(|_| OidcError::Random)?;
+    Ok(URL_SAFE_NO_PAD.encode(value))
+}
+
+fn pkce_challenge(verifier: &str) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()))
+}
+
+fn valid_pkce_verifier(verifier: &str) -> bool {
+    (43..=128).contains(&verifier.len())
+        && verifier
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~'))
+}
+
+fn safe_return_to(value: &str) -> String {
+    let safe = value.len() <= 4096
+        && value.starts_with('/')
+        && !value.starts_with("//")
+        && !value.starts_with("/\\")
+        && !value.contains('\\')
+        && !value.chars().any(char::is_control)
+        && value.parse::<axum::http::Uri>().is_ok_and(|uri| {
+            uri.scheme().is_none() && uri.authority().is_none() && uri.path().starts_with('/')
+        });
+    if safe {
+        value.to_string()
+    } else {
+        "/".to_string()
+    }
+}
+
+fn supported_signature_algorithm(algorithm: Algorithm) -> bool {
+    matches!(
+        algorithm,
+        Algorithm::RS256
+            | Algorithm::RS384
+            | Algorithm::RS512
+            | Algorithm::PS256
+            | Algorithm::PS384
+            | Algorithm::PS512
+            | Algorithm::ES256
+            | Algorithm::ES384
+    )
+}
+
+fn select_jwk<'a>(
+    set: &'a JwkSet,
+    kid: Option<&str>,
+    algorithm: Algorithm,
+) -> Result<&'a Jwk, OidcError> {
+    if let Some(kid) = kid {
+        return set
+            .keys
+            .iter()
+            .find(|key| key.common.key_id.as_deref() == Some(kid) && jwk_usable(key, algorithm))
+            .ok_or(OidcError::InvalidResponse(
+                "no matching ID-token verification key",
+            ));
+    }
+
+    let mut candidates = set.keys.iter().filter(|key| jwk_usable(key, algorithm));
+    let Some(key) = candidates.next() else {
+        return Err(OidcError::InvalidResponse(
+            "no usable ID-token verification key",
+        ));
+    };
+    if candidates.next().is_some() {
+        return Err(OidcError::InvalidResponse(
+            "ID token omitted key id with multiple usable keys",
+        ));
+    }
+    Ok(key)
+}
+
+fn jwk_usable(key: &Jwk, algorithm: Algorithm) -> bool {
+    if key.common.public_key_use == Some(PublicKeyUse::Encryption) {
+        return false;
+    }
+    if key
+        .common
+        .key_operations
+        .as_ref()
+        .is_some_and(|ops| !ops.contains(&KeyOperations::Verify))
+    {
+        return false;
+    }
+    if key
+        .common
+        .key_algorithm
+        .is_some_and(|key_alg| key_alg.to_string() != format!("{algorithm:?}"))
+    {
+        return false;
+    }
+    matches!(
+        (&key.algorithm, algorithm),
+        (
+            AlgorithmParameters::RSA(_),
+            Algorithm::RS256
+                | Algorithm::RS384
+                | Algorithm::RS512
+                | Algorithm::PS256
+                | Algorithm::PS384
+                | Algorithm::PS512
+        ) | (
+            AlgorithmParameters::EllipticCurve(_),
+            Algorithm::ES256 | Algorithm::ES384
+        )
+    )
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+/// Relative login URL used by the authorization middleware's 401 response.
+pub(crate) fn login_location(host_prefix: &str, return_to: &str) -> String {
+    let return_to = safe_return_to(return_to);
+    let encoded =
+        percent_encoding::utf8_percent_encode(&return_to, percent_encoding::NON_ALPHANUMERIC);
+    format!("{host_prefix}/.oidc/login?return_to={encoded}")
+}
+
+#[derive(Default, Deserialize)]
+pub struct LoginQuery {
+    #[serde(default)]
+    return_to: String,
+}
+
+#[derive(Default, Deserialize)]
+pub struct CallbackQuery {
+    code: Option<String>,
+    state: Option<String>,
+    error: Option<String>,
+}
+
+/// `GET /.oidc/login` — discover the provider and begin code+PKCE.
+pub async fn handle_login(
+    State(state): State<Arc<ServerState>>,
+    Query(query): Query<LoginQuery>,
+) -> Response {
+    let Some(oidc) = state.oidc.as_ref() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    match oidc.authorize_url(&query.return_to).await {
+        Ok(location) => redirect_response(location),
+        Err(error) => {
+            tracing::error!("could not start OIDC login: {error}");
+            (StatusCode::BAD_GATEWAY, "OIDC provider unavailable").into_response()
+        }
+    }
+}
+
+/// `GET /.oidc/callback` — exchange and verify, then mint an SB cookie.
+pub async fn handle_callback(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Query(query): Query<CallbackQuery>,
+) -> Response {
+    let Some(oidc) = state.oidc.as_ref() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    if query.error.is_some() {
+        return (StatusCode::UNAUTHORIZED, "OIDC authorization was denied").into_response();
+    }
+    let (Some(code), Some(signed_state)) = (query.code.as_deref(), query.state.as_deref()) else {
+        return (StatusCode::BAD_REQUEST, "Missing OIDC callback parameters").into_response();
+    };
+
+    let callback = match oidc.handle_callback(code, signed_state).await {
+        Ok(callback) => callback,
+        Err(error) => {
+            tracing::warn!("OIDC callback rejected: {error}");
+            return (StatusCode::UNAUTHORIZED, "OIDC callback rejected").into_response();
+        }
+    };
+    let (jwt, max_age) = match oidc.issue_session(&callback.username) {
+        Ok(session) => session,
+        Err(error) => {
+            tracing::error!("failed to mint OIDC session: {error}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    let options = CookieOptions {
+        path: "/".to_string(),
+        max_age_secs: Some(max_age as i64),
+        http_only: true,
+        secure: is_secure_request(&headers),
+        same_site: "Lax",
+    };
+    let mut response = redirect_response(callback.return_to);
+    append_session_cookie(&mut response, &headers, &jwt, &options);
+    response
+}
+
+/// `GET /.oidc/logout` — clear the host-wide SB session, then send the
+/// browser through the provider's RP-initiated logout endpoint when present.
+pub async fn handle_logout(State(state): State<Arc<ServerState>>, headers: HeaderMap) -> Response {
+    let Some(oidc) = state.oidc.as_ref() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let options = CookieOptions {
+        path: "/".to_string(),
+        max_age_secs: Some(0),
+        http_only: true,
+        secure: is_secure_request(&headers),
+        same_site: "Lax",
+    };
+    let mut response = redirect_response(oidc.logout_url().await);
+    append_session_cookie(&mut response, &headers, "", &options);
+    response
+}
+
+fn redirect_response(location: String) -> Response {
+    let Ok(location) = HeaderValue::from_str(&location) else {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    };
+    let mut response = StatusCode::FOUND.into_response();
+    response.headers_mut().insert(header::LOCATION, location);
+    response
+}
+
+fn append_session_cookie(
+    response: &mut Response,
+    headers: &HeaderMap,
+    value: &str,
+    options: &CookieOptions,
+) {
+    let name = auth_cookie_name(&request_host(headers));
+    let cookie = set_cookie_value(&name, value, options);
+    if let Ok(cookie) = HeaderValue::from_str(&cookie) {
+        response.headers_mut().append(header::SET_COOKIE, cookie);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_client(secret: u8) -> OidcClient {
+        OidcClient::new(
+            OidcConfig {
+                issuer: "https://id.example/application/o/wiki/".to_string(),
+                client_id: "silverbullet".to_string(),
+                client_secret: "secret".to_string(),
+                redirect_uri: "https://wiki.example/.oidc/callback".to_string(),
+            },
+            Arc::new(Authenticator::from_secret_bytes(
+                vec![secret; 32],
+                "test".to_string(),
+            )),
+        )
+    }
+
+    #[test]
+    fn signed_state_round_trips_and_rejects_wrong_secret() {
+        let client = test_client(1);
+        let verifier = URL_SAFE_NO_PAD.encode([7u8; 32]);
+        let state = client
+            .sign_state(
+                "/notes/today?mode=edit",
+                &verifier,
+                "nonce-1",
+                now_secs() + 300,
+            )
+            .unwrap();
+        let claims = client.verify_state(&state).unwrap();
+        assert_eq!(claims.return_to, "/notes/today?mode=edit");
+        assert_eq!(claims.code_verifier, verifier);
+        assert_eq!(claims.nonce, "nonce-1");
+        assert!(test_client(2).verify_state(&state).is_err());
+    }
+
+    #[test]
+    fn signed_state_rejects_expiry_and_external_return_paths() {
+        let client = test_client(1);
+        let verifier = URL_SAFE_NO_PAD.encode([8u8; 32]);
+        let expired = client.sign_state("/", &verifier, "nonce", 1).unwrap();
+        assert!(client.verify_state(&expired).is_err());
+        assert_eq!(safe_return_to("https://evil.example/"), "/");
+        assert_eq!(safe_return_to("//evil.example/"), "/");
+        assert_eq!(safe_return_to("/safe/path?q=1"), "/safe/path?q=1");
+    }
+
+    #[test]
+    fn authorization_url_contains_code_pkce_and_oidc_parameters() {
+        let client = test_client(1);
+        let url = client
+            .build_authorize_url(
+                "https://id.example/authorize",
+                "signed-state",
+                "pkce-challenge",
+                "nonce-1",
+            )
+            .unwrap();
+        let url = reqwest::Url::parse(&url).unwrap();
+        let query: std::collections::BTreeMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(
+            url.as_str().split('?').next(),
+            Some("https://id.example/authorize")
+        );
+        assert_eq!(query.get("response_type").map(String::as_str), Some("code"));
+        assert_eq!(
+            query.get("client_id").map(String::as_str),
+            Some("silverbullet")
+        );
+        assert_eq!(
+            query.get("redirect_uri").map(String::as_str),
+            Some("https://wiki.example/.oidc/callback")
+        );
+        assert_eq!(
+            query.get("scope").map(String::as_str),
+            Some("openid profile")
+        );
+        assert_eq!(query.get("state").map(String::as_str), Some("signed-state"));
+        assert_eq!(
+            query.get("code_challenge").map(String::as_str),
+            Some("pkce-challenge")
+        );
+        assert_eq!(
+            query.get("code_challenge_method").map(String::as_str),
+            Some("S256")
+        );
+        assert_eq!(query.get("nonce").map(String::as_str), Some("nonce-1"));
+    }
+
+    #[test]
+    fn pkce_uses_s256() {
+        assert_eq!(
+            pkce_challenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        );
+    }
+
+    #[test]
+    fn preferred_username_falls_back_to_subject() {
+        let claims = |preferred_username: Option<&str>, sub: &str| IdTokenClaims {
+            sub: sub.to_string(),
+            preferred_username: preferred_username.map(str::to_string),
+            aud: IdTokenAudience::One("silverbullet".to_string()),
+            azp: None,
+            nonce: Some("nonce".to_string()),
+        };
+        assert_eq!(
+            username_from_claims(&claims(Some(" alice "), "subject-1")).unwrap(),
+            "alice"
+        );
+        assert_eq!(
+            username_from_claims(&claims(Some(" "), "subject-1")).unwrap(),
+            "subject-1"
+        );
+        assert!(username_from_claims(&claims(None, "")).is_err());
+    }
+
+    #[test]
+    fn login_location_keeps_return_path_local() {
+        assert_eq!(
+            login_location("", "/work/.config?x=1"),
+            "/.oidc/login?return_to=%2Fwork%2F%2Econfig%3Fx%3D1"
+        );
+        assert_eq!(
+            login_location("/work", "https://evil.example"),
+            "/work/.oidc/login?return_to=%2F"
+        );
+    }
+
+    #[test]
+    fn historical_admin_list_is_trimmed_and_exact() {
+        assert!(admin_list_contains("alice, root ,bob", "root"));
+        assert!(!admin_list_contains("alice, root ,bob", "roo"));
+        assert!(!admin_list_contains("alice,,bob", ""));
+    }
+}

--- a/server/src/handlers/bundle.rs
+++ b/server/src/handlers/bundle.rs
@@ -118,6 +118,28 @@ pub async fn handle_client_bundle(
     // the client's `/.config` fetch triggers the redirect instead.
     if !authorized && !path.is_empty() {
         let prefix = &state.host_url_prefix;
+        if state.oidc.is_some() {
+            let mut return_to = format!("{prefix}{}", req.uri().path());
+            if let Some(query) = req.uri().query() {
+                return_to.push('?');
+                return_to.push_str(query);
+            }
+            let location = crate::auth::oidc::login_location(prefix, &return_to);
+            let status = if path.ends_with(".md") {
+                StatusCode::UNAUTHORIZED
+            } else {
+                StatusCode::FOUND
+            };
+            return Response::builder()
+                .status(status)
+                .header(axum::http::header::LOCATION, location)
+                .body(if status == StatusCode::UNAUTHORIZED {
+                    Body::from("Unauthorized")
+                } else {
+                    Body::empty()
+                })
+                .unwrap();
+        }
         if path.ends_with(".md") {
             return Response::builder()
                 .status(StatusCode::UNAUTHORIZED)
@@ -269,6 +291,26 @@ mod tests {
         Arc::new(s)
     }
 
+    fn oidc_gated_state() -> Arc<ServerState> {
+        let mut s = test_state();
+        s.authorizer = Some(Arc::new(Deny));
+        let authenticator = Arc::new(crate::auth::Authenticator::from_secret_bytes(
+            vec![1; 32],
+            "test".into(),
+        ));
+        s.oidc = Some(Arc::new(crate::auth::OidcClient::new(
+            crate::auth::OidcConfig {
+                issuer: "https://id.example/application/o/wiki/".into(),
+                client_id: "silverbullet".into(),
+                client_secret: "secret".into(),
+                redirect_uri: "https://wiki.example/.oidc/callback".into(),
+            },
+            authenticator,
+        )));
+        seed_bundle(&s, ".client/index.html", INDEX_TPL);
+        Arc::new(s)
+    }
+
     #[tokio::test]
     async fn unauthenticated_page_navigation_redirects_to_auth() {
         let resp = crate::build_router(gated_state())
@@ -300,6 +342,39 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
         assert_eq!(resp.headers().get("location").unwrap(), "/.auth");
+    }
+
+    #[tokio::test]
+    async fn oidc_page_and_markdown_navigation_use_the_oidc_login() {
+        let page = crate::build_router(oidc_gated_state())
+            .oneshot(
+                Request::builder()
+                    .uri("/SomePage?mode=edit")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.status(), StatusCode::FOUND);
+        assert_eq!(
+            page.headers().get("location").unwrap(),
+            "/.oidc/login?return_to=%2FSomePage%3Fmode%3Dedit"
+        );
+
+        let markdown = crate::build_router(oidc_gated_state())
+            .oneshot(
+                Request::builder()
+                    .uri("/Page.md")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(markdown.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            markdown.headers().get("location").unwrap(),
+            "/.oidc/login?return_to=%2FPage%2Emd"
+        );
     }
 
     #[tokio::test]

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -58,6 +58,7 @@ mod test_support {
             space_description: "Powerful and programmable note taking app".into(),
             authorizer: None,
             login: None,
+            oidc: None,
             shell: crate::shell::ShellConfig {
                 enabled: true,
                 whitelist: vec![],

--- a/server/src/multi/admin_api.rs
+++ b/server/src/multi/admin_api.rs
@@ -33,6 +33,13 @@ pub struct AdminState {
     pub runtime_availability: crate::runtime::RuntimeAvailability,
 }
 
+fn oidc_admin_claims_allowed(
+    claims: &crate::auth::authenticator::Claims,
+    is_admin: impl Fn(&str) -> bool,
+) -> bool {
+    claims.credential_version.is_none() && is_admin(&claims.username)
+}
+
 impl AdminState {
     /// Uses the same server-wide authenticator as every space. Sessions are
     /// minted by the unified `/.spaces` surface; this state only *authorizes*,
@@ -44,6 +51,31 @@ impl AdminState {
         authenticator: Arc<Authenticator>,
         runtime_availability: crate::runtime::RuntimeAvailability,
     ) -> Self {
+        if crate::auth::oidc_enabled() {
+            let authorizer: Arc<dyn RequestAuthorizer> = Arc::new(JwtAuthorizer::with_filter(
+                authenticator.clone(),
+                String::new(),
+                String::new(),
+                Box::new(|claims| {
+                    oidc_admin_claims_allowed(claims, crate::auth::oidc::oidc_is_admin)
+                }),
+            ));
+            let account_authorizer: Arc<dyn RequestAuthorizer> =
+                Arc::new(JwtAuthorizer::with_filter(
+                    authenticator,
+                    String::new(),
+                    String::new(),
+                    Box::new(|claims| claims.credential_version.is_none()),
+                ));
+            return Self {
+                manager,
+                authorizer,
+                account_authorizer,
+                users,
+                runtime_availability,
+            };
+        }
+
         let is_admin_token = {
             let store = users.clone();
             move |u: &str| store.is_admin(u)
@@ -617,6 +649,28 @@ mod tests {
 
     fn test_authenticator() -> Arc<Authenticator> {
         Arc::new(Authenticator::from_secret_bytes(vec![9; 32], "v1".into()))
+    }
+
+    #[test]
+    fn oidc_admin_gate_requires_a_versionless_admin_session() {
+        let claims =
+            |username: &str, credential_version: Option<&str>| crate::auth::authenticator::Claims {
+                username: username.to_string(),
+                credential_version: credential_version.map(str::to_string),
+                token_use: None,
+                exp: usize::MAX,
+            };
+        let is_admin = |username: &str| username == "root";
+
+        assert!(oidc_admin_claims_allowed(&claims("root", None), is_admin));
+        assert!(!oidc_admin_claims_allowed(
+            &claims("root", Some("password-version")),
+            is_admin
+        ));
+        assert!(!oidc_admin_claims_allowed(
+            &claims("member", None),
+            is_admin
+        ));
     }
 
     fn deps(

--- a/server/src/multi/instance.rs
+++ b/server/src/multi/instance.rs
@@ -14,7 +14,7 @@ use silverbullet_server_common::{BootConfig, FileMeta, SpaceError, SpacePrimitiv
 
 use crate::auth::{
     headless_cookie_name, AuthConfig, Authenticator, HeadlessTokenAuthorizer, JwtAuthorizer,
-    LockoutTimer, LoginManager, RequestAuthorizer,
+    LockoutTimer, LoginManager, OidcClient, OidcConfig, RequestAuthorizer,
 };
 use crate::multi::access::{SessionPolicy, SpaceUsersAuth, UserTokenAuthorizer};
 use crate::multi::config::{Binding, SpaceConfig};
@@ -339,6 +339,19 @@ fn member_name_filter(
     Box::new(move |username| store.is_admin(username) || members.contains(username))
 }
 
+fn oidc_claims_filter(
+    members: BTreeSet<String>,
+) -> Box<dyn Fn(&crate::auth::authenticator::Claims) -> bool + Send + Sync> {
+    Box::new(move |claims| {
+        // OIDC sessions are deliberately versionless. Account-password
+        // sessions carry a credential version and must not become an
+        // alternate way around the configured identity provider.
+        claims.credential_version.is_none()
+            && (members.contains(&claims.username)
+                || crate::auth::oidc::oidc_is_admin(&claims.username))
+    })
+}
+
 pub fn build_instance(id: &str, config: &SpaceConfig, deps: &InstanceDeps) -> SpaceInstance {
     let prefix = match &config.binding {
         Binding::Prefix { prefix } => normalize_prefix(prefix),
@@ -400,12 +413,26 @@ fn try_build_state(
     // admin-or-member authorization policy.
     let headless_token = generate_token();
     let members: BTreeSet<String> = config.members.keys().cloned().collect();
+    let oidc = match &deps.auth {
+        InstanceAuth::Accounts { authenticator, .. } => OidcConfig::from_env()
+            .map(|config| Arc::new(OidcClient::new(config, authenticator.clone()))),
+        InstanceAuth::Single(_) => None,
+    };
     let (authorizer, login): AuthPair = match &deps.auth {
         InstanceAuth::Single(None) => (None, None),
         InstanceAuth::Single(Some(config)) => {
             build_env_style_auth(id, &folder, prefix, config, &headless_token)?
         }
         InstanceAuth::Accounts { .. } if config.public => (None, None),
+        InstanceAuth::Accounts { authenticator, .. } if oidc.is_some() => (
+            Some(Arc::new(JwtAuthorizer::with_filter(
+                authenticator.clone(),
+                String::new(),
+                String::new(),
+                oidc_claims_filter(members.clone()),
+            ))),
+            None,
+        ),
         InstanceAuth::Accounts {
             users: store,
             authenticator,
@@ -518,6 +545,7 @@ fn try_build_state(
         space_description: config.description.clone(),
         authorizer,
         login,
+        oidc,
         shell: ShellConfig {
             enabled: shell_enabled,
             whitelist: config.shell.whitelist.clone(),
@@ -585,6 +613,22 @@ mod tests {
             revisions: Default::default(),
             extra: Default::default(),
         }
+    }
+
+    #[test]
+    fn oidc_filter_accepts_only_versionless_member_sessions() {
+        let filter = oidc_claims_filter(["alice".to_string()].into_iter().collect());
+        let claims =
+            |username: &str, credential_version: Option<&str>| crate::auth::authenticator::Claims {
+                username: username.to_string(),
+                credential_version: credential_version.map(str::to_string),
+                token_use: None,
+                exp: usize::MAX,
+            };
+
+        assert!(filter(&claims("alice", None)));
+        assert!(!filter(&claims("alice", Some("password-version"))));
+        assert!(!filter(&claims("eve", None)));
     }
 
     #[test]

--- a/server/src/multi/space_index.rs
+++ b/server/src/multi/space_index.rs
@@ -33,6 +33,7 @@ pub struct SpaceIndexState {
     authenticator: Arc<Authenticator>,
     users: Arc<UserStore>,
     client_bundle: Box<dyn SpacePrimitives>,
+    oidc_enabled: bool,
 }
 
 impl SpaceIndexState {
@@ -79,6 +80,7 @@ impl SpaceIndexState {
             authenticator,
             users,
             client_bundle,
+            oidc_enabled: crate::auth::oidc_enabled(),
         }
     }
 }
@@ -152,10 +154,26 @@ fn current_username(state: &SpaceIndexState, headers: &HeaderMap) -> Option<Stri
     let name = scoped_auth_cookie_name(&request_host(headers), "");
     let token = cookie_value(headers, &name)?;
     let claims = state.authenticator.verify_jwt(&token).ok()?;
+    if state.oidc_enabled {
+        // OIDC sessions are versionless. Reject account-password sessions so
+        // they cannot become an alternate path around the identity provider.
+        return claims
+            .credential_version
+            .is_none()
+            .then_some(claims.username);
+    }
     state
         .users
         .session_is_current(&claims.username, claims.credential_version.as_deref())
         .then_some(claims.username)
+}
+
+fn current_user_is_admin(state: &SpaceIndexState, username: &str) -> bool {
+    if state.oidc_enabled {
+        crate::auth::oidc::oidc_is_admin(username)
+    } else {
+        state.users.is_admin(username)
+    }
 }
 
 /// Any *account* — not public. The client reads `admin` from here to decide
@@ -165,7 +183,7 @@ async fn handle_session(State(state): State<Arc<SpaceIndexState>>, headers: Head
     let Some(username) = current_username(&state, &headers) else {
         return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
     };
-    let admin = state.users.is_admin(&username);
+    let admin = current_user_is_admin(&state, &username);
     Json(json!({ "username": username, "admin": admin })).into_response()
 }
 
@@ -188,7 +206,7 @@ async fn handle_get_profile(
     let profile = state.users.profile(&username).unwrap_or_default();
     Json(json!({
         "username": username,
-        "admin": state.users.is_admin(&username),
+        "admin": current_user_is_admin(&state, &username),
         "fullName": profile.full_name,
         "email": profile.email,
     }))
@@ -229,11 +247,22 @@ async fn handle_list(State(state): State<Arc<SpaceIndexState>>, headers: HeaderM
     let Some(username) = current_username(&state, &headers) else {
         return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
     };
-    let admin = state.users.is_admin(&username);
+    let admin = current_user_is_admin(&state, &username);
     Json(state.manager.list_accessible(&username, admin)).into_response()
 }
 
-async fn handle_shell(State(state): State<Arc<SpaceIndexState>>) -> Response {
+async fn handle_shell(
+    State(state): State<Arc<SpaceIndexState>>,
+    axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+    headers: HeaderMap,
+) -> Response {
+    // In OIDC mode the spaces manager is a logged-in surface. Serving its
+    // anonymous shell would expose a password form whose versioned session is
+    // intentionally rejected in this mode.
+    if state.oidc_enabled && current_username(&state, &headers).is_none() {
+        let location = crate::auth::oidc::login_location("", uri.path());
+        return (StatusCode::FOUND, [(header::LOCATION, location)]).into_response();
+    }
     let bundle = state.clone();
     match run_blocking(move || bundle.client_bundle.read_file(".client/spaces.html")).await {
         Ok((data, _)) => ([(header::CONTENT_TYPE, "text/html")], data).into_response(),
@@ -343,6 +372,14 @@ mod tests {
     }
 
     fn setup_with(session: SessionPolicy) -> (tempfile::TempDir, Router) {
+        let (dir, router, _) = setup_with_mode(session, false);
+        (dir, router)
+    }
+
+    fn setup_with_mode(
+        session: SessionPolicy,
+        oidc_enabled: bool,
+    ) -> (tempfile::TempDir, Router, Arc<Authenticator>) {
         let dir = tempfile::tempdir().unwrap();
         let users = UserStore::create_empty(dir.path()).unwrap();
         users
@@ -400,19 +437,22 @@ mod tests {
             authenticator.clone(),
             crate::runtime::RuntimeAvailability::Available,
         ));
-        let state = Arc::new(SpaceIndexState::new(
+        let mut state = SpaceIndexState::new(
             manager,
             users,
-            authenticator,
+            authenticator.clone(),
             session,
             Box::new(bundle),
-        ));
+        );
+        state.oidc_enabled = oidc_enabled;
+        let state = Arc::new(state);
         (
             dir,
             build_spaces_router(
                 state,
                 crate::multi::admin_api::build_admin_api_router(admin_state),
             ),
+            authenticator,
         )
     }
 
@@ -481,6 +521,73 @@ mod tests {
             StatusCode::OK
         );
         assert_eq!(list(&router, None).await.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn oidc_current_username_accepts_only_versionless_sessions() {
+        let (_dir, router, authenticator) = setup_with_mode(SessionPolicy::default(), true);
+        let versionless = authenticator.issue_jwt("alice", 3600).unwrap();
+        let response = send(
+            &router,
+            Request::builder()
+                .uri("/api/session")
+                .header("host", "localhost")
+                .header("cookie", format!("auth_localhost={versionless}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(json_body(response).await["username"], "alice");
+
+        let versioned = authenticator
+            .issue_jwt_with_version("alice", "password-version".into(), 3600)
+            .unwrap();
+        let response = send(
+            &router,
+            Request::builder()
+                .uri("/api/session")
+                .header("host", "localhost")
+                .header("cookie", format!("auth_localhost={versioned}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn oidc_shell_redirects_anonymous_visitors_to_login() {
+        let (_dir, router, authenticator) = setup_with_mode(SessionPolicy::default(), true);
+        let outer = Router::new().nest(SPACES_PREFIX, router);
+
+        let response = send(
+            &outer,
+            Request::builder()
+                .uri("/.spaces/new")
+                .header("host", "localhost")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            "/.oidc/login?return_to=%2F%2Espaces%2Fnew"
+        );
+
+        let jwt = authenticator.issue_jwt("alice", 3600).unwrap();
+        let response = send(
+            &outer,
+            Request::builder()
+                .uri("/.spaces/new")
+                .header("host", "localhost")
+                .header("cookie", format!("auth_localhost={jwt}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/server/src/multi/users.rs
+++ b/server/src/multi/users.rs
@@ -171,6 +171,15 @@ impl UserStore {
         }))
     }
 
+    /// Open an empty store WITHOUT writing `users.json`. Used in OIDC mode,
+    /// where the OIDC provider is the identity source of record.
+    pub fn empty(root: &Path) -> Result<Arc<Self>, String> {
+        Ok(Arc::new(Self {
+            path: root.join(USERS_FILE),
+            state: RwLock::new(UsersConfig::default()),
+        }))
+    }
+
     /// Create an empty store (file written immediately). Test-only helper:
     /// production provisioning goes through `setup::run_setup`, which writes
     /// `users.json` with the first admin already populated.

--- a/server/src/multi/validate.rs
+++ b/server/src/multi/validate.rs
@@ -117,7 +117,9 @@ pub fn validate(
             }
         }
         for member in space.members.keys() {
-            if !known_users.contains(member) {
+            // In OIDC mode the provider is the identity source of record, so
+            // members need not exist in users.json (which may be absent).
+            if !known_users.contains(member) && !crate::auth::oidc_enabled() {
                 err(
                     &mut errors,
                     format!("{id}.members"),

--- a/server/src/router.rs
+++ b/server/src/router.rs
@@ -66,7 +66,16 @@ async fn require_authorization(
             // The client's boot code follows this `Location` to the login page;
             // all protected routes are `/.`-prefixed, hence the
             // 401-with-Location branch.
-            let location = format!("{}/.auth", state.host_url_prefix);
+            let location = if state.oidc.is_some() {
+                let mut return_to = format!("{}{}", state.host_url_prefix, req.uri().path());
+                if let Some(query) = req.uri().query() {
+                    return_to.push('?');
+                    return_to.push_str(query);
+                }
+                crate::auth::oidc::login_location(&state.host_url_prefix, &return_to)
+            } else {
+                format!("{}/.auth", state.host_url_prefix)
+            };
             (
                 axum::http::StatusCode::UNAUTHORIZED,
                 [(axum::http::header::LOCATION, location)],
@@ -175,11 +184,22 @@ pub fn build_router(state: Arc<ServerState>) -> Router {
         .route_layer(DefaultBodyLimit::max(64 * 1024));
 
     // Open: liveness + the SPA shell/assets must always load.
-    let open = Router::new()
+    let mut open = Router::new()
         .route("/.ping", get(control::handle_ping))
         .route("/.client/manifest.json", get(control::handle_manifest))
-        .route("/.logout", get(crate::handlers::auth::handle_logout))
         .merge(auth_routes);
+
+    // Keep OIDC entirely additive: without OIDC configuration these paths
+    // retain the same SPA-fallback behavior they had before.
+    if state.oidc.is_some() {
+        open = open
+            .route("/.oidc/login", get(crate::auth::oidc::handle_login))
+            .route("/.oidc/callback", get(crate::auth::oidc::handle_callback))
+            .route("/.oidc/logout", get(crate::auth::oidc::handle_logout))
+            .route("/.logout", get(crate::auth::oidc::handle_logout));
+    } else {
+        open = open.route("/.logout", get(crate::handlers::auth::handle_logout));
+    }
 
     let bundle_compression = CompressionLayer::new()
         .compress_when(DefaultPredicate::new().and(NotForContentType::const_new("font/")));
@@ -286,6 +306,61 @@ mod auth_tests {
     async fn unauthorized_protected_route_is_401() {
         let st = state_with(Some(Arc::new(Always(false))));
         assert_eq!(status(st, "/.config").await, StatusCode::UNAUTHORIZED);
+    }
+
+    fn add_test_oidc(state: &mut ServerState) {
+        let authenticator = Arc::new(crate::auth::Authenticator::from_secret_bytes(
+            vec![2; 32],
+            "test".into(),
+        ));
+        state.oidc = Some(Arc::new(crate::auth::OidcClient::new(
+            crate::auth::OidcConfig {
+                issuer: "https://id.example/application/o/wiki/".into(),
+                client_id: "silverbullet".into(),
+                client_secret: "secret".into(),
+                redirect_uri: "https://wiki.example/.oidc/callback".into(),
+            },
+            authenticator,
+        )));
+    }
+
+    #[tokio::test]
+    async fn oidc_unauthorized_response_points_to_login_with_return_path() {
+        let mut state = test_state();
+        state.authorizer = Some(Arc::new(Always(false)));
+        state.host_url_prefix = "/work".to_string();
+        add_test_oidc(&mut state);
+
+        let response = crate::build_router(Arc::new(state))
+            .oneshot(
+                Request::builder()
+                    .uri("/.config?mode=edit")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response.headers().get("location").unwrap(),
+            "/work/.oidc/login?return_to=%2Fwork%2F%2Econfig%3Fmode%3Dedit"
+        );
+    }
+
+    #[tokio::test]
+    async fn oidc_callback_route_is_mounted() {
+        let mut state = test_state();
+        add_test_oidc(&mut state);
+        let response = crate::build_router(Arc::new(state))
+            .oneshot(
+                Request::builder()
+                    .uri("/.oidc/callback")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -102,6 +102,9 @@ pub struct ServerState {
     /// `authorizer == None` (an open server). Shares the `Authenticator` with
     /// the `authorizer` via `Arc`.
     pub login: Option<Arc<crate::auth::LoginManager>>,
+    /// Self-contained OIDC login flow. Present only for account-managed
+    /// servers when `SB_OIDC_ISSUER` and `SB_OIDC_CLIENT_ID` are configured.
+    pub oidc: Option<Arc<crate::auth::OidcClient>>,
     /// Shell-execution policy for `/.shell`.
     pub shell: ShellConfig,
     /// Request metrics. `None` disables counting and `/metrics`.


### PR DESCRIPTION
## Summary

- Adds self-contained OIDC authentication to SilverBullet: authorization-code flow with PKCE (S256), running entirely inside SB (no external auth proxy required).
- Feature-gated via env vars (`SB_OIDC_ISSUER` + `SB_OIDC_CLIENT_ID`) — when unset, upstream password/auth behavior is completely unchanged.
- Builds directly on the existing auth infrastructure (`Authenticator`, `RequestAuthorizer`/`JwtAuthorizer`, `require_authorization`) — no new crate dependencies.

## Motivation

Addresses #2103 (OIDC/SSO support). This lets multi-user SilverBullet deployments authenticate against any standard OIDC provider (Authentik, Keycloak, etc.) while keeping anonymous access to public spaces open and protecting private spaces per `spaces.json` `members`.

## Changes

- **`server/src/auth/oidc.rs`** (new): discovery, `authorize_url` with stateless HMAC-signed state (return path + PKCE verifier), callback handling (state verification → token exchange → JWKS ID-token verification → username extraction from `preferred_username`/`sub`), session JWT minting via the existing `Authenticator`.
- **Routes under `/.oidc/*`** (in `server/src/router.rs`): `GET /.oidc/login?return_to=...`, `GET /.oidc/callback`, `GET /.oidc/logout`.
- **Space authorization** (`server/src/multi/instance.rs`): OIDC mode uses `JwtAuthorizer` with a `members`-based filter; admins via `SB_PROXY_ADMINS`; public spaces stay anonymous.
- **`space_index.rs` / `admin_api.rs`**: OIDC mode accepts only versionless host-wide JWT claims and reads the admin flag from `SB_PROXY_ADMINS`.
- **`OIDC_DESIGN.md`**: design doc included.
- OIDC deployments may omit `users.json`.

## Test Plan

- [x] `cargo build` — clean
- [x] `cargo test --workspace` — 872 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `git diff --check` — clean
- [x] No `proxy-auth` / `HeaderAuthorizer` residue (this branch contains no trusted-header auth code)

## Notes for Reviewers

- `SB_PROXY_ADMINS` keeps the fork's env name for deployment compatibility; happy to rename to `SB_OIDC_ADMINS` if preferred.
- Route prefix is `/.oidc/*` (not `/.auth/oidc`).
- E2E testing against a live IdP (Authentik) is planned for the follow-up; unit tests cover state signing/verification, authorize-URL construction, and claim extraction without network.
- New env vars: `SB_OIDC_ISSUER`, `SB_OIDC_CLIENT_ID`, `SB_OIDC_CLIENT_SECRET`, `SB_OIDC_REDIRECT_URI`, `SB_PROXY_ADMINS`.
